### PR TITLE
Add support for hexagon listening to its own locale changes

### DIFF
--- a/modules/date-picker/main/index.coffee
+++ b/modules/date-picker/main/index.coffee
@@ -142,7 +142,7 @@ buildCalendar = (datepicker, mode) ->
   mode ?= _.mode
   _.mode = mode
 
-  localiser = datepicker.localiser
+  localizer = datepicker.localizer
 
   visible = datepicker.visibleMonth()
 
@@ -150,20 +150,20 @@ buildCalendar = (datepicker, mode) ->
     when 'd'
       data = getCalendarDecade(visible.year)
       cls = 'hx-calendar-decade'
-      text = localiser.localiseDecade(data[0][1], data[3][1])
+      text = localizer.localizeDecade(data[0][1], data[3][1])
     when 'y'
       data = getCalendarYear()
       cls = 'hx-calendar-year'
-      text = localiser.localiseYear(visible.year)
+      text = localizer.localizeYear(visible.year)
     else
-      data = getCalendarMonth(visible.year, visible.month - 1, localiser.localiseWeekStart())
+      data = getCalendarMonth(visible.year, visible.month - 1, localizer.localizeWeekStart())
       data.unshift 'days' # When the update gets to this it adds the days of the week as a row
       cls = 'hx-calendar-month'
-      text = localiser.localiseMonth(visible.month - 1) + ' / ' + localiser.localiseYear(visible.year)
+      text = localizer.localizeMonth(visible.month - 1) + ' / ' + localizer.localizeYear(visible.year)
 
   _.calendarGrid.class('hx-calendar-grid ' + cls)
   _.calendarHeadBtn.text(text)
-  _.calendarTodayButton?.text(localiser.localiseToday())
+  _.calendarTodayButton?.text(localizer.localizeToday())
   _.calendarView.apply(data)
 
 calendarGridUpdate = (datepicker, data, elem, index, mode) ->
@@ -175,7 +175,7 @@ calendarGridUpdate = (datepicker, data, elem, index, mode) ->
       .classed 'hx-grid-row-heading', true
       .view '.hx-grid'
       .update (d) -> @text(d).node()
-      .apply(datepicker.localiser.localiseWeek())
+      .apply(datepicker.localizer.localizeWeek())
   else
     element.view('.hx-grid')
       .enter (d) ->
@@ -209,17 +209,17 @@ calendarGridRowUpdate = (datepicker, data, elem, index, rowIndex, mode) ->
     switch mode
       when 'd'
         year = data
-        screenVal = datepicker.localiser.localiseYear(data)
+        screenVal = datepicker.localizer.localizeYear(data)
         selectable = if rowIndex is 0 then index isnt 0 else if rowIndex is 3 then index isnt 2 else true
       when 'y'
         month = data
         year = visible.year
-        screenVal = datepicker.localiser.localiseMonth(data)
+        screenVal = datepicker.localizer.localizeMonth(data)
       else
         day = data
         month = visible.month - 1
         year = visible.year
-        screenVal = datepicker.localiser.localiseDay(data)
+        screenVal = datepicker.localizer.localizeDay(data)
 
     isValid = isSelectable(datepicker, year, month, day) and selectable
 
@@ -289,13 +289,13 @@ buildDatepicker = (datepicker) ->
   day = datepicker.day()
   month = datepicker.month()
   year = datepicker.year()
-  localiser = datepicker.localiser
+  localizer = datepicker.localizer
   _.dayPicker.suppressed 'change', true
   _.monthPicker.suppressed 'change', true
   _.yearPicker.suppressed 'change', true
-  _.dayPicker.value(day, localiser.localiseDay(day, true))
-  _.monthPicker.value(month, localiser.localiseMonth(month - 1, true))
-  _.yearPicker.value(year, localiser.localiseYear(year))
+  _.dayPicker.value(day, localizer.localizeDay(day, true))
+  _.monthPicker.value(month, localizer.localizeMonth(month - 1, true))
+  _.yearPicker.value(year, localizer.localizeYear(year))
   _.dayPicker.suppressed 'change', false
   _.monthPicker.suppressed 'change', false
   _.yearPicker.suppressed 'change', false
@@ -308,10 +308,10 @@ setupInput = (datepicker) ->
 
   if datepicker.options.selectRange
     range = datepicker.range()
