### PR TITLE
Add coveralls support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ node_js:
   - "0.11"
   - "0.10"
   - "iojs"
+build: npm test && npm run combine-coverage && npm run upload-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ node_js:
   - "0.11"
   - "0.10"
   - "iojs"
-build: npm test && npm run combine-coverage && npm run upload-coverage
+script: npm test && npm run combine-coverage && npm run upload-coverage

--- a/build/main/combine-coverage.js
+++ b/build/main/combine-coverage.js
@@ -1,0 +1,21 @@
+var Promise = require('bluebird')
+var fs = Promise.promisifyAll(require('fs-extra'))
+var istanbul = require('istanbul')
+
+function getDirectories (path) {
+  return fs.readdirSync(path).filter(function (file) {
+    return fs.statSync(path + '/' + file).isDirectory()
+  })
+}
+
+var reporter = new istanbul.Reporter(undefined, 'target/test-library/coverage')
+var collector = new istanbul.Collector()
+
+getDirectories('target/test-library/coverage').forEach(function (dir) {
+  collector.add(JSON.parse(fs.readFileSync('target/test-library/coverage/' + dir + '/coverage.json', 'utf8')))
+})
+
+reporter.add('lcovonly')
+reporter.write(collector, true, function () {
+  console.log('done')
+})

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "dist": "node build/main/dist.js",
     "test": "npm run test-build; npm run test-library",
     "test-build": "./node_modules/istanbul/lib/cli.js cover --dir target/test-build/coverage ./node_modules/mocha/bin/_mocha -- --ui bdd -R spec build/test",
-    "test-library": "node build/main/test.js"
+    "test-library": "node build/main/test.js",
+    "combine-coverage": "node build/main/combine-coverage.js",
+    "upload-coverage": "cat target/test-library/coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
   },
   "dependencies": {
     "autoprefixer": "^6.0.3",
@@ -32,6 +34,7 @@
   "devDependencies": {
     "chai": "^3.3.0",
     "chai-as-promised": "^5.1.0",
+    "coveralls": "^2.11.6",
     "istanbul": "^0.4.1",
     "jasmine-core": "^2.3.4",
     "karma": "^0.13.10",


### PR DESCRIPTION
This adds uploading of coverage results to coveralls.io. I've tested in a fork - and it seems to work.

Hexagon runs tests on temporary generated javascript files, so the coverage information cannot be viewed on coveralls.io currently - just the overall percentage (still, it's better than nothing)

The webpack branch can do coverage reports on the original coffeescript - so once that is ready to merge in, we can get full coverage info on coverage.io