-    _.inputStart.value(datepicker.localiser.localiseDate range.start, _.useInbuilt)
-    _.inputEnd.value(datepicker.localiser.localiseDate range.end or range.start, _.useInbuilt)
+    _.inputStart.value(datepicker.localizer.localizeDate range.start, _.useInbuilt)
+    _.inputEnd.value(datepicker.localizer.localizeDate range.end or range.start, _.useInbuilt)
   else
-    _.input.value(datepicker.localiser.localiseDate datepicker.date(), _.useInbuilt)
+    _.input.value(datepicker.localizer.localizeDate datepicker.date(), _.useInbuilt)
 
 
 # Function for updating the input fields and emitting the change event.
@@ -336,20 +336,18 @@ updateDatepicker = (datepicker) ->
       buildDatepicker datepicker
 
 
-# Localisers
+# Localizers
 
-class Localiser
-  constructor: -> @currentLocale = 'en-gb'
-
+class Localizer
   dateOrder: -> ['DD','MM','YYYY']
 
-  localiseWeekStart: -> 0
+  localizeWeekStart: -> 0
 
-  localiseWeek: -> ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']
+  localizeWeek: -> ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']
 
-  localiseDay: (day, pad) -> if pad then zeroPad(day) else day
+  localizeDay: (day, pad) -> if pad then zeroPad(day) else day
 
-  localiseMonth: (month, short) ->
+  localizeMonth: (month, short) ->
     if short then zeroPad(month + 1)
     else
       [
@@ -367,12 +365,12 @@ class Localiser
         'Dec'
       ][month]
 
-  localiseYear: (year) -> year
+  localizeYear: (year) -> year
 
-  localiseDecade: (start, end) ->
-    @localiseYear(start) + ' - ' + @localiseYear(end)
+  localizeDecade: (start, end) ->
+    @localizeYear(start) + ' - ' + @localizeYear(end)
 
-  localiseDate: (date, useInbuilt) ->
+  localizeDate: (date, useInbuilt) ->
     if useInbuilt
       date.getFullYear() + '-' +
       zeroPad(date.getMonth() + 1 )+ '-' +
@@ -380,14 +378,7 @@ class Localiser
     else
       zeroPad(date.getDate()) + '/' + zeroPad(date.getMonth() + 1) + '/' + date.getFullYear()
 
-  localiseToday: -> 'Today'
-
-  locale: (locale) ->
-    # Can't set the locale for default localiser
-    if locale?
-      return
-    else
-      'en-gb'
+  localizeToday: -> 'Today'
 
   stringToDate: (dateString, inbuilt) ->
     if inbuilt
@@ -420,12 +411,9 @@ class Localiser
       new Date('Invalid Date')
 
 
-class LocaliserMoment
-  constructor: ->
-    @currentLocale = moment.locale()
-
+class LocalizerMoment
   dateOrder: ->
-    date = moment({year:2003, month:11, day:22}).locale(@currentLocale)
+    date = moment({year:2003, month:11, day:22}).locale(hx.preferences.locale())
     dateCheck = date.format('L')
     yearIndex = dateCheck.indexOf(date.format('YYYY'))
     monthIndex = dateCheck.indexOf(date.format('MM'))
@@ -441,33 +429,33 @@ class LocaliserMoment
     if result.length is 0 then result = ['DD','MM','YYYY']
     result
 
-  localiseWeekStart: -> moment().weekday(0).toDate().getDay()
+  localizeWeekStart: -> moment().weekday(0).toDate().getDay()
 
-  localiseWeek: ->
+  localizeWeek: ->
     dayDate = moment().weekday(0)
-    dayDate.locale(@currentLocale)
+    dayDate.locale(hx.preferences.locale())
     dayNames = [dayDate.format('dd')]
     for i in [0...6]
       dayNames.push(dayDate.add(1,'d').format('dd'))
     dayNames
 
-  localiseDay: (day, pad) ->
-    moment({day: day, month: 0}).locale(@currentLocale).format(if pad then 'DD' else 'D')
+  localizeDay: (day, pad) ->
+    moment({day: day, month: 0}).locale(hx.preferences.locale()).format(if pad then 'DD' else 'D')
 
-  localiseMonth: (month, short) ->
-    moment({month: month}).locale(@currentLocale).format(if short then 'MM' else 'MMM')
+  localizeMonth: (month, short) ->
+    moment({month: month}).locale(hx.preferences.locale()).format(if short then 'MM' else 'MMM')
 
-  localiseYear: (year) ->
-    moment({year: year}).locale(@currentLocale).format('YYYY')
+  localizeYear: (year) ->
+    moment({year: year}).locale(hx.preferences.locale()).format('YYYY')
 
-  localiseDecade: (start, end) ->
-    @localiseYear(start) + ' - ' + @localiseYear(end)
+  localizeDecade: (start, end) ->
+    @localizeYear(start) + ' - ' + @localizeYear(end)
 
-  localiseDate: (date) ->
-    moment(date).locale(@currentLocale).format('L')
+  localizeDate: (date) ->
+    moment(date).locale(hx.preferences.locale()).format('L')
 
-  localiseToday: ->
-    today = moment({hour: 12, minute: 0, second: 0}).locale(@currentLocale)
+  localizeToday: ->
+    today = moment({hour: 12, minute: 0, second: 0}).locale(hx.preferences.locale())
     tomorrow = today.clone().add(1, 'day')
     todayArr = today.calendar().split('').reverse()
     tomorrowArr = tomorrow.calendar().split('').reverse()
@@ -476,12 +464,6 @@ class LocaliserMoment
         break
     todayArr.splice(0, i)
     todayArr.reverse().join('')
-
-  locale: (locale) ->
-    if locale?
-      @currentLocale = locale
-    else
-      @currentLocale
 
   stringToDate: (dateString) ->
     order = @dateOrder()
@@ -502,7 +484,7 @@ class LocaliserMoment
             yearsValid = part.length < 5 and part isnt ''
             format += 'YYYY'
       if daysValid and monthsValid and yearsValid
-        moment(dateString, format, @currentLocale).toDate()
+        moment(dateString, format, hx.preferences.locale()).toDate()
       else
         new Date('Invalid Date')
     else
@@ -518,6 +500,8 @@ class DatePicker extends hx.EventEmitter
     hx.component.register(@selector, this)
 
     self = this
+
+    hx.preferences.on 'localechange', => updateDatepicker this
 
     @options = hx.merge.defined({
       type: 'calendar' # 'calendar' or 'datepicker'
@@ -539,7 +523,7 @@ class DatePicker extends hx.EventEmitter
     _.startDate.setHours(0, 0, 0, 0)
     _.endDate.setHours(0, 0, 0, 0)
 
-    @localiser = if moment? then new LocaliserMoment else new Localiser
+    @localizer = if moment? then new LocalizerMoment else new Localizer
 
     @selection = hx.select(@selector).classed('hx-date-picker', true)
 
@@ -560,8 +544,8 @@ class DatePicker extends hx.EventEmitter
         self.hide()
         clearTimeout timeout
         timeout = setTimeout ->
-          date1 = self.localiser.stringToDate(_.inputStart.value(), _.useInbuilt)
-          date2 = self.localiser.stringToDate(_.inputEnd.value(), _.useInbuilt)
+          date1 = self.localizer.stringToDate(_.inputStart.value(), _.useInbuilt)
+          date2 = self.localizer.stringToDate(_.inputEnd.value(), _.useInbuilt)
           if which and date2 < date1
             date1 = date2
             _.inputStart.value(_.inputEnd.value())
@@ -595,7 +579,7 @@ class DatePicker extends hx.EventEmitter
           self.hide()
           clearTimeout timeout
           timeout = setTimeout ->
-            date = self.localiser.stringToDate(_.input.value(), _.useInbuilt)
+            date = self.localizer.stringToDate(_.input.value(), _.useInbuilt)
             if date.getTime()
               if date.getTime() isnt self.date().getTime()
                 self.date(date)
@@ -643,7 +627,7 @@ class DatePicker extends hx.EventEmitter
       _.calendarHeadBtn = calendarHeader.append('button')
         .class('hx-btn hx-btn-invert hx-calendar-button')
         .on 'click', 'hx.date-picker', ->
-           switch _.mode
+          switch _.mode
             when 'd' then return
             when 'y' then buildCalendar self, 'd'
             else buildCalendar self, 'y'
@@ -706,7 +690,7 @@ class DatePicker extends hx.EventEmitter
           selection = hx.select(elem)
 
           # add nodes in the correct order
-          for i in self.localiser.dateOrder()
+          for i in self.localizer.dateOrder()
             switch i
               when 'DD' then selection.append dayNode
               when 'MM' then selection.append monthNode
@@ -753,7 +737,7 @@ class DatePicker extends hx.EventEmitter
     this
 
   getScreenDate: (endDate) ->
-    @localiser.localiseDate if not endDate then _.startDate else _.endDate
+    @localizer.localizeDate if not endDate then _.startDate else _.endDate
 
   visibleMonth: (month, year) ->
     _ = @_
@@ -865,12 +849,12 @@ class DatePicker extends hx.EventEmitter
       _.validRange
 
   locale: (locale) ->
+    hx.deprecatedWarning 'hx.DatePicker::locale is deprecated. Use hx.preferences.locale instead.'
     if arguments.length > 0
-      @localiser.locale(locale)
-      updateDatepicker(this)
+      hx.preferences.locale locale
       this
     else
-      @localiser.locale()
+      hx.preferences.locale()
 
 hx.datePicker = (options) ->
   selection = hx.detached('div')

--- a/modules/date-picker/module.json
+++ b/modules/date-picker/module.json
@@ -8,7 +8,8 @@
     "util",
     "dropdown",
     "icon",
-    "input-group"
+    "input-group",
+    "preferences"
   ],
   "keywords": [
     "date",

--- a/modules/date-picker/test/spec.coffee
+++ b/modules/date-picker/test/spec.coffee
@@ -44,7 +44,7 @@ describe 'hx-date-picker', ->
 
       it 'dp.locale', ->
         dp = new hx.DatePicker(hx.detached('div').node())
-        expect(dp.locale('en-gb')).toEqual(dp)
+        expect(dp.locale('en-GB')).toEqual(dp)
 
     describe 'should return values for setter/getters without parameters:', ->
 
@@ -67,7 +67,7 @@ describe 'hx-date-picker', ->
 
       it 'dp.locale', ->
         dp = new hx.DatePicker(hx.detached('div').node())
-        expect(dp.locale('en-gb').locale()).toEqual('en-gb')
+        expect(dp.locale('en-GB').locale()).toEqual('en-GB')
 
 
     it 'should return this for show', ->

--- a/modules/date-time-picker/main/index.coffee
+++ b/modules/date-time-picker/main/index.coffee
@@ -92,12 +92,12 @@ class DateTimePicker extends hx.EventEmitter
   getScreenTime: -> @timePicker.getScreenTime()
 
   locale: (locale) ->
+    hx.deprecatedWarning 'hx.DateTimePicker::locale is deprecated. Please use hx.preferences.locale.'
     if arguments.length > 0
-      @timePicker.locale(locale)
-      @datePicker.locale(locale)
+      hx.preferences.locale locale
       this
     else
-      @timePicker.locale()
+      hx.preferences.locale()
 
 
   disabled: (disable) ->

--- a/modules/date-time-picker/test/spec.coffee
+++ b/modules/date-time-picker/test/spec.coffee
@@ -10,7 +10,7 @@ describe 'date-time-picker', ->
       it 'datetimepicker.month', -> dp.month(10).should.equal(dp)
       it 'datetimepicker.second', -> dp.second(10).should.equal(dp)
       it 'datetimepicker.year', -> dp.year(10).should.equal(dp)
-      it 'datetimepicker.locale', -> dp.locale('en-gb').should.equal(dp)
+      it 'datetimepicker.locale', -> dp.locale('en-GB').should.equal(dp)
       it 'datetimepicker.disabled', -> dp.disabled(true).should.equal(dp)
 
     describe 'should return values for setter/getters without parameters:', ->
@@ -25,5 +25,5 @@ describe 'date-time-picker', ->
       it 'datetimepicker.month', -> dp.month(10).month().should.equal(10)
       it 'datetimepicker.second', -> dp.second(10).second().should.equal(10)
       it 'datetimepicker.year', -> dp.year(10).year().should.equal(10)
-      it 'datetimepicker.locale', -> dp.locale('en-gb').locale().should.equal('en-gb')
+      it 'datetimepicker.locale', -> dp.locale('en-GB').locale().should.equal('en-GB')
       it 'datetimepicker.disabled', -> dp.disabled(true).disabled().should.equal(true)

--- a/modules/preferences/main/index.coffee
+++ b/modules/preferences/main/index.coffee
@@ -115,7 +115,7 @@ class Preferences extends hx.EventEmitter
         inputMap: (item) -> item.full
         showOtherResults: true
         mustMatch: true
-      }).on 'change', (item) => locale = item.value
+      }).on 'change', (item) -> locale = item.value
 
       localeSection = hx.detached('div')
         .add(hx.detached('label').text('Locale'))
@@ -125,7 +125,7 @@ class Preferences extends hx.EventEmitter
       timezoneAutocompleteElement.value(timezone)
 
       new hx.AutoComplete(timezoneAutocompleteElement.node(), moment?.tz.names() or [], {showOtherResults: true, mustMatch: true})
-        .on 'change', (value) => timezone = value
+        .on 'change', (value) -> timezone = value
 
       timezoneSection = hx.detached('div')
         .add(hx.detached('label').text('Time Zone'))
@@ -137,7 +137,7 @@ class Preferences extends hx.EventEmitter
         .on 'click', =>
           @locale(locale)
           @timezone(timezone)
-          @save (err) =>
+          @save (err) ->
             if err
               hx.notify.negative(err)
             else
@@ -158,6 +158,8 @@ class Preferences extends hx.EventEmitter
       modal: modal
     }
 
+    @locale moment?.locale() or navigator.language or 'en'
+
   timezone: (timezone) ->
     if arguments.length > 0
       if @_.preferences['timezone'] isnt timezone
@@ -171,16 +173,13 @@ class Preferences extends hx.EventEmitter
     if arguments.length > 0
       # check that the local being set is supported
 
-      if locale is undefined
-        if @_.preferences['locale'] isnt undefined
-          @_.preferences['locale'] = undefined
-          @emit('localechange', undefined)
-      else if (localeObject = localeList.filter((l) -> l.value.toLowerCase() is locale.toLowerCase())[0])
+      if hx.isString(locale) and (localeObject = localeList.filter((l) -> l.value.toLowerCase() is locale.toLowerCase())[0])
         if @_.preferences['locale'] isnt localeObject.value
           @_.preferences['locale'] = localeObject.value
           @emit('localechange', localeObject.value)
       else
-        hx.consoleWarning('preferences.locale', locale + ' is not a valid locale. If you think the locale should be added to the list contact the maintainers of hexagon')
+        hx.consoleWarning('preferences.locale',
+          locale + ' is not a valid locale. If you think the locale should be added to the list contact the maintainers of hexagon')
       this
     else
       @_.preferences['locale']
@@ -210,7 +209,7 @@ class Preferences extends hx.EventEmitter
   # loads the preferences
   load: (cb) ->
     try
-       @_.backingStore.load (err, prefs) =>
+      @_.backingStore.load (err, prefs) =>
         if prefs?
           @_.preferences = JSON.parse(prefs)
         cb?(err)

--- a/modules/preferences/test/spec.coffee
+++ b/modules/preferences/test/spec.coffee
@@ -5,6 +5,14 @@ describe 'hx-preferences', ->
       expect(hx.preferences.supportedLocales(list)).toEqual(hx.preferences)
       expect(hx.preferences.supportedLocales()).toEqual(list)
 
+    it 'locale: should not be possible to explicitly clear the locale', ->
+      # sanity check
+      expect(hx.preferences.locale()).toBeDefined()
+
+      hx.preferences.locale undefined
+      expect(hx.preferences.locale()).toBeDefined()
+
+
     it 'locale: setter/getter', ->
       expect(hx.preferences.locale('vi')).toEqual(hx.preferences)
       expect(hx.preferences.locale()).toEqual('vi')
@@ -30,10 +38,6 @@ describe 'hx-preferences', ->
       hx.preferences.on 'localechange', -> called = true
       hx.preferences.locale('en-us')
       expect(called).toEqual(true)
-
-    it 'locale: setting undefined should clear the locale', ->
-      expect(hx.preferences.locale('vi').locale(undefined)).toEqual(hx.preferences)
-      expect(hx.preferences.locale()).toEqual(undefined)
 
     it 'locale: setter/getter for non supported value', ->
       spyOn(hx, 'consoleWarning')

--- a/modules/time-picker/module.json
+++ b/modules/time-picker/module.json
@@ -7,7 +7,8 @@
     "dropdown",
     "util",
     "format",
-    "icon"
+    "icon",
+    "preferences"
   ],
   "keywords": [
     "time",

--- a/modules/time-picker/test/spec.coffee
+++ b/modules/time-picker/test/spec.coffee
@@ -23,5 +23,5 @@ describe 'time-picker', ->
 
     it 'locale', ->
       tp = new hx.TimePicker(document.createElement('div'))
-      expect(tp.locale('en-gb')).toEqual(tp)
-      expect(tp.locale()).toEqual('en-gb')
+      expect(tp.locale('en-GB')).toEqual(tp)
+      expect(tp.locale()).toEqual('en-GB')


### PR DESCRIPTION
* Deprecate hx.DatePicker::locale etc - components should get the locale directly from the preferences module
* Make it impossible for locale to be missing - it defaults first to the moment locale if moment is present, then to the browser locale, then to US English.
* Use American spellings for some non-external-facing things