### PR TITLE
Converts some of the test over to use chai instead of jasmine's assertions

### DIFF
--- a/build/main/karma.js
+++ b/build/main/karma.js
@@ -128,7 +128,7 @@ function runKarma (files, destDir, phantomOnly) {
     jsonReporter: jsonReporter,
     singleRun: true,
     browsers: null,
-    frameworks: ['jasmine-ajax', 'jasmine', 'sinon', 'chai'],
+    frameworks: ['jasmine-ajax', 'jasmine', 'sinon', 'chai-spies', 'chai'],
     autoWatch: false,
     reporters: ['coverage', 'html', 'json', 'mocha']
   }

--- a/modules/animate/test/spec.coffee
+++ b/modules/animate/test/spec.coffee
@@ -60,8 +60,8 @@ describe 'hx-animate', ->
       ease = ->
       fromSelection = hx.select(node).animate(ease)
       normal = hx.animate(node, ease)
-      expect(fromSelection.node).toEqual(normal.node)
-      expect(fromSelection.ease).toEqual(normal.ease)
+      fromSelection.node.should.equal(normal.node)
+      fromSelection.ease.should.equal(normal.ease)
 
     describe 'style', ->
       it 'should emit end at the end of an animation', ->
@@ -71,12 +71,12 @@ describe 'hx-animate', ->
           .on 'end', -> end = true
 
         jasmine.clock().tick(10)
-        expect(end).toBe(true)
+        end.should.equal(true)
 
       it 'the easing function passed in should be used', ->
         ease = (d) -> Math.sqrt(Math.abs(d))
         anim = hx.animate(new FakeNode, ease)
-        expect(anim.ease).toBe(ease)
+        anim.ease.should.equal(ease)
 
       it 'should emit end at the end of an animation with multiple styles', ->
         end = false
@@ -86,7 +86,7 @@ describe 'hx-animate', ->
           .on 'end', -> end = true
 
         jasmine.clock().tick(10)
-        expect(end).toBe(true)
+        end.should.equal(true)
 
       it 'should take roughly the amount of time requested', ->
         start = now()
@@ -99,7 +99,7 @@ describe 'hx-animate', ->
 
         jasmine.clock().tick(100)
 
-        expect(time).toEqual(100)
+        time.should.equal(100)
 
       it 'should take roughly the amount of time requested (using default)', ->
         start = now()
@@ -111,7 +111,7 @@ describe 'hx-animate', ->
             time = now() - start
 
         jasmine.clock().tick(200)
-        expect(time).toEqual(200)
+        time.should.equal(200)
 
       it 'if you dont supply a node, then the end event should be emitted straight away', ->
         end = false
@@ -120,7 +120,7 @@ describe 'hx-animate', ->
           .style('height', '100%', 100)
           .style('width', '100%', 50)
 
-        expect(end).toEqual(true)
+        end.should.equal(true)
 
       it 'should only emit end once', ->
         count = 0
@@ -130,7 +130,7 @@ describe 'hx-animate', ->
           .style('width', '100%', 50)
 
 
-        expect(count).toBe(1)
+        count.should.equal(1)
 
       it 'should end on the correct values', ->
         node = new FakeNode
@@ -139,8 +139,8 @@ describe 'hx-animate', ->
           .style('width', '100%', 50)
 
         jasmine.clock().tick(100)
-        expect(node.styles['height']).toEqual('100%')
-        expect(node.styles['width']).toEqual('100%')
+        node.styles['height'].should.equal('100%')
+        node.styles['width'].should.equal('100%')
 
       it 'should end on the correct values', ->
 
@@ -154,8 +154,8 @@ describe 'hx-animate', ->
           .style('width', '100%', 50)
 
         jasmine.clock().tick(100)
-        expect(node.styles['height']).toEqual('100%')
-        expect(node.styles['width']).toEqual('100%')
+        node.styles['height'].should.equal('100%')
+        node.styles['width'].should.equal('100%')
 
       it 'should interpolate to the correct values', ->
 
@@ -169,16 +169,16 @@ describe 'hx-animate', ->
           .style('height', '100%', 100)
 
         jasmine.clock().tick(25)
-        expect(node.styles['width']).toEqual('25%')
-        expect(node.styles['height']).toEqual('62.5%')
+        node.styles['width'].should.equal('25%')
+        node.styles['height'].should.equal('62.5%')
 
         jasmine.clock().tick(25)
-        expect(node.styles['width']).toEqual('50%')
-        expect(node.styles['height']).toEqual('75%')
+        node.styles['width'].should.equal('50%')
+        node.styles['height'].should.equal('75%')
 
         jasmine.clock().tick(50)
-        expect(node.styles['width']).toEqual('100%')
-        expect(node.styles['height']).toEqual('100%')
+        node.styles['width'].should.equal('100%')
+        node.styles['height'].should.equal('100%')
 
       it 'changing the easing function should affect the values', ->
 
@@ -192,15 +192,15 @@ describe 'hx-animate', ->
           .style('height', '100%', 100)
 
         jasmine.clock().tick(25)
-        expect(node.styles['width']).toEqual('1.5625%')
+        node.styles['width'].should.equal('1.5625%')
 
         jasmine.clock().tick(25)
-        expect(node.styles['width']).toEqual('12.5%')
-        expect(node.styles['height']).toEqual('56.25%')
+        node.styles['width'].should.equal('12.5%')
+        node.styles['height'].should.equal('56.25%')
 
         jasmine.clock().tick(50)
-        expect(node.styles['width']).toEqual('100%')
-        expect(node.styles['height']).toEqual('100%')
+        node.styles['width'].should.equal('100%')
+        node.styles['height'].should.equal('100%')
 
       it 'changing the easing function should affect the values', ->
 
@@ -214,15 +214,15 @@ describe 'hx-animate', ->
           .style('height', '100%', 100)
 
         jasmine.clock().tick(25)
-        expect(node.styles['width']).toEqual('6.25%')
+        node.styles['width'].should.equal('6.25%')
 
         jasmine.clock().tick(25)
-        expect(node.styles['width']).toEqual('25%')
-        expect(node.styles['height']).toEqual('62.5%')
+        node.styles['width'].should.equal('25%')
+        node.styles['height'].should.equal('62.5%')
 
         jasmine.clock().tick(50)
-        expect(node.styles['width']).toEqual('100%')
-        expect(node.styles['height']).toEqual('100%')
+        node.styles['width'].should.equal('100%')
+        node.styles['height'].should.equal('100%')
 
       it 'should interpolate the correct values', ->
 
@@ -234,16 +234,16 @@ describe 'hx-animate', ->
           .style('height', '50%', '100%', 100)
 
         jasmine.clock().tick(25)
-        expect(node.styles['width']).toEqual('25%')
-        expect(node.styles['height']).toEqual('62.5%')
+        node.styles['width'].should.equal('25%')
+        node.styles['height'].should.equal('62.5%')
 
         jasmine.clock().tick(25)
-        expect(node.styles['width']).toEqual('50%')
-        expect(node.styles['height']).toEqual('75%')
+        node.styles['width'].should.equal('50%')
+        node.styles['height'].should.equal('75%')
 
         jasmine.clock().tick(50)
-        expect(node.styles['width']).toEqual('100%')
-        expect(node.styles['height']).toEqual('100%')
+        node.styles['width'].should.equal('100%')
+        node.styles['height'].should.equal('100%')
 
       it 'should interpolate the correct values', ->
 
@@ -255,16 +255,16 @@ describe 'hx-animate', ->
           .style('height', '50%', '100%', undefined)
 
         jasmine.clock().tick(50)
-        expect(node.styles['width']).toEqual('25%')
-        expect(node.styles['height']).toEqual('62.5%')
+        node.styles['width'].should.equal('25%')
+        node.styles['height'].should.equal('62.5%')
 
         jasmine.clock().tick(50)
-        expect(node.styles['width']).toEqual('50%')
-        expect(node.styles['height']).toEqual('75%')
+        node.styles['width'].should.equal('50%')
+        node.styles['height'].should.equal('75%')
 
         jasmine.clock().tick(100)
-        expect(node.styles['width']).toEqual('100%')
-        expect(node.styles['height']).toEqual('100%')
+        node.styles['width'].should.equal('100%')
+        node.styles['height'].should.equal('100%')
 
       it 'cancel should work for range animations', ->
 
@@ -276,18 +276,18 @@ describe 'hx-animate', ->
           .style('height', '50%', '100%', undefined)
 
         jasmine.clock().tick(50)
-        expect(node.styles['width']).toEqual('25%')
-        expect(node.styles['height']).toEqual('62.5%')
+        node.styles['width'].should.equal('25%')
+        node.styles['height'].should.equal('62.5%')
 
         anim.cancel()
 
         jasmine.clock().tick(50)
-        expect(node.styles['width']).toEqual('25%')
-        expect(node.styles['height']).toEqual('62.5%')
+        node.styles['width'].should.equal('25%')
+        node.styles['height'].should.equal('62.5%')
 
         jasmine.clock().tick(100)
-        expect(node.styles['width']).toEqual('25%')
-        expect(node.styles['height']).toEqual('62.5%')
+        node.styles['width'].should.equal('25%')
+        node.styles['height'].should.equal('62.5%')
 
       it 'cancel should work for range animations', ->
 
@@ -301,18 +301,18 @@ describe 'hx-animate', ->
           .style('height', '100%')
 
         jasmine.clock().tick(50)
-        expect(node.styles['width']).toEqual('25%')
-        expect(node.styles['height']).toEqual('62.5%')
+        node.styles['width'].should.equal('25%')
+        node.styles['height'].should.equal('62.5%')
 
         anim.cancel()
 
         jasmine.clock().tick(50)
-        expect(node.styles['width']).toEqual('25%')
-        expect(node.styles['height']).toEqual('62.5%')
+        node.styles['width'].should.equal('25%')
+        node.styles['height'].should.equal('62.5%')
 
         jasmine.clock().tick(100)
-        expect(node.styles['width']).toEqual('25%')
-        expect(node.styles['height']).toEqual('62.5%')
+        node.styles['width'].should.equal('25%')
+        node.styles['height'].should.equal('62.5%')
 
     describe 'attr', ->
       it 'should emit end at the end of an animation', ->
@@ -322,12 +322,12 @@ describe 'hx-animate', ->
           .on 'end', -> end = true
 
         jasmine.clock().tick(10)
-        expect(end).toBe(true)
+        end.should.equal(true)
 
       it 'the easing function passed in should be used', ->
         ease = (d) -> Math.sqrt(Math.abs(d))
         anim = hx.animate(new FakeNode, ease)
-        expect(anim.ease).toBe(ease)
+        anim.ease.should.equal(ease)
 
       it 'should emit end at the end of an animation with multiple attrs', ->
         end = false
@@ -337,7 +337,7 @@ describe 'hx-animate', ->
           .on 'end', -> end = true
 
         jasmine.clock().tick(10)
-        expect(end).toBe(true)
+        end.should.equal(true)
 
       it 'should take roughly the amount of time requested', ->
         start = now()
@@ -350,7 +350,7 @@ describe 'hx-animate', ->
 
         jasmine.clock().tick(100)
 
-        expect(time).toEqual(100)
+        time.should.equal(100)
 
       it 'should take roughly the amount of time requested (using default)', ->
         start = now()
@@ -362,7 +362,7 @@ describe 'hx-animate', ->
             time = now() - start
 
         jasmine.clock().tick(200)
-        expect(time).toEqual(200)
+        time.should.equal(200)
 
       it 'if you dont supply a node, then the end event should be emitted straight away', ->
         end = false
@@ -371,7 +371,7 @@ describe 'hx-animate', ->
           .attr('height', '100%', 100)
           .attr('width', '100%', 50)
 
-        expect(end).toEqual(true)
+        end.should.equal(true)
 
       it 'should only emit end once', ->
         count = 0
@@ -381,7 +381,7 @@ describe 'hx-animate', ->
           .attr('width', '100%', 50)
 
 
-        expect(count).toBe(1)
+        count.should.equal(1)
 
       it 'should end on the correct values', ->
         node = new FakeNode
@@ -390,8 +390,8 @@ describe 'hx-animate', ->
           .attr('width', '100%', 50)
 
         jasmine.clock().tick(100)
-        expect(node.attrs['height']).toEqual('100%')
-        expect(node.attrs['width']).toEqual('100%')
+        node.attrs['height'].should.equal('100%')
+        node.attrs['width'].should.equal('100%')
 
       it 'should end on the correct values', ->
 
@@ -405,8 +405,8 @@ describe 'hx-animate', ->
           .attr('width', '100%', 50)
 
         jasmine.clock().tick(100)
-        expect(node.attrs['height']).toEqual('100%')
-        expect(node.attrs['width']).toEqual('100%')
+        node.attrs['height'].should.equal('100%')
+        node.attrs['width'].should.equal('100%')
 
       it 'should interpolate to the correct values', ->
 
@@ -420,16 +420,16 @@ describe 'hx-animate', ->
           .attr('height', '100%', 100)
 
         jasmine.clock().tick(25)
-        expect(node.attrs['width']).toEqual('25%')
-        expect(node.attrs['height']).toEqual('62.5%')
+        node.attrs['width'].should.equal('25%')
+        node.attrs['height'].should.equal('62.5%')
 
         jasmine.clock().tick(25)
-        expect(node.attrs['width']).toEqual('50%')
-        expect(node.attrs['height']).toEqual('75%')
+        node.attrs['width'].should.equal('50%')
+        node.attrs['height'].should.equal('75%')
 
         jasmine.clock().tick(50)
-        expect(node.attrs['width']).toEqual('100%')
-        expect(node.attrs['height']).toEqual('100%')
+        node.attrs['width'].should.equal('100%')
+        node.attrs['height'].should.equal('100%')
 
       it 'changing the easing function should affect the values', ->
 
@@ -443,15 +443,15 @@ describe 'hx-animate', ->
           .attr('height', '100%', 100)
 
         jasmine.clock().tick(25)
-        expect(node.attrs['width']).toEqual('1.5625%')
+        node.attrs['width'].should.equal('1.5625%')
 
         jasmine.clock().tick(25)
-        expect(node.attrs['width']).toEqual('12.5%')
-        expect(node.attrs['height']).toEqual('56.25%')
+        node.attrs['width'].should.equal('12.5%')
+        node.attrs['height'].should.equal('56.25%')
 
         jasmine.clock().tick(50)
-        expect(node.attrs['width']).toEqual('100%')
-        expect(node.attrs['height']).toEqual('100%')
+        node.attrs['width'].should.equal('100%')
+        node.attrs['height'].should.equal('100%')
 
       it 'changing the easing function should affect the values', ->
 
@@ -465,15 +465,15 @@ describe 'hx-animate', ->
           .attr('height', '100%', 100)
 
         jasmine.clock().tick(25)
-        expect(node.attrs['width']).toEqual('6.25%')
+        node.attrs['width'].should.equal('6.25%')
 
         jasmine.clock().tick(25)
-        expect(node.attrs['width']).toEqual('25%')
-        expect(node.attrs['height']).toEqual('62.5%')
+        node.attrs['width'].should.equal('25%')
+        node.attrs['height'].should.equal('62.5%')
 
         jasmine.clock().tick(50)
-        expect(node.attrs['width']).toEqual('100%')
-        expect(node.attrs['height']).toEqual('100%')
+        node.attrs['width'].should.equal('100%')
+        node.attrs['height'].should.equal('100%')
 
       it 'should interpolate the correct values', ->
 
@@ -485,16 +485,16 @@ describe 'hx-animate', ->
           .attr('height', '50%', '100%', 100)
 
         jasmine.clock().tick(25)
-        expect(node.attrs['width']).toEqual('25%')
-        expect(node.attrs['height']).toEqual('62.5%')
+        node.attrs['width'].should.equal('25%')
+        node.attrs['height'].should.equal('62.5%')
 
         jasmine.clock().tick(25)
-        expect(node.attrs['width']).toEqual('50%')
-        expect(node.attrs['height']).toEqual('75%')
+        node.attrs['width'].should.equal('50%')
+        node.attrs['height'].should.equal('75%')
 
         jasmine.clock().tick(50)
-        expect(node.attrs['width']).toEqual('100%')
-        expect(node.attrs['height']).toEqual('100%')
+        node.attrs['width'].should.equal('100%')
+        node.attrs['height'].should.equal('100%')
 
       it 'should interpolate the correct values', ->
 
@@ -506,16 +506,16 @@ describe 'hx-animate', ->
           .attr('height', '50%', '100%', undefined)
 
         jasmine.clock().tick(50)
-        expect(node.attrs['width']).toEqual('25%')
-        expect(node.attrs['height']).toEqual('62.5%')
+        node.attrs['width'].should.equal('25%')
+        node.attrs['height'].should.equal('62.5%')
 
         jasmine.clock().tick(50)
-        expect(node.attrs['width']).toEqual('50%')
-        expect(node.attrs['height']).toEqual('75%')
+        node.attrs['width'].should.equal('50%')
+        node.attrs['height'].should.equal('75%')
 
         jasmine.clock().tick(100)
-        expect(node.attrs['width']).toEqual('100%')
-        expect(node.attrs['height']).toEqual('100%')
+        node.attrs['width'].should.equal('100%')
+        node.attrs['height'].should.equal('100%')
 
       it 'cancel should work for range animations', ->
 
@@ -527,18 +527,18 @@ describe 'hx-animate', ->
           .attr('height', '50%', '100%', undefined)
 
         jasmine.clock().tick(50)
-        expect(node.attrs['width']).toEqual('25%')
-        expect(node.attrs['height']).toEqual('62.5%')
+        node.attrs['width'].should.equal('25%')
+        node.attrs['height'].should.equal('62.5%')
 
         anim.cancel()
 
         jasmine.clock().tick(50)
-        expect(node.attrs['width']).toEqual('25%')
-        expect(node.attrs['height']).toEqual('62.5%')
+        node.attrs['width'].should.equal('25%')
+        node.attrs['height'].should.equal('62.5%')
 
         jasmine.clock().tick(100)
-        expect(node.attrs['width']).toEqual('25%')
-        expect(node.attrs['height']).toEqual('62.5%')
+        node.attrs['width'].should.equal('25%')
+        node.attrs['height'].should.equal('62.5%')
 
       it 'cancel should work for range animations', ->
 
@@ -552,18 +552,18 @@ describe 'hx-animate', ->
           .attr('height', '100%')
 
         jasmine.clock().tick(50)
-        expect(node.attrs['width']).toEqual('25%')
-        expect(node.attrs['height']).toEqual('62.5%')
+        node.attrs['width'].should.equal('25%')
+        node.attrs['height'].should.equal('62.5%')
 
         anim.cancel()
 
         jasmine.clock().tick(50)
-        expect(node.attrs['width']).toEqual('25%')
-        expect(node.attrs['height']).toEqual('62.5%')
+        node.attrs['width'].should.equal('25%')
+        node.attrs['height'].should.equal('62.5%')
 
         jasmine.clock().tick(100)
-        expect(node.attrs['width']).toEqual('25%')
-        expect(node.attrs['height']).toEqual('62.5%')
+        node.attrs['width'].should.equal('25%')
+        node.attrs['height'].should.equal('62.5%')
 
 
   describe 'hx.morph', ->
@@ -572,7 +572,7 @@ describe 'hx-animate', ->
       node = hx.detached('div').node()
       fromSelection = hx.select(node).morph()
       normal = hx.morph(node)
-      expect(fromSelection.node).toEqual(normal.node)
+      fromSelection.node.should.equal(normal.node)
 
     it 'should proceed straight away for no argument functions that are not event emitters', ->
       called1 = false
@@ -582,8 +582,8 @@ describe 'hx-animate', ->
         .then -> called2 = true
         .go()
 
-      expect(called1).toEqual(true)
-      expect(called2).toEqual(true)
+      called1.should.equal(true)
+      called2.should.equal(true)
 
     it 'should wait until async functions finish before continuing', ->
       called = false
@@ -593,11 +593,11 @@ describe 'hx-animate', ->
         .then -> called = true
         .go()
 
-      expect(called).toEqual(false)
+      called.should.equal(false)
       jasmine.clock().tick(25)
-      expect(called).toEqual(false)
+      called.should.equal(false)
       jasmine.clock().tick(100)
-      expect(called).toEqual(true)
+      called.should.equal(true)
 
     it 'should wait until event emitters emit end finish before continuing', ->
       called = false
@@ -610,11 +610,11 @@ describe 'hx-animate', ->
         .then -> called = true
         .go()
 
-      expect(called).toEqual(false)
+      called.should.equal(false)
       jasmine.clock().tick(25)
-      expect(called).toEqual(false)
+      called.should.equal(false)
       jasmine.clock().tick(100)
-      expect(called).toEqual(true)
+      called.should.equal(true)
 
     it 'should cancel ongoing morphs correctly', ->
       called1 = false
@@ -636,8 +636,8 @@ describe 'hx-animate', ->
 
       jasmine.clock().tick(150)
 
-      expect(called1).toEqual(false)
-      expect(called2).toEqual(true)
+      called1.should.equal(false)
+      called2.should.equal(true)
 
     it 'should do nothing when you cancel an ongoing morph when a node isnt given', ->
       called1 = false
@@ -657,8 +657,8 @@ describe 'hx-animate', ->
 
       jasmine.clock().tick(150)
 
-      expect(called1).toEqual(true)
-      expect(called2).toEqual(true)
+      called1.should.equal(true)
+      called2.should.equal(true)
 
     it 'should be fine with cancelling morphs on a node that hasnt got any', ->
       called = false
@@ -671,7 +671,7 @@ describe 'hx-animate', ->
 
       jasmine.clock().tick(150)
 
-      expect(called).toEqual(true)
+      called.should.equal(true)
 
     it 'should be fine with cancelling morphs on a node that hasnt got any (due to them all expiring)', ->
       called = false
@@ -686,7 +686,7 @@ describe 'hx-animate', ->
 
       jasmine.clock().tick(150)
 
-      expect(called).toEqual(true)
+      called.should.equal(true)
 
     it 'should ignore things that have already been cancelled', ->
       called = false
@@ -702,7 +702,7 @@ describe 'hx-animate', ->
         .then (done) -> setTimeout(done, 100)
         .go(true)
 
-      expect(called).toEqual(false)
+      called.should.equal(false)
 
     it 'cancelling a morph twice should be fine', ->
       node = new FakeNode
@@ -713,7 +713,7 @@ describe 'hx-animate', ->
 
       morph.cancel()
 
-      expect(-> morph.cancel()).not.toThrow()
+      should.not.Throw(-> morph.cancel())
 
     it 'when cancelling, the cancellers should be called', ->
       node = new FakeNode
@@ -728,8 +728,8 @@ describe 'hx-animate', ->
 
       morph.cancel()
 
-      expect(cancelled1).toEqual(true)
-      expect(cancelled2).toEqual(true)
+      cancelled1.should.equal(true)
+      cancelled2.should.equal(true)
 
     it 'shouldnt fall over on cancel properties that isnt a function', ->
       node = new FakeNode
@@ -743,7 +743,7 @@ describe 'hx-animate', ->
         .and (done) -> {cancel: -> cancelled2 = true}
         .go()
 
-      expect(-> morph.cancel()).not.toThrow()
+      should.not.Throw(-> morph.cancel())
 
     it 'should ignore things that have already finished', ->
       called = false
@@ -757,7 +757,7 @@ describe 'hx-animate', ->
 
       hx.morph(node).go(true)
 
-      expect(called).toEqual(false)
+      called.should.equal(false)
 
     it 'should filter out cancelled morphs when a new one is started', ->
       called = false
@@ -775,7 +775,7 @@ describe 'hx-animate', ->
 
       hx.morph(node).go(false)
 
-      expect(node.__hx__.morphs).toContain(original[0])
+      node.__hx__.morphs.should.contain(original[0])
 
     it 'things with a cancel method should be put onto the cancellers array', ->
       node = new FakeNode
@@ -788,7 +788,7 @@ describe 'hx-animate', ->
         .and (done) -> obj
         .go()
 
-      expect(morph.cancelers).toEqual([obj, obj, obj])
+      morph.cancelers.should.eql([obj, obj, obj])
 
 
     it 'should wait until all async things have finished before emitting end', ->
@@ -817,22 +817,22 @@ describe 'hx-animate', ->
         .on 'end', -> end = true
 
       jasmine.clock().tick(101)
-      expect(called1).toEqual(true)
-      expect(called2).toEqual(false)
-      expect(called3).toEqual(false)
-      expect(end).toEqual(false)
+      called1.should.equal(true)
+      called2.should.equal(false)
+      called3.should.equal(false)
+      end.should.equal(false)
 
       jasmine.clock().tick(100)
-      expect(called1).toEqual(true)
-      expect(called2).toEqual(true)
-      expect(called3).toEqual(false)
-      expect(end).toEqual(false)
+      called1.should.equal(true)
+      called2.should.equal(true)
+      called3.should.equal(false)
+      end.should.equal(false)
 
       jasmine.clock().tick(100)
-      expect(called1).toEqual(true)
-      expect(called2).toEqual(true)
-      expect(called3).toEqual(true)
-      expect(end).toEqual(true)
+      called1.should.equal(true)
+      called2.should.equal(true)
+      called3.should.equal(true)
+      end.should.equal(true)
 
     it 'with should do the same as then', ->
       called1 = false
@@ -860,22 +860,22 @@ describe 'hx-animate', ->
         .go()
 
       jasmine.clock().tick(101)
-      expect(called1).toEqual(true)
-      expect(called2).toEqual(false)
-      expect(called3).toEqual(false)
-      expect(end).toEqual(false)
+      called1.should.equal(true)
+      called2.should.equal(false)
+      called3.should.equal(false)
+      end.should.equal(false)
 
       jasmine.clock().tick(100)
-      expect(called1).toEqual(true)
-      expect(called2).toEqual(true)
-      expect(called3).toEqual(false)
-      expect(end).toEqual(false)
+      called1.should.equal(true)
+      called2.should.equal(true)
+      called3.should.equal(false)
+      end.should.equal(false)
 
       jasmine.clock().tick(100)
-      expect(called1).toEqual(true)
-      expect(called2).toEqual(true)
-      expect(called3).toEqual(true)
-      expect(end).toEqual(true)
+      called1.should.equal(true)
+      called2.should.equal(true)
+      called3.should.equal(true)
+      end.should.equal(true)
 
     it 'named morphs should work', ->
       end = false
@@ -901,10 +901,10 @@ describe 'hx-animate', ->
         .go()
 
       jasmine.clock().tick(101)
-      expect(end).toEqual(false)
+      end.should.equal(false)
 
       jasmine.clock().tick(400)
-      expect(end).toEqual(true)
+      end.should.equal(true)
 
     it 'named morphs should do nothing when you have no node', ->
       end = false
@@ -928,19 +928,19 @@ describe 'hx-animate', ->
         .go()
 
       jasmine.clock().tick(101)
-      expect(end).toEqual(true)
+      end.should.equal(true)
 
       jasmine.clock().tick(400)
-      expect(end).toEqual(true)
+      end.should.equal(true)
 
     it 'a warning should be thrown when a named morph is used that doesnt exist', ->
-      spyOn(console, 'warn')
+      chai.spy.on(console, 'warn')
 
       hx.morph(new FakeNode)
         .with('delay5', 500)
         .go()
 
-      expect(console.warn).toHaveBeenCalled()
+      console.warn.should.have.been.called.once
 
     it 'andStyle should affect an elements styles', ->
       node = new FakeNode
@@ -951,11 +951,11 @@ describe 'hx-animate', ->
         .andStyle('height', '100')
         .go()
 
-      expect(node.styles['height']).toEqual('0')
+      node.styles['height'].should.equal('0')
       jasmine.clock().tick(100)
-      expect(node.styles['height']).toEqual('50')
+      node.styles['height'].should.equal('50')
       jasmine.clock().tick(100)
-      expect(node.styles['height']).toEqual('100')
+      node.styles['height'].should.equal('100')
 
     it 'andStyle should affect an elements styles (with custom duration)', ->
       node = new FakeNode
@@ -966,11 +966,11 @@ describe 'hx-animate', ->
         .andStyle('height', '100', 500)
         .go()
 
-      expect(node.styles['height']).toEqual('0')
+      node.styles['height'].should.equal('0')
       jasmine.clock().tick(250)
-      expect(node.styles['height']).toEqual('50')
+      node.styles['height'].should.equal('50')
       jasmine.clock().tick(250)
-      expect(node.styles['height']).toEqual('100')
+      node.styles['height'].should.equal('100')
 
     it 'andStyle should affect an elements styles (with start and end values)', ->
       node = new FakeNode
@@ -979,11 +979,11 @@ describe 'hx-animate', ->
         .andStyle('height', '0', '100', undefined)
         .go()
 
-      expect(node.styles['height']).toEqual('0')
+      node.styles['height'].should.equal('0')
       jasmine.clock().tick(100)
-      expect(node.styles['height']).toEqual('50')
+      node.styles['height'].should.equal('50')
       jasmine.clock().tick(100)
-      expect(node.styles['height']).toEqual('100')
+      node.styles['height'].should.equal('100')
 
     it 'andStyle should affect an elements styles (with start and end values and custom duration)', ->
       node = new FakeNode
@@ -992,11 +992,11 @@ describe 'hx-animate', ->
         .andStyle('height', '0', '100', 500)
         .go()
 
-      expect(node.styles['height']).toEqual('0')
+      node.styles['height'].should.equal('0')
       jasmine.clock().tick(250)
-      expect(node.styles['height']).toEqual('50')
+      node.styles['height'].should.equal('50')
       jasmine.clock().tick(250)
-      expect(node.styles['height']).toEqual('100')
+      node.styles['height'].should.equal('100')
 
     it 'thenStyle should affect an elements styles', ->
       node = new FakeNode
@@ -1007,11 +1007,11 @@ describe 'hx-animate', ->
         .thenStyle('height', '100')
         .go()
 
-      expect(node.styles['height']).toEqual('0')
+      node.styles['height'].should.equal('0')
       jasmine.clock().tick(100)
-      expect(node.styles['height']).toEqual('50')
+      node.styles['height'].should.equal('50')
       jasmine.clock().tick(100)
-      expect(node.styles['height']).toEqual('100')
+      node.styles['height'].should.equal('100')
 
     it 'thenStyle should affect an elements styles (with custom duration)', ->
       node = new FakeNode
@@ -1022,11 +1022,11 @@ describe 'hx-animate', ->
         .thenStyle('height', '100', 500)
         .go()
 
-      expect(node.styles['height']).toEqual('0')
+      node.styles['height'].should.equal('0')
       jasmine.clock().tick(250)
-      expect(node.styles['height']).toEqual('50')
+      node.styles['height'].should.equal('50')
       jasmine.clock().tick(250)
-      expect(node.styles['height']).toEqual('100')
+      node.styles['height'].should.equal('100')
 
     it 'thenStyle should affect an elements styles (with start and end values)', ->
       node = new FakeNode
@@ -1035,11 +1035,11 @@ describe 'hx-animate', ->
         .thenStyle('height', '0', '100', undefined)
         .go()
 
-      expect(node.styles['height']).toEqual('0')
+      node.styles['height'].should.equal('0')
       jasmine.clock().tick(100)
-      expect(node.styles['height']).toEqual('50')
+      node.styles['height'].should.equal('50')
       jasmine.clock().tick(100)
-      expect(node.styles['height']).toEqual('100')
+      node.styles['height'].should.equal('100')
 
     it 'thenStyle should affect an elements styles (with start and end values and custom duration)', ->
       node = new FakeNode
@@ -1048,11 +1048,11 @@ describe 'hx-animate', ->
         .thenStyle('height', '0', '100', 500)
         .go()
 
-      expect(node.styles['height']).toEqual('0')
+      node.styles['height'].should.equal('0')
       jasmine.clock().tick(250)
-      expect(node.styles['height']).toEqual('50')
+      node.styles['height'].should.equal('50')
       jasmine.clock().tick(250)
-      expect(node.styles['height']).toEqual('100')
+      node.styles['height'].should.equal('100')
 
     it 'andAttr should affect an elements attributes', ->
       node = new FakeNode
@@ -1063,11 +1063,11 @@ describe 'hx-animate', ->
         .andAttr('height', '100')
         .go()
 
-      expect(node.attrs['height']).toEqual('0')
+      node.attrs['height'].should.equal('0')
       jasmine.clock().tick(100)
-      expect(node.attrs['height']).toEqual('50')
+      node.attrs['height'].should.equal('50')
       jasmine.clock().tick(100)
-      expect(node.attrs['height']).toEqual('100')
+      node.attrs['height'].should.equal('100')
 
     it 'andAttr should affect an elements attributes (with custom duration)', ->
       node = new FakeNode
@@ -1078,11 +1078,11 @@ describe 'hx-animate', ->
         .andAttr('height', '100', 500)
         .go()
 
-      expect(node.attrs['height']).toEqual('0')
+      node.attrs['height'].should.equal('0')
       jasmine.clock().tick(250)
-      expect(node.attrs['height']).toEqual('50')
+      node.attrs['height'].should.equal('50')
       jasmine.clock().tick(250)
-      expect(node.attrs['height']).toEqual('100')
+      node.attrs['height'].should.equal('100')
 
     it 'andAttr should affect an elements attributes (with start and end values)', ->
       node = new FakeNode
@@ -1091,11 +1091,11 @@ describe 'hx-animate', ->
         .andAttr('height', '0', '100', undefined)
         .go()
 
-      expect(node.attrs['height']).toEqual('0')
+      node.attrs['height'].should.equal('0')
       jasmine.clock().tick(100)
-      expect(node.attrs['height']).toEqual('50')
+      node.attrs['height'].should.equal('50')
       jasmine.clock().tick(100)
-      expect(node.attrs['height']).toEqual('100')
+      node.attrs['height'].should.equal('100')
 
     it 'andAttr should affect an elements attributes (with start and end values and custom duration)', ->
       node = new FakeNode
@@ -1104,11 +1104,11 @@ describe 'hx-animate', ->
         .andAttr('height', '0', '100', 500)
         .go()
 
-      expect(node.attrs['height']).toEqual('0')
+      node.attrs['height'].should.equal('0')
       jasmine.clock().tick(250)
-      expect(node.attrs['height']).toEqual('50')
+      node.attrs['height'].should.equal('50')
       jasmine.clock().tick(250)
-      expect(node.attrs['height']).toEqual('100')
+      node.attrs['height'].should.equal('100')
 
     it 'thenAttr should affect an elements attributes', ->
       node = new FakeNode
@@ -1119,11 +1119,11 @@ describe 'hx-animate', ->
         .thenAttr('height', '100')
         .go()
 
-      expect(node.attrs['height']).toEqual('0')
+      node.attrs['height'].should.equal('0')
       jasmine.clock().tick(100)
-      expect(node.attrs['height']).toEqual('50')
+      node.attrs['height'].should.equal('50')
       jasmine.clock().tick(100)
-      expect(node.attrs['height']).toEqual('100')
+      node.attrs['height'].should.equal('100')
 
     it 'thenAttr should affect an elements attributes (with custom duration)', ->
       node = new FakeNode
@@ -1134,11 +1134,11 @@ describe 'hx-animate', ->
         .thenAttr('height', '100', 500)
         .go()
 
-      expect(node.attrs['height']).toEqual('0')
+      node.attrs['height'].should.equal('0')
       jasmine.clock().tick(250)
-      expect(node.attrs['height']).toEqual('50')
+      node.attrs['height'].should.equal('50')
       jasmine.clock().tick(250)
-      expect(node.attrs['height']).toEqual('100')
+      node.attrs['height'].should.equal('100')
 
     it 'thenAttr should affect an elements attributes (with start and end values)', ->
       node = new FakeNode
@@ -1147,11 +1147,11 @@ describe 'hx-animate', ->
         .thenAttr('height', '0', '100', undefined)
         .go()
 
-      expect(node.attrs['height']).toEqual('0')
+      node.attrs['height'].should.equal('0')
       jasmine.clock().tick(100)
-      expect(node.attrs['height']).toEqual('50')
+      node.attrs['height'].should.equal('50')
       jasmine.clock().tick(100)
-      expect(node.attrs['height']).toEqual('100')
+      node.attrs['height'].should.equal('100')
 
     it 'thenAttr should affect an elements attributes (with start and end values and custom duration)', ->
       node = new FakeNode
@@ -1160,11 +1160,11 @@ describe 'hx-animate', ->
         .thenAttr('height', '0', '100', 500)
         .go()
 
-      expect(node.attrs['height']).toEqual('0')
+      node.attrs['height'].should.equal('0')
       jasmine.clock().tick(250)
-      expect(node.attrs['height']).toEqual('50')
+      node.attrs['height'].should.equal('50')
       jasmine.clock().tick(250)
-      expect(node.attrs['height']).toEqual('100')
+      node.attrs['height'].should.equal('100')
 
    it 'withStyle should affect an elements attributes', ->
       node = new FakeNode
@@ -1175,11 +1175,11 @@ describe 'hx-animate', ->
         .withStyle('height', '100')
         .go()
 
-      expect(node.styles['height']).toEqual('0')
+      node.styles['height'].should.equal('0')
       jasmine.clock().tick(100)
-      expect(node.styles['height']).toEqual('50')
+      node.styles['height'].should.equal('50')
       jasmine.clock().tick(100)
-      expect(node.styles['height']).toEqual('100')
+      node.styles['height'].should.equal('100')
 
     it 'withStyle should affect an elements attributes (with custom duration)', ->
       node = new FakeNode
@@ -1190,11 +1190,11 @@ describe 'hx-animate', ->
         .withStyle('height', '100', 500)
         .go()
 
-      expect(node.styles['height']).toEqual('0')
+      node.styles['height'].should.equal('0')
       jasmine.clock().tick(250)
-      expect(node.styles['height']).toEqual('50')
+      node.styles['height'].should.equal('50')
       jasmine.clock().tick(250)
-      expect(node.styles['height']).toEqual('100')
+      node.styles['height'].should.equal('100')
 
     it 'withStyle should affect an elements attributes (with start and end values)', ->
       node = new FakeNode
@@ -1203,11 +1203,11 @@ describe 'hx-animate', ->
         .withStyle('height', '0', '100', undefined)
         .go()
 
-      expect(node.styles['height']).toEqual('0')
+      node.styles['height'].should.equal('0')
       jasmine.clock().tick(100)
-      expect(node.styles['height']).toEqual('50')
+      node.styles['height'].should.equal('50')
       jasmine.clock().tick(100)
-      expect(node.styles['height']).toEqual('100')
+      node.styles['height'].should.equal('100')
 
     it 'withStyle should affect an elements attributes (with start and end values and custom duration)', ->
       node = new FakeNode
@@ -1216,11 +1216,11 @@ describe 'hx-animate', ->
         .withStyle('height', '0', '100', 500)
         .go()
 
-      expect(node.styles['height']).toEqual('0')
+      node.styles['height'].should.equal('0')
       jasmine.clock().tick(250)
-      expect(node.styles['height']).toEqual('50')
+      node.styles['height'].should.equal('50')
       jasmine.clock().tick(250)
-      expect(node.styles['height']).toEqual('100')
+      node.styles['height'].should.equal('100')
 
     it 'withAttr should affect an elements attributes', ->
       node = new FakeNode
@@ -1231,11 +1231,11 @@ describe 'hx-animate', ->
         .withAttr('height', '100')
         .go()
 
-      expect(node.attrs['height']).toEqual('0')
+      node.attrs['height'].should.equal('0')
       jasmine.clock().tick(100)
-      expect(node.attrs['height']).toEqual('50')
+      node.attrs['height'].should.equal('50')
       jasmine.clock().tick(100)
-      expect(node.attrs['height']).toEqual('100')
+      node.attrs['height'].should.equal('100')
 
     it 'withAttr should affect an elements attributes (with custom duration)', ->
       node = new FakeNode
@@ -1246,11 +1246,11 @@ describe 'hx-animate', ->
         .withAttr('height', '100', 500)
         .go()
 
-      expect(node.attrs['height']).toEqual('0')
+      node.attrs['height'].should.equal('0')
       jasmine.clock().tick(250)
-      expect(node.attrs['height']).toEqual('50')
+      node.attrs['height'].should.equal('50')
       jasmine.clock().tick(250)
-      expect(node.attrs['height']).toEqual('100')
+      node.attrs['height'].should.equal('100')
 
     it 'withAttr should affect an elements attributes (with start and end values)', ->
       node = new FakeNode
@@ -1259,11 +1259,11 @@ describe 'hx-animate', ->
         .withAttr('height', '0', '100', undefined)
         .go()
 
-      expect(node.attrs['height']).toEqual('0')
+      node.attrs['height'].should.equal('0')
       jasmine.clock().tick(100)
-      expect(node.attrs['height']).toEqual('50')
+      node.attrs['height'].should.equal('50')
       jasmine.clock().tick(100)
-      expect(node.attrs['height']).toEqual('100')
+      node.attrs['height'].should.equal('100')
 
     it 'withAttr should affect an elements attributes (with start and end values and custom duration)', ->
       node = new FakeNode
@@ -1272,8 +1272,8 @@ describe 'hx-animate', ->
         .withAttr('height', '0', '100', 500)
         .go()
 
-      expect(node.attrs['height']).toEqual('0')
+      node.attrs['height'].should.equal('0')
       jasmine.clock().tick(250)
-      expect(node.attrs['height']).toEqual('50')
+      node.attrs['height'].should.equal('50')
       jasmine.clock().tick(250)
-      expect(node.attrs['height']).toEqual('100')
+      node.attrs['height'].should.equal('100')

--- a/modules/click-detector/test/spec.coffee
+++ b/modules/click-detector/test/spec.coffee
@@ -1,5 +1,7 @@
 describe 'ClickDetector', ->
 
+  ClickDetector = hx.ClickDetector
+
   cd = null
   beforeEach ->
     fixture = hx.select('body')
@@ -15,7 +17,7 @@ describe 'ClickDetector', ->
       .attr('id', 'elem')
 
 
-    cd = new hx.ClickDetector()
+    cd = new ClickDetector
 
   afterEach ->
     cd = null
@@ -23,30 +25,30 @@ describe 'ClickDetector', ->
   it 'should correctly add exceptions', ->
     cd.addException(document.getElementById('exception'))
 
-    expect(cd.exceptions.size).toEqual(1)
-    expect(cd.exceptions.entries()).toEqual([document.getElementById('exception')])
+    cd.exceptions.size.should.equal(1)
+    cd.exceptions.entries().should.eql([document.getElementById('exception')])
 
   it 'should correctly remove exceptions', ->
     cd.addException(document.getElementById('exception'))
 
-    expect(cd.exceptions.size).toEqual(1)
-    expect(cd.exceptions.entries()).toEqual([document.getElementById('exception')])
+    cd.exceptions.size.should.equal(1)
+    cd.exceptions.entries().should.eql([document.getElementById('exception')])
     cd.removeException(document.getElementById('exception'))
-    expect(cd.exceptions.size).toEqual(0)
+    cd.exceptions.size.should.equal(0)
 
     cd.removeException(document.getElementById('elem'))
-    expect(cd.exceptions.size).toEqual(0)
+    cd.exceptions.size.should.equal(0)
 
   it 'should correctly clear exceptions', ->
     cd.addException(document.getElementById('exception'))
 
-    expect(cd.exceptions.size).toEqual(1)
-    expect(cd.exceptions.entries()).toEqual([document.getElementById('exception')])
+    cd.exceptions.size.should.equal(1)
+    cd.exceptions.entries().should.eql([document.getElementById('exception')])
 
     cd.removeAllExceptions()
 
-    expect(cd.exceptions.size).toEqual(0)
-    expect(cd.exceptions.entries()).toEqual([])
+    cd.exceptions.size.should.equal(0)
+    cd.exceptions.entries().should.eql([])
 
   it 'should emit the click event when a pointerdown event is called', ->
     val = 0
@@ -55,7 +57,7 @@ describe 'ClickDetector', ->
 
     document.__hx__.eventEmitter.emit('pointerdown', { event: {target: document.getElementById('elem')}})
 
-    expect(val).toEqual(1)
+    val.should.equal(1)
 
   it 'should emit the click event when a pointerup event is called', ->
     val = 0
@@ -64,7 +66,7 @@ describe 'ClickDetector', ->
 
     document.__hx__.eventEmitter.emit('pointerup', { event: {target: document.getElementById('elem')}})
 
-    expect(val).toEqual(1)
+    val.should.equal(1)
 
 
   it 'should not emit an event for an exception', ->
@@ -77,7 +79,7 @@ describe 'ClickDetector', ->
     document.__hx__.eventEmitter.emit('pointerdown', { event: {target: document.getElementById('exception')}})
     document.__hx__.eventEmitter.emit('pointerup', { event: {target: document.getElementById('exception')}})
 
-    expect(val).toEqual(0)
+    val.should.equal(0)
 
   it 'should emit an event for an element that is not an exception', ->
     cd.addException(document.getElementById('exception'))
@@ -89,7 +91,7 @@ describe 'ClickDetector', ->
     document.__hx__.eventEmitter.emit('pointerdown', { event: {target: document.getElementById('elem')}})
     document.__hx__.eventEmitter.emit('pointerup', { event: {target: document.getElementById('elem')}})
 
-    expect(val).toEqual(2)
+    val.should.equal(2)
 
   it 'should correctly check for the original element when pointerup is called on a different element to that of pointerdown', ->
     val = 0
@@ -99,7 +101,7 @@ describe 'ClickDetector', ->
     document.__hx__.eventEmitter.emit('pointerdown', { event: {target: document.getElementById('elem')}})
     document.__hx__.eventEmitter.emit('pointerup', { event: {target: document.getElementById('exception')}})
 
-    expect(val).toEqual(1)
+    val.should.equal(1)
 
   it 'should correctly deregister listeners', ->
     val = 0
@@ -108,10 +110,10 @@ describe 'ClickDetector', ->
 
     document.__hx__.eventEmitter.emit('pointerdown', { event: {target: document.getElementById('elem')}})
 
-    expect(val).toEqual(1)
+    val.should.equal(1)
 
     cd.cleanUp()
 
     document.__hx__.eventEmitter.emit('pointerdown', { event: {target: document.getElementById('elem')}})
 
-    expect(val).toEqual(1)
+    val.should.equal(1)

--- a/modules/collapsible/test/spec.coffee
+++ b/modules/collapsible/test/spec.coffee
@@ -1,6 +1,10 @@
 describe 'collapsible', ->
+
+  Collapsible = hx.Collapsible
+  select = hx.select
+
   beforeEach ->
-    fixture = hx.select('body').append('div').attr('id', 'fixture').html """
+    fixture = select('body').append('div').attr('id', 'fixture').html """
       <div id="example" class="hx-collapsible">
         <div class="hx-collapsible-heading">Header</div>
         <div class="hx-collapsible-content">Content</div>
@@ -27,154 +31,154 @@ describe 'collapsible', ->
     """
 
   afterEach ->
-    hx.select('#fixture').remove()
+    select('#fixture').remove()
 
   it 'should initialise the target element with openable', ->
-    new hx.Collapsible(hx.select('#example').node())
-    expect(hx.select('#example').classed('hx-openable')).toEqual(true)
+    new Collapsible(select('#example').node())
+    select('#example').classed('hx-openable').should.equal(true)
 
   it 'should initialise with visible if visible is set', ->
-    new hx.Collapsible(hx.select('#example').node(), {visible: true})
-    expect(hx.select('#example').classed('hx-collapsible-expanded')).toEqual(true)
-    expect(hx.select('#example').classed('hx-opened')).toEqual(true)
+    new Collapsible(select('#example').node(), {visible: true})
+    select('#example').classed('hx-collapsible-expanded').should.equal(true)
+    select('#example').classed('hx-opened').should.equal(true)
 
   it 'should initialise with visible if visible is set to false', ->
-    new hx.Collapsible(hx.select('#example').node(), {visible: false})
-    expect(hx.select('#example').classed('hx-collapsible-expanded')).toEqual(false)
-    expect(hx.select('#example').classed('hx-opened')).toEqual(false)
+    new Collapsible(select('#example').node(), {visible: false})
+    select('#example').classed('hx-collapsible-expanded').should.equal(false)
+    select('#example').classed('hx-opened').should.equal(false)
 
   it 'should call the lazy function just once', ->
     called = 0
     f = -> called++
-    collapsible = new hx.Collapsible(hx.select('#example').node(), {lazyContent: f})
-    expect(called).toEqual(0)
+    collapsible = new Collapsible(select('#example').node(), {lazyContent: f})
+    called.should.equal(0)
     collapsible.show(false)
-    expect(called).toEqual(1)
+    called.should.equal(1)
     collapsible.hide(false)
-    expect(called).toEqual(1)
+    called.should.equal(1)
     collapsible.show(false)
-    expect(called).toEqual(1)
+    called.should.equal(1)
     collapsible.show(false)
-    expect(called).toEqual(1)
+    called.should.equal(1)
 
   it 'should add an icon by default', ->
-    collapsible = new hx.Collapsible(hx.select('#example').node())
-    expect(hx.select('#example').select('i').size()).toEqual(1)
+    collapsible = new Collapsible(select('#example').node())
+    select('#example').select('i').size().should.equal(1)
 
   it 'should not add an icon if addIcon is false', ->
-    collapsible = new hx.Collapsible(hx.select('#example').node(), { visible: false, addIcon: false })
-    expect(hx.select('#example').select('i').size()).toEqual(0)
+    collapsible = new Collapsible(select('#example').node(), { visible: false, addIcon: false })
+    select('#example').select('i').size().should.equal(0)
 
   it 'should remove an existing icon if there is one, then add a new one', ->
-    collapsible = new hx.Collapsible(hx.select('#example2').node())
-    expect(hx.select('#example2').select('i').classed('existing')).toEqual(false)
+    collapsible = new Collapsible(select('#example2').node())
+    select('#example2').select('i').classed('existing').should.equal(false)
 
   it 'an existing icon should not be touched if addIcon is false', ->
-    collapsible = new hx.Collapsible(hx.select('#example2').node(), { visible: false, addIcon: false })
-    expect(hx.select('#example2').select('i').classed('existing')).toEqual(true)
+    collapsible = new Collapsible(select('#example2').node(), { visible: false, addIcon: false })
+    select('#example2').select('i').classed('existing').should.equal(true)
 
   it 'should add an icon by default (with toggle area)', ->
-    collapsible = new hx.Collapsible(hx.select('#example3').node())
-    expect(hx.select('#example3').select('i').size()).toEqual(1)
+    collapsible = new Collapsible(select('#example3').node())
+    select('#example3').select('i').size().should.equal(1)
 
   it 'should not add an icon if addIcon is false (with toggle area)', ->
-    collapsible = new hx.Collapsible(hx.select('#example3').node(), { visible: false, addIcon: false })
-    expect(hx.select('#example3').select('i').size()).toEqual(0)
+    collapsible = new Collapsible(select('#example3').node(), { visible: false, addIcon: false })
+    select('#example3').select('i').size().should.equal(0)
 
   it 'should remove an existing icon if there is one, then add a new one (with toggle area)', ->
-    collapsible = new hx.Collapsible(hx.select('#example4').node())
-    expect(hx.select('#example4').select('i').classed('existing')).toEqual(false)
+    collapsible = new Collapsible(select('#example4').node())
+    select('#example4').select('i').classed('existing').should.equal(false)
 
   it 'an existing icon should not be touched if addIcon is false (with toggle area)', ->
-    collapsible = new hx.Collapsible(hx.select('#example4').node(), { visible: false, addIcon: false })
-    expect(hx.select('#example4').select('i').classed('existing')).toEqual(true)
+    collapsible = new Collapsible(select('#example4').node(), { visible: false, addIcon: false })
+    select('#example4').select('i').classed('existing').should.equal(true)
 
   it 'the collapsible should be visible after show is called', ->
-    collapsible = new hx.Collapsible(hx.select('#example').node(), { visible: false })
+    collapsible = new Collapsible(select('#example').node(), { visible: false })
     collapsible.show(false)
-    expect(collapsible.isOpen()).toEqual(true)
+    collapsible.isOpen().should.equal(true)
 
   it 'the collapsible should not be visible after hide is called', ->
-    collapsible = new hx.Collapsible(hx.select('#example').node(), { visible: false })
+    collapsible = new Collapsible(select('#example').node(), { visible: false })
     collapsible.hide(false)
-    expect(collapsible.isOpen()).toEqual(false)
+    collapsible.isOpen().should.equal(false)
 
   it 'toggle should work as expected', ->
-    collapsible = new hx.Collapsible(hx.select('#example').node(), { visible: false })
+    collapsible = new Collapsible(select('#example').node(), { visible: false })
     collapsible.show(false)
     collapsible.toggle(false)
-    expect(collapsible.isOpen()).toEqual(false)
+    collapsible.isOpen().should.equal(false)
     collapsible.toggle(false)
-    expect(collapsible.isOpen()).toEqual(true)
+    collapsible.isOpen().should.equal(true)
 
   it 'the collapsible should be visible after show is called (with animation enabled)', ->
-    collapsible = new hx.Collapsible(hx.select('#example').node(), { visible: false })
+    collapsible = new Collapsible(select('#example').node(), { visible: false })
     collapsible.show(true)
-    expect(collapsible.isOpen()).toEqual(true)
+    collapsible.isOpen().should.equal(true)
 
   it 'the collapsible should not be visible after hide is called (with animation enabled)', ->
-    collapsible = new hx.Collapsible(hx.select('#example').node(), { visible: false })
+    collapsible = new Collapsible(select('#example').node(), { visible: false })
     collapsible.hide(true)
-    expect(collapsible.isOpen()).toEqual(false)
+    collapsible.isOpen().should.equal(false)
 
   it 'toggle should work as expected (with animation enabled)', ->
-    collapsible = new hx.Collapsible(hx.select('#example').node(), { visible: false })
+    collapsible = new Collapsible(select('#example').node(), { visible: false })
     collapsible.show(true)
     collapsible.toggle(true)
-    expect(collapsible.isOpen()).toEqual(false)
+    collapsible.isOpen().should.equal(false)
     collapsible.toggle(true)
-    expect(collapsible.isOpen()).toEqual(true)
+    collapsible.isOpen().should.equal(true)
 
   it 'the collapsible should be visible after show is called (with default animation)', ->
-    collapsible = new hx.Collapsible(hx.select('#example').node(), { visible: false })
+    collapsible = new Collapsible(select('#example').node(), { visible: false })
     collapsible.show()
-    expect(collapsible.isOpen()).toEqual(true)
+    collapsible.isOpen().should.equal(true)
 
   it 'the collapsible should not be visible after hide is called (with default animation)', ->
-    collapsible = new hx.Collapsible(hx.select('#example').node(), { visible: false })
+    collapsible = new Collapsible(select('#example').node(), { visible: false })
     collapsible.hide()
-    expect(collapsible.isOpen()).toEqual(false)
+    collapsible.isOpen().should.equal(false)
 
   it 'toggle should work as expected (with default animation)', ->
-    collapsible = new hx.Collapsible(hx.select('#example').node(), { visible: false })
+    collapsible = new Collapsible(select('#example').node(), { visible: false })
     collapsible.show()
     collapsible.toggle()
-    expect(collapsible.isOpen()).toEqual(false)
+    collapsible.isOpen().should.equal(false)
     collapsible.toggle()
-    expect(collapsible.isOpen()).toEqual(true)
+    collapsible.isOpen().should.equal(true)
 
   it 'initializeCollapsibles should work', ->
     collapsibles = hx.initializeCollapsibles('.hx-collapsible')
-    expect(collapsibles.length).toEqual(4)
-    expect(collapsibles[0]).toEqual(jasmine.any(hx.Collapsible))
-    expect(collapsibles[1]).toEqual(jasmine.any(hx.Collapsible))
-    expect(collapsibles[2]).toEqual(jasmine.any(hx.Collapsible))
-    expect(collapsibles[3]).toEqual(jasmine.any(hx.Collapsible))
+    collapsibles.length.should.equal(4)
+    collapsibles[0].should.be.an.instanceOf(Collapsible)
+    collapsibles[1].should.be.an.instanceOf(Collapsible)
+    collapsibles[2].should.be.an.instanceOf(Collapsible)
+    collapsibles[3].should.be.an.instanceOf(Collapsible)
 
   it 'should open when clicked', ->
-    collapsible = new hx.Collapsible(hx.select('#example').node())
+    collapsible = new Collapsible(select('#example').node())
     collapsible.hide()
-    expect(collapsible.isOpen()).toEqual(false)
-    hx.select('#example').select('.hx-collapsible-heading').node().__hx__.eventEmitter.emit('click')
-    expect(collapsible.isOpen()).toEqual(true)
+    collapsible.isOpen().should.equal(false)
+    select('#example').select('.hx-collapsible-heading').node().__hx__.eventEmitter.emit('click')
+    collapsible.isOpen().should.equal(true)
 
   it 'should close when clicked', ->
-    collapsible = new hx.Collapsible(hx.select('#example').node())
+    collapsible = new Collapsible(select('#example').node())
     collapsible.show()
-    expect(collapsible.isOpen()).toEqual(true)
-    hx.select('#example').select('.hx-collapsible-heading').node().__hx__.eventEmitter.emit('click')
-    expect(collapsible.isOpen()).toEqual(false)
+    collapsible.isOpen().should.equal(true)
+    select('#example').select('.hx-collapsible-heading').node().__hx__.eventEmitter.emit('click')
+    collapsible.isOpen().should.equal(false)
 
   it 'should open when clicked (with toggle area)', ->
-    collapsible = new hx.Collapsible(hx.select('#example3').node())
+    collapsible = new Collapsible(select('#example3').node())
     collapsible.hide()
-    expect(collapsible.isOpen()).toEqual(false)
-    hx.select('#example3').select('.hx-collapsible-toggle').node().__hx__.eventEmitter.emit('click')
-    expect(collapsible.isOpen()).toEqual(true)
+    collapsible.isOpen().should.equal(false)
+    select('#example3').select('.hx-collapsible-toggle').node().__hx__.eventEmitter.emit('click')
+    collapsible.isOpen().should.equal(true)
 
   it 'should close when clicked (with toggle area)', ->
-    collapsible = new hx.Collapsible(hx.select('#example3').node())
+    collapsible = new Collapsible(select('#example3').node())
     collapsible.show()
-    expect(collapsible.isOpen()).toEqual(true)
-    hx.select('#example3').select('.hx-collapsible-toggle').node().__hx__.eventEmitter.emit('click')
-    expect(collapsible.isOpen()).toEqual(false)
+    collapsible.isOpen().should.equal(true)
+    select('#example3').select('.hx-collapsible-toggle').node().__hx__.eventEmitter.emit('click')
+    collapsible.isOpen().should.equal(false)

--- a/modules/color/test/spec.coffee
+++ b/modules/color/test/spec.coffee
@@ -1,276 +1,277 @@
-describe 'hx-color', ->
+describe 'color', ->
+  color = hx.color
 
-  describe 'hx.color', ->
+  describe 'color', ->
     it 'should default to black when no arguments are passed in', ->
-      hx.color().rgb().should.eql([0, 0, 0, 1])
+      color().rgb().should.eql([0, 0, 0, 1])
 
     it 'should create an object from a string', ->
-      hx.color('rgb(77,255,88)').rgb().should.eql([77,255,88,1])
+      color('rgb(77,255,88)').rgb().should.eql([77,255,88,1])
 
     it 'should create an object from an array', ->
-      hx.color(55,37,199).rgb().should.eql([55,37,199,1])
+      color(55,37,199).rgb().should.eql([55,37,199,1])
 
     it 'should create an object from 3 arguments', ->
-      hx.color(10, 20, 35).rgb().should.eql([10, 20, 35, 1])
+      color(10, 20, 35).rgb().should.eql([10, 20, 35, 1])
 
     it 'should create an object from 4 arguments', ->
-      hx.color(55, 72, 99, 0.6).rgb().should.eql([55, 72, 99, 0.6])
+      color(55, 72, 99, 0.6).rgb().should.eql([55, 72, 99, 0.6])
 
     it 'set the color based on a hex string', ->
-      hx.color('#7BBE31').rgb().should.eql([123,190,49,1])
+      color('#7BBE31').rgb().should.eql([123,190,49,1])
 
     it 'set the color based on a shortened hex string', ->
-      hx.color('#ABC').rgb().should.eql([170, 187, 204, 1 ])
+      color('#ABC').rgb().should.eql([170, 187, 204, 1 ])
 
     it 'set the color based on an rgb string', ->
-      hx.color('rgb(199,1,37)').rgb().should.eql([199,1,37,1])
+      color('rgb(199,1,37)').rgb().should.eql([199,1,37,1])
 
     it 'set the color based on an rgba string', ->
-      hx.color('rgba(199,1,37, 0.7)').rgb().should.eql([199,1,37,0.7])
+      color('rgba(199,1,37, 0.7)').rgb().should.eql([199,1,37,0.7])
 
     it 'set the color based on an hsl string', ->
-      hx.color('hsl(50,100,10)').rgb().should.eql([ 51, 43, 0, 1 ])
+      color('hsl(50,100,10)').rgb().should.eql([ 51, 43, 0, 1 ])
 
     it 'set the color based on an hsla string', ->
-      hx.color('hsla(50,100,10,0.7)').rgb().should.eql([ 51, 43, 0, 0.7 ])
+      color('hsla(50,100,10,0.7)').rgb().should.eql([ 51, 43, 0, 0.7 ])
 
     it 'should return undefined when an invalid color string is passed in ', ->
-      expect(hx.color('#GGGGGG')).toEqual(undefined)
+      expect(color('#GGGGGG')).toEqual(undefined)
 
     it 'should return undefined when an invalid color string is passed in ', ->
-      expect(hx.color(123)).toEqual(undefined)
+      expect(color(123)).toEqual(undefined)
 
     it 'should return undefined when an invalid color string is passed in ', ->
-      expect(hx.color({})).toEqual(undefined)
+      expect(color({})).toEqual(undefined)
 
     it 'should return undefined when an invalid color string is passed in ', ->
-      expect(hx.color(->)).toEqual(undefined)
+      expect(color(->)).toEqual(undefined)
 
     it 'should return undefined when an invalid color string is passed in ', ->
-      expect(hx.color('not a string')).toEqual(undefined)
+      expect(color('not a string')).toEqual(undefined)
 
     it 'should return undefined when an invalid color string is passed in ', ->
-      expect(hx.color('hsl(aasd, 12, 12)')).toEqual(undefined)
+      expect(color('hsl(aasd, 12, 12)')).toEqual(undefined)
 
     it 'should return undefined when an invalid color string is passed in ', ->
-      expect(hx.color('rgb(aasd, 12, 12)')).toEqual(undefined)
+      expect(color('rgb(aasd, 12, 12)')).toEqual(undefined)
 
     it 'should return a color when a valid color string is passed in ', ->
-      hx.color('#FFFFFF').should.eql(hx.color(255, 255, 255, 1))
+      color('#FFFFFF').should.eql(color(255, 255, 255, 1))
 
     it 'should return a color when a valid color string is passed in (rgb)', ->
-      hx.color('rgb(255, 255, 255)').should.eql(hx.color(255, 255, 255, 1))
+      color('rgb(255, 255, 255)').should.eql(color(255, 255, 255, 1))
 
     it 'should return a color when a valid color string is passed in (rgba)', ->
-      hx.color('rgba(255, 255, 255, 0.5)').should.eql(hx.color(255, 255, 255, 0.5))
+      color('rgba(255, 255, 255, 0.5)').should.eql(color(255, 255, 255, 0.5))
 
     it 'should return a color when a valid color string is passed in hsl', ->
-      hx.color('hsl(50, 50, 50)').should.eql(hx.color().hsl([50, 50, 50]))
+      color('hsl(50, 50, 50)').should.eql(color().hsl([50, 50, 50]))
 
     it 'should return  a color when a valid color string is passed in hsla', ->
-      hx.color('hsl(50, 50, 50, 0.5)').should.eql(hx.color().hsl([50, 50, 50]).alpha(0.5))
+      color('hsl(50, 50, 50, 0.5)').should.eql(color().hsl([50, 50, 50]).alpha(0.5))
 
     it 'should return a color when a valid array is passed in', ->
-      hx.color(0, 0, 0).should.eql(hx.color().rgb([0, 0, 0]))
+      color(0, 0, 0).should.eql(color().rgb([0, 0, 0]))
 
     it 'should clamp to valid values for arrays', ->
-      hx.color(0, 0, 256).should.eql(hx.color().rgb([0, 0, 255]))
+      color(0, 0, 256).should.eql(color().rgb([0, 0, 255]))
 
   describe 'hx.isColor', ->
     it 'should return true for a color instance', ->
-      hx.color.isColor(hx.color()).should.eql(true)
+      color.isColor(color()).should.eql(true)
 
     it 'should return false for a color instance', ->
-      hx.color.isColor({}).should.eql(false)
+      color.isColor({}).should.eql(false)
 
   describe 'hx.isColorString', ->
     it 'should return false when an invalid color string is passed in ', ->
-      hx.color.isColorString('#GGGGGG').should.eql(false)
+      color.isColorString('#GGGGGG').should.eql(false)
 
     it 'should return false when an invalid color string is passed in ', ->
-      hx.color.isColorString(123).should.eql(false)
+      color.isColorString(123).should.eql(false)
 
     it 'should return false when an invalid color string is passed in ', ->
-      hx.color.isColorString({}).should.eql(false)
+      color.isColorString({}).should.eql(false)
 
     it 'should return false when an invalid color string is passed in ', ->
-      hx.color.isColorString(->).should.eql(false)
+      color.isColorString(->).should.eql(false)
 
     it 'should return false when an invalid color string is passed in ', ->
-      hx.color.isColorString('not a string').should.eql(false)
+      color.isColorString('not a string').should.eql(false)
 
     it 'should return false when an invalid color string is passed in ', ->
-      hx.color.isColorString('hsl(aasd, 12, 12)').should.eql(false)
+      color.isColorString('hsl(aasd, 12, 12)').should.eql(false)
 
     it 'should return false when an invalid color string is passed in ', ->
-      hx.color.isColorString('rgb(aasd, 12, 12)').should.eql(false)
+      color.isColorString('rgb(aasd, 12, 12)').should.eql(false)
 
     it 'should return true when a valid color string is passed in ', ->
-      hx.color.isColorString('#FFFFFF').should.eql(true)
+      color.isColorString('#FFFFFF').should.eql(true)
 
     it 'should return true when a valid color string is passed in (rgb)', ->
-      hx.color.isColorString('rgb(255, 255, 255)').should.eql(true)
+      color.isColorString('rgb(255, 255, 255)').should.eql(true)
 
     it 'should return true when a valid color string is passed in (rgba)', ->
-      hx.color.isColorString('rgba(255, 255, 255, 0.5)').should.eql(true)
+      color.isColorString('rgba(255, 255, 255, 0.5)').should.eql(true)
 
     it 'should return true when a valid color string is passed in hsl', ->
-      hx.color.isColorString('hsl(50, 50, 50)').should.eql(true)
+      color.isColorString('hsl(50, 50, 50)').should.eql(true)
 
     it 'should return true when a valid color string is passed in hsla', ->
-      hx.color.isColorString('hsl(50, 50, 50, 0.5)').should.eql(true)
+      color.isColorString('hsl(50, 50, 50, 0.5)').should.eql(true)
 
   describe 'Color::toString', ->
     it 'should return correct 6 character hex color by default', ->
-      hx.color().toString().should.eql('#000000')
+      color().toString().should.eql('#000000')
 
     it 'should return correct hex string of color', ->
-      hx.color(123,190,49).toString().should.eql('#7bbe31')
+      color(123,190,49).toString().should.eql('#7bbe31')
 
     it 'should return the rgba css string of a color when no type is passed in', ->
-      hx.color(240,120,10,0.5).toString().should.eql('rgba(240,120,10,0.5)')
+      color(240,120,10,0.5).toString().should.eql('rgba(240,120,10,0.5)')
 
     it 'should return the rgb css string of a color', ->
-      hx.color(240,120,10,0.5).toString('rgb').should.eql('rgb(240,120,10)')
+      color(240,120,10,0.5).toString('rgb').should.eql('rgb(240,120,10)')
 
     it 'should return the rgba css string of a color', ->
-      hx.color(240,120,10,0.5).toString('rgba').should.eql('rgba(240,120,10,0.5)')
+      color(240,120,10,0.5).toString('rgba').should.eql('rgba(240,120,10,0.5)')
 
     it 'should return the hsl css string of a color', ->
-      hx.color().hsl([10,50,50]).toString('hsl').should.eql('hsl(10,50%,50%)')
+      color().hsl([10,50,50]).toString('hsl').should.eql('hsl(10,50%,50%)')
 
     it 'should return the hsla css string of a color', ->
-      hx.color().hsl([10,50,50,1]).toString('hsla').should.eql('hsla(10,50%,50%,1)')
+      color().hsl([10,50,50,1]).toString('hsla').should.eql('hsla(10,50%,50%,1)')
 
   describe 'Color::mix', ->
     it 'should return a 50/50 mix of two colors', ->
-      hx.color(51,204,51).mix(hx.color(245,107,196)).rgb().should.eql([148,156,124,1])
+      color(51,204,51).mix(color(245,107,196)).rgb().should.eql([148,156,124,1])
 
     it 'should allow non-color objects', ->
-      hx.color(51,204,51).mix([245,107,196]).rgb().should.eql([148,156,124,1])
+      color(51,204,51).mix([245,107,196]).rgb().should.eql([148,156,124,1])
 
     it 'should return a 70/30 mix of two colors', ->
-      hx.color(51,204,51).mix(hx.color(245,107,196), 0.7).rgb().should.eql([187, 136, 153, 1])
+      color(51,204,51).mix(color(245,107,196), 0.7).rgb().should.eql([187, 136, 153, 1])
 
   describe 'Color::hue', ->
     it 'should set the hue value of a color', ->
-      hx.color(226,124,29).hue(100).rgb().should.eql([95,226,29,1])
+      color(226,124,29).hue(100).rgb().should.eql([95,226,29,1])
 
     it 'the hue should not be changed if the color is grey', ->
-      hx.color(120,120,120).hue(30).rgb().should.eql([120,120,120,1])
+      color(120,120,120).hue(30).rgb().should.eql([120,120,120,1])
 
   describe 'Color::saturation', ->
     it 'should set the saturation value of a color', ->
-      hx.color(226,124,29).saturation(10).rgb().should.eql([140,127,115,1])
+      color(226,124,29).saturation(10).rgb().should.eql([140,127,115,1])
 
     it 'the saturation should not be changed if the saturation of the color is at 0 (color is grey)', ->
-      hx.color(0,0,0).saturation(50).rgb().should.eql([0,0,0,1])
+      color(0,0,0).saturation(50).rgb().should.eql([0,0,0,1])
 
   describe 'Color::lightness', ->
     it 'should set and get the lightness value of a color', ->
-      hx.color(0,8,26).lightness(88).lightness().should.equal(88)
+      color(0,8,26).lightness(88).lightness().should.equal(88)
 
     it 'should not set lightness above 100', ->
-      hx.color(53,29,184,0.5).lightness(300).lightness().should.equal(100)
+      color(53,29,184,0.5).lightness(300).lightness().should.equal(100)
 
     it 'should not set lightness below 0', ->
-      hx.color(53,29,184,0.5).lightness(-300).lightness().should.equal(0)
+      color(53,29,184,0.5).lightness(-300).lightness().should.equal(0)
 
   describe 'Color::alpha', ->
     it 'should set the opacity value for a color', ->
-      hx.color(76,62,21,0.1).alpha(0.93).rgb().should.eql([76,62,21,0.93])
+      color(76,62,21,0.1).alpha(0.93).rgb().should.eql([76,62,21,0.93])
 
     it 'should not set alpha above 1', ->
-      hx.color(53,29,184,0.5).alpha(3).alpha().should.equal(1)
+      color(53,29,184,0.5).alpha(3).alpha().should.equal(1)
 
     it 'should not set alpha below 0', ->
-      hx.color(53,29,184,0.5).alpha(-3).alpha().should.equal(0)
+      color(53,29,184,0.5).alpha(-3).alpha().should.equal(0)
 
   describe 'Color::lighten', ->
     it 'should increase the lightness of a color', ->
-      hx.color(0,170,255).lighten(0.2).rgb().should.eql([51,187,255,1])
+      color(0,170,255).lighten(0.2).rgb().should.eql([51,187,255,1])
 
     it 'should reduce the lightness of a color', ->
-      hx.color(255,0,200).lighten(-0.2).rgb().should.eql([204,0,160,1])
+      color(255,0,200).lighten(-0.2).rgb().should.eql([204,0,160,1])
 
   describe 'Color::saturate', ->
     it 'increase saturation by a percentage of the colors saturation', ->
-      hx.color(100,64,191).saturate(0.5).rgb().should.eql([86,32,223,1])
+      color(100,64,191).saturate(0.5).rgb().should.eql([86,32,223,1])
 
     it 'decrease saturation by a percentage of the colors saturation', ->
-      hx.color(38,217,95).saturate(-0.5).rgb().should.eql([83,172,111,1])
+      color(38,217,95).saturate(-0.5).rgb().should.eql([83,172,111,1])
 
   describe 'Color::fade', ->
     it 'make a color more opaque', ->
-      hx.color().alpha(0.5).fade(0.5).alpha().should.equal(0.75)
+      color().alpha(0.5).fade(0.5).alpha().should.equal(0.75)
 
     it 'make a color more transparent', ->
-      hx.color().alpha(0.5).fade(-0.5).alpha().should.equal(0.25)
+      color().alpha(0.5).fade(-0.5).alpha().should.equal(0.25)
 
     it 'should not set alpha above 1', ->
-      hx.color(53,29,184,0.5).fade(3).alpha().should.equal(1)
+      color(53,29,184,0.5).fade(3).alpha().should.equal(1)
 
     it 'should not set alpha below 0', ->
-      hx.color(53,29,184,0.5).fade(-3).alpha().should.equal(0)
+      color(53,29,184,0.5).fade(-3).alpha().should.equal(0)
 
   describe 'Color::rgb', ->
     it 'should set the color correctly', ->
-      hx.color().rgb([255,200,50, 0.7]).rgb().should.eql([255,200,50,0.7])
+      color().rgb([255,200,50, 0.7]).rgb().should.eql([255,200,50,0.7])
 
     it 'should return the correct rgb values', ->
-      hx.color(255,200,50,0.7).rgb().should.eql([255,200,50,0.7])
+      color(255,200,50,0.7).rgb().should.eql([255,200,50,0.7])
 
     it 'should return the correct rgb values for the default color', ->
-      hx.color().rgb().should.eql([0, 0, 0, 1])
+      color().rgb().should.eql([0, 0, 0, 1])
 
     it 'should handle undefined things being passed in', ->
-      color = hx.color()
-      color.rgb(undefined).should.eql(color)
+      col = color()
+      col.rgb(undefined).should.eql(col)
 
   describe 'Color::hsl', ->
     it 'should set the correct hsl values', ->
-      hx.color().hsl([44,100,60,0.7]).hsl().should.eql([44,100,60,0.7])
+      color().hsl([44,100,60,0.7]).hsl().should.eql([44,100,60,0.7])
 
     it 'should return the correct hsl values', ->
-      hx.color(255,200,50,0.7).hsl().should.eql([44,100,60,0.7])
+      color(255,200,50,0.7).hsl().should.eql([44,100,60,0.7])
 
     it 'should return the correct hsl values for the default color', ->
-      hx.color().hsl().should.eql([0, 0, 0, 1])
+      color().hsl().should.eql([0, 0, 0, 1])
 
     it 'should handle undefined things being passed in', ->
-      color = hx.color()
-      color.hsl(undefined).should.eql(color)
+      col = color()
+      col.hsl(undefined).should.eql(col)
 
   describe 'Color::textCol', ->
     it 'should return white for a dark color', ->
-      hx.color('#3D3D3D').textCol().should.equal('white')
+      color('#3D3D3D').textCol().should.equal('white')
 
     it 'should return black for a light color', ->
-      hx.color('#FAFAFA').textCol().should.equal('black')
+      color('#FAFAFA').textCol().should.equal('black')
 
   describe 'Color::range', ->
 
     it 'should return the correct number of colors by default', ->
-      hx.color([50,50,50]).range().length.should.equal(7)
+      color([50,50,50]).range().length.should.equal(7)
 
     it 'should return the correct number of colors when numLight/numDark are set', ->
-      hx.color([50,50,50]).range(2, 2).length.should.equal(5)
+      color([50,50,50]).range(2, 2).length.should.equal(5)
 
     it 'should correctly use the default color difference', ->
-      hx.color([50,50,50]).range()
+      color([50,50,50]).range()
         .map((col) -> col.rgb())
         .should.eql([[25,25,25,1], [33,33,33,1], [42,42,42,1], [50,50,50,1], [58,58,58,1], [67,67,67,1], [75,75,75,1]])
 
     it 'should correctly use the maxRange to set the color difference', ->
-      hx.color([50,50,50]).range(1,1,1)
+      color([50,50,50]).range(1,1,1)
         .map((col) -> col.rgb())
         .should.eql([[0,0,0,1], [50,50,50,1], [100,100,100,1]])
 
     it 'should output in array format', ->
-      hx.color([50,50,50]).range(undefined, undefined, undefined, 'array')
+      color([50,50,50]).range(undefined, undefined, undefined, 'array')
         .should.eql([[25,25,25,1], [33,33,33,1], [42,42,42,1], [50,50,50,1], [58,58,58,1], [67,67,67,1], [75,75,75,1]])
 
     it 'should output in hex format', ->
-      hx.color([50,50,50]).range(undefined, undefined, undefined, 'hex')
+      color([50,50,50]).range(undefined, undefined, undefined, 'hex')
         .should.eql(['#191919', '#212121', '#2a2a2a', '#323232', '#3a3a3a', '#434343', '#4b4b4b'])
 

--- a/modules/list/test/spec.coffee
+++ b/modules/list/test/spec.coffee
@@ -1,130 +1,132 @@
 describe "List", ->
 
+  List = hx.List
+
   it "contains nothing when initialsed",  ->
-    list = new hx.List
-    expect(list.entries()) .toEqual []
+    list = new List
+    list.entries().should.eql([])
 
   it "size should be reported as 0 for a newly initialsed list",  ->
-    list = new hx.List
-    expect(list.size) .toEqual 0
+    list = new List
+    list.size.should.equal(0)
 
   it "contains stuff when initialsed with a non empty array",  ->
-    list = new hx.List([2, 3, 1])
-    expect(list.entries()) .toEqual [2, 3, 1]
+    list = new List([2, 3, 1])
+    list.entries().should.eql([2, 3, 1])
 
   it "size should be reported as non-zero for a list initialsed with a non empty array",  ->
-    list = new hx.List([2, 3, 1])
-    expect(list.size) .toEqual 3
+    list = new List([2, 3, 1])
+    list.size.should.equal(3)
 
   it "add should work",  ->
-    list = new hx.List
+    list = new List
     list.add 2
     list.add 4
     list.add 7
-    expect(list.entries()) .toEqual [2, 4, 7]
-    expect(list.size) .toEqual 3
+    list.entries().should.eql([2, 4, 7])
+    list.size.should.equal(3)
 
   it "clear should work", ->
-    list = new hx.List([8, 7, 6, 5])
+    list = new List([8, 7, 6, 5])
     list.clear()
-    expect(list.entries()) .toEqual []
-    expect(list.size) .toEqual 0
+    list.entries().should.eql([])
+    list.size.should.equal(0)
 
   it "delete should work",  ->
-    list = new hx.List([8, 7, 6, 5])
+    list = new List([8, 7, 6, 5])
     list.delete 2
-    expect(list.entries()) .toEqual [8, 7, 5]
-    expect(list.size) .toEqual 3
+    list.entries().should.eql([8, 7, 5])
+    list.size.should.equal(3)
 
   it "delete out of range should do nothing",  ->
-    list = new hx.List([8, 7, 6, 5])
+    list = new List([8, 7, 6, 5])
     list.delete 20000
-    expect(list.entries()) .toEqual [8, 7, 6, 5]
-    expect(list.size) .toEqual 4
+    list.entries().should.eql([8, 7, 6, 5])
+    list.size.should.equal(4)
 
   it "forEach should work",  ->
-    list = new hx.List([3, 3, 2, 1, 3])
+    list = new List([3, 3, 2, 1, 3])
     items = []
     list.forEach (d) -> items.push d
-    expect(items) .toEqual [3, 3, 2, 1, 3]
+    items.should.eql([3, 3, 2, 1, 3])
 
   it "forEach should work with a different this",  ->
-    list = new hx.List([3, 3, 2, 1, 3])
+    list = new List([3, 3, 2, 1, 3])
     items = []
     list.forEach(((d) -> this.push d), items)
-    expect(items) .toEqual [3, 3, 2, 1, 3]
+    items.should.eql([3, 3, 2, 1, 3])
 
   it "get should work",  ->
-    list = new hx.List([3, 3, 2, 1, 3])
-    expect(list.get(0)) .toEqual 3
-    expect(list.get(2)) .toEqual 2
-    expect(list.get(4)) .toEqual 3
+    list = new List([3, 3, 2, 1, 3])
+    list.get(0).should.equal(3)
+    list.get(2).should.equal(2)
+    list.get(4).should.equal(3)
 
   it "get should return undefined when out of bounds",  ->
-    list = new hx.List([3, 3, 2, 1, 3])
-    expect(list.get(-1)) .toEqual undefined
-    expect(list.get(5)) .toEqual undefined
-    expect(list.get(NaN)) .toEqual undefined
+    list = new List([3, 3, 2, 1, 3])
+    should.not.exist(list.get(-1))
+    should.not.exist(list.get(5))
+    should.not.exist(list.get(NaN))
 
   it "has should work",  ->
-    list = new hx.List([3, 3, 2, 1, 3])
-    expect(list.has(-1)) .toEqual false
-    expect(list.has(0)) .toEqual false
-    expect(list.has(1)) .toEqual true
-    expect(list.has(2)) .toEqual true
-    expect(list.has(3)) .toEqual true
-    expect(list.has(4)) .toEqual false
-    expect(list.has(5)) .toEqual false
-    expect(list.has(NaN)) .toEqual false
+    list = new List([3, 3, 2, 1, 3])
+    list.has(-1).should.equal(false)
+    list.has(0).should.equal(false)
+    list.has(1).should.equal(true)
+    list.has(2).should.equal(true)
+    list.has(3).should.equal(true)
+    list.has(4).should.equal(false)
+    list.has(5).should.equal(false)
+    list.has(NaN).should.equal(false)
 
   it "remove should work",  ->
-    list = new hx.List([3, 3, 2, 1, 3])
+    list = new List([3, 3, 2, 1, 3])
     list.remove 3
-    expect(list.entries()) .toEqual [3, 2, 1, 3]
-    expect(list.size) .toEqual 4
+    list.entries().should.eql([3, 2, 1, 3])
+    list.size.should.equal(4)
 
   it "removeAll should work",  ->
-    list = new hx.List([3, 3, 2, 1, 3])
+    list = new List([3, 3, 2, 1, 3])
     list.removeAll 3
-    expect(list.entries()) .toEqual [2, 1]
-    expect(list.size) .toEqual 2
+    list.entries().should.eql([2, 1])
+    list.size.should.equal(2)
 
   it "remove should do nothing when it can't find any matching value",  ->
-    list = new hx.List([3, 3, 2, 1, 3])
+    list = new List([3, 3, 2, 1, 3])
     list.remove 4
-    expect(list.entries()) .toEqual [3, 3, 2, 1, 3]
-    expect(list.size) .toEqual 5
+    list.entries().should.eql([3, 3, 2, 1, 3])
+    list.size.should.equal(5)
 
   it "removeAll should do nothing when it can't find any matching value",  ->
-    list = new hx.List([3, 3, 2, 1, 3])
+    list = new List([3, 3, 2, 1, 3])
     list.removeAll 4
-    expect(list.entries()) .toEqual [3, 3, 2, 1, 3]
-    expect(list.size) .toEqual 5
+    list.entries().should.eql([3, 3, 2, 1, 3])
+    list.size.should.equal(5)
 
   it "values should return the same as entries", ->
-    list = new hx.List([3, 2, 1])
-    expect(list.values()) .toEqual list.entries()
-    expect(list.values()) .toEqual [3, 2, 1]
+    list = new List([3, 2, 1])
+    list.values().should.equal(list.entries())
+    list.values().should.eql([3, 2, 1])
 
   it "size should be correct after adding and removing several items",  ->
-    list = new hx.List
-    expect(list.size) .toEqual 0
+    list = new List
+    list.size.should.equal(0)
     list.add 42
-    expect(list.size) .toEqual 1
+    list.size.should.equal(1)
     list.add 43
-    expect(list.size) .toEqual 2
+    list.size.should.equal(2)
     list.add 44
-    expect(list.size) .toEqual 3
+    list.size.should.equal(3)
     list.add 45
-    expect(list.size) .toEqual 4
+    list.size.should.equal(4)
     list.delete 0
-    expect(list.size) .toEqual 3
+    list.size.should.equal(3)
     list.remove 44
-    expect(list.size) .toEqual 2
+    list.size.should.equal(2)
     list.delete -1
-    expect(list.size) .toEqual 2
+    list.size.should.equal(2)
     list.remove 44
-    expect(list.size) .toEqual 2
+    list.size.should.equal(2)
     list.clear()
-    expect(list.size) .toEqual 0
+    list.size.should.equal(0)
 

--- a/modules/map/test/spec.coffee
+++ b/modules/map/test/spec.coffee
@@ -1,183 +1,173 @@
 describe "hx-map", ->
   a = [1]
 
+  Map = hx.Map
+
   it "size should distinguish between keys with the same toString", ->
-    map = new hx.Map [[1, 'Bob'], ['1', 'Lazlo'], [a, 'Ganesh']]
-    expect map.size
-      .toEqual 3
+    map = new Map([[1, 'Bob'], ['1', 'Lazlo'], [a, 'Ganesh']])
+    map.size.should.equal(3)
 
   it "get should distinguish between keys with the same toString", ->
-    map = new hx.Map [[1, 'Bob'], ['1', 'Lazlo'], [a, 'Ganesh']]
-    expect map.get 1
-      .toEqual 'Bob'
-    expect map.get '1'
-      .toEqual 'Lazlo'
-    expect map.get a
-      .toEqual 'Ganesh'
+    map = new Map([[1, 'Bob'], ['1', 'Lazlo'], [a, 'Ganesh']])
+    map.get(1).should.equal('Bob')
+    map.get('1').should.equal('Lazlo')
+    map.get(a).should.equal('Ganesh')
 
   it "delete should distinguish between keys with the same toString", ->
-    map = new hx.Map [[1, 'Bob'], ['1', 'Lazlo'], [a, 'Ganesh']]
-    map.delete 1
-    expect map.size
-      .toEqual 2
-    expect map.entries()
-      .toEqual [['1', 'Lazlo'], [a, 'Ganesh']]
+    map = new Map([[1, 'Bob'], ['1', 'Lazlo'], [a, 'Ganesh']])
+    map.delete(1)
+    map.size.should.equal(2)
+    map.entries().should.eql([['1', 'Lazlo'], [a, 'Ganesh']])
     map.delete a
-    expect map.size
-      .toEqual 1
-    expect map.entries()
-      .toEqual [['1', 'Lazlo']]
+    map.size.should.equal(1)
+    map.entries().should.eql([['1', 'Lazlo']])
 
   it "set should distinguish between keys with the same toString", ->
-    map = new hx.Map [[1, 'Bob'], ['1', 'Ganesh']]
-    map.set 1, 'Lazlo'
-    expect map.entries()
-      .toEqual [[1, 'Lazlo'], ['1', 'Ganesh']]
+    map = new Map([[1, 'Bob'], ['1', 'Ganesh']])
+    map.set(1, 'Lazlo')
+    map.entries().should.eql [[1, 'Lazlo'], ['1', 'Ganesh']]
 
   it "has should distinguish between keys with the same toString", ->
-    map = new hx.Map [[1, 'Bob'], [a, 'Ganesh']]
-    expect map.has 1
-      .toBeTruthy()
-    expect map.has '1'
-      .toBeFalsy()
-    expect map.has a
-      .toBeTruthy()
+    map = new Map([[1, 'Bob'], [a, 'Ganesh']])
+    map.has(1).should.be.ok
+    map.has('1').should.not.be.ok
+    map.has(a).should.be.ok
 
   it "contains nothing when initialsed",  ->
-    map = new hx.Map
-    expect(map.values()) .toEqual []
+    map = new Map
+    map.values().should.eql([])
 
   it "contains stuff when initialsed with an array",  ->
-    map = new hx.Map([['key', 'value'], ['key2', 123]])
-    expect(map.entries()) .toEqual [['key', 'value'], ['key2', 123]]
+    map = new Map([['key', 'value'], ['key2', 123]])
+    map.entries().should.eql([['key', 'value'], ['key2', 123]])
 
   it "size should be reported as 0 for a newly initialsed map",  ->
-    map = new hx.Map
-    expect(map.size) .toEqual 0
+    map = new Map
+    map.size.should.equal(0)
 
   it "set should work",  ->
-    map = new hx.Map
-    map.set 'a', 5
-    map.set 'b', 2
-    map.set 'c', 7
-    expect(map.entries()) .toEqual [['a', 5], ['b', 2], ['c', 7]]
-    expect(map.size) .toEqual 3
+    map = new Map
+    map.set('a', 5)
+    map.set('b', 2)
+    map.set('c', 7)
+    map.entries().should.eql([['a', 5], ['b', 2], ['c', 7]])
+    map.size.should.equal(3)
 
   it "clear should work", ->
-    map = new hx.Map
+    map = new Map
     [8, 7, 6, 5].forEach((d) -> map.set('' + d, d*2))
     map.clear()
-    expect(map.values()) .toEqual []
-    expect(map.size) .toEqual 0
+    map.values().should.eql([])
+    map.size.should.equal(0)
 
   it "get should return undefined for previously defined value after clear is called", ->
-    map = new hx.Map
+    map = new Map
     map.set('a', 42)
-    expect(map.get('a')) .toEqual 42
+    map.get('a').should.equal(42)
     map.clear()
-    expect(map.get('a')) .toEqual undefined
+    should.not.exist(map.get('a'))
 
   it "delete should work",  ->
-    map = new hx.Map
+    map = new Map
     [8, 7, 6, 5].forEach((d) -> map.set('' + d, d*2))
     map.delete '6'
-    expect(map.entries()) .toEqual [['8', 16], ['7', 14], ['5', 10]]
-    expect(map.size) .toEqual 3
+    map.entries().should.eql([['8', 16], ['7', 14], ['5', 10]])
+    map.size.should.equal(3)
 
   it "delete for non existant entry should do nothing",  ->
-    map = new hx.Map
+    map = new Map
     [8, 7, 6, 5].forEach((d) -> map.set('' + d, d*2))
-    map.delete 20000
-    expect(map.entries()) .toEqual [['8', 16], ['7', 14], ['6', 12], ['5', 10]]
-    expect(map.size) .toEqual 4
+    map.delete(20000)
+    map.entries().should.eql([['8', 16], ['7', 14], ['6', 12], ['5', 10]])
+    map.size.should.equal(4)
 
   it "forEach should work",  ->
-    map = new hx.Map
+    map = new Map
     [3, 3, 2, 1, 3].forEach((d) -> map.set('' + d, d*2))
     keys = []
     values = []
     map.forEach (k, v) ->
       keys.push k
       values.push v
-    expect(keys) .toEqual ['3', '2', '1']
-    expect(values) .toEqual [6, 4, 2]
+    keys.should.eql(['3', '2', '1'])
+    values.should.eql([6, 4, 2])
 
   it "forEach should work with a different this",  ->
-    map = new hx.Map
+    map = new Map
     [3, 3, 2, 1, 3].forEach((d) -> map.set('' + d, d*2))
     keys = []
     values = []
     map.forEach(((k, v) -> this.push k), keys)
     map.forEach(((k, v) -> this.push v), values)
-    expect(keys) .toEqual ['3', '2', '1']
-    expect(values) .toEqual [6, 4, 2]
+    keys.should.eql(['3', '2', '1'])
+    values.should.eql([6, 4, 2])
 
   it "has should work",  ->
-    map = new hx.Map
+    map = new Map
     [3, 3, 2, 1, 3].forEach((d) -> map.set('' + d, d*2))
-    expect(map.has('-1')) .toEqual false
-    expect(map.has('0')) .toEqual false
-    expect(map.has('1')) .toEqual true
-    expect(map.has('2')) .toEqual true
-    expect(map.has('3')) .toEqual true
-    expect(map.has('4')) .toEqual false
-    expect(map.has('5')) .toEqual false
-    expect(map.has('NaN')) .toEqual false
-    expect(map.has(NaN)) .toEqual false
-    expect(map.has(undefined)) .toEqual false
-    expect(map.has(null)) .toEqual false
-    expect(map.has(0)) .toEqual false
+    map.has('-1').should.equal(false)
+    map.has('0').should.equal(false)
+    map.has('1').should.equal(true)
+    map.has('2').should.equal(true)
+    map.has('3').should.equal(true)
+    map.has('4').should.equal(false)
+    map.has('5').should.equal(false)
+    map.has('NaN').should.equal(false)
+    map.has(NaN).should.equal(false)
+    map.has(undefined).should.equal(false)
+    map.has(null).should.equal(false)
+    map.has(0).should.equal(false)
 
   it "entries should return the correct values", ->
-    map = new hx.Map
+    map = new Map
     [3, 2, 1].forEach((d) -> map.set('' + d, d*2))
-    expect(map.entries()) .toEqual [['3', 6], ['2', 4], ['1', 2]]
+    map.entries().should.eql([['3', 6], ['2', 4], ['1', 2]])
 
   it "keys should return the correct values", ->
-    map = new hx.Map
+    map = new Map
     [3, 2, 1].forEach((d) -> map.set('' + d, d*2))
-    expect(map.keys()) .toEqual ['3', '2', '1']
+    map.keys().should.eql(['3', '2', '1'])
 
   it "size should be correct after adding and removing several items",  ->
-    map = new hx.Map
-    expect(map.size) .toEqual 0
+    map = new Map
+    map.size.should.equal(0)
     map.set('a', 42)
-    expect(map.size) .toEqual 1
+    map.size.should.equal(1)
     map.set('b', 43)
-    expect(map.size) .toEqual 2
+    map.size.should.equal(2)
     map.set('b', 42)
-    expect(map.size) .toEqual 2
+    map.size.should.equal(2)
     map.set('c', 44*2)
-    expect(map.size) .toEqual 3
+    map.size.should.equal(3)
     map.set('d', 45*2)
-    expect(map.size) .toEqual 4
+    map.size.should.equal(4)
     map.delete 'a'
-    expect(map.size) .toEqual 3
+    map.size.should.equal(3)
     map.delete 'a'
-    expect(map.size) .toEqual 3
+    map.size.should.equal(3)
     map.clear()
-    expect(map.size) .toEqual 0
+    map.size.should.equal(0)
 
   it "overwriting keys should work",  ->
-    map = new hx.Map
+    map = new Map
     map.set('a', 1)
-    expect(map.get('a')) .toEqual 1
+    map.get('a').should.equal(1)
     map.set('a', 2)
-    expect(map.get('a')) .toEqual 2
+    map.get('a').should.equal(2)
 
   it "using NaN as a key should work", ->
-    map = new hx.Map
+    map = new Map
     map.set(NaN, 50)
     map.set('a', 54)
-    expect(map.get(NaN)) .toEqual 50
-    expect(map.keys()) .toEqual ['a', NaN]
-    expect(map.entries()) .toEqual [['a', 54], [NaN, 50]]
+    map.get(NaN).should.equal(50)
+    map.keys().should.eql(['a', NaN])
+    map.entries().should.eql([['a', 54], [NaN, 50]])
 
   it "using NaN should update the size correctly", ->
-    map = new hx.Map
+    map = new Map
     map.set(NaN, 50)
     map.set(NaN, 50)
     map.set('a', 52)
-    expect(map.size) .toEqual 2
+    map.size.should.equal(2)
     map.delete(NaN)
-    expect(map.size) .toEqual 1
+    map.size.should.equal(1)

--- a/modules/set/test/spec.coffee
+++ b/modules/set/test/spec.coffee
@@ -1,167 +1,152 @@
-describe "hx-set", ->
+describe "set", ->
+
+  Set = hx.Set
 
   it "can be intialized using an array", ->
-    set = new hx.Set [1, 2, 3]
-    expect set.size
-      .toEqual 3
+    set = new Set [1, 2, 3]
+    set.size.should.equal(3)
 
   it "can contain things with the same toString", ->
-    set = new hx.Set [1, "1"]
-    expect set.size
-      .toEqual 2
-    expect set.has 1
-      .toBeTruthy()
-    expect set.has "1"
-      .toBeTruthy()
+    set = new Set([1, '1'])
+    set.size.should.equal(2)
+    set.has(1).should.be.ok
+    set.has('1').should.be.ok
 
   it "can distinguish things with the same toString when looking up", ->
-    set = new hx.Set [1]
-    expect set.has 1
-      .toBeTruthy()
-    expect set.has "1"
-      .toBeFalsy()
+    set = new Set([1])
+    set.has(1).should.be.ok
+    set.has('1').should.not.be.ok
 
   it "can choose the right thing to delete when the elements have the same toString", ->
     a = [1]
-    set = new hx.Set [1, a, "1"]
-    expect set.size
-      .toEqual 3
-    expect set.has 1
-      .toBeTruthy()
-    expect set.has "1"
-      .toBeTruthy()
-    expect set.has a
-      .toBeTruthy()
-    set.delete a
-    expect set.has 1
-      .toBeTruthy()
-    expect set.has "1"
-      .toBeTruthy()
-    expect set.has a
-      .toBeFalsy()
+    set = new Set([1, a, '1'])
+    set.size.should.equal(3)
+    set.has(1).should.be.ok
+    set.has('1').should.be.ok
+    set.has(a).should.be.ok
+    set.delete(a)
+    set.has(1).should.be.ok
+    set.has('1').should.be.ok
+    set.has(a).should.not.be.ok
 
-
-  it "contains nothing when initialsed",  ->
-    set = new hx.Set
-    expect(set.values()) .toEqual []
+  it "contains nothing when initialised",  ->
+    (new Set).values().should.eql([])
 
   it "contains stuff when initialsed with a non empty array",  ->
-    list = new hx.Set([2, 3, 1])
-    expect(list.values()) .toEqual [2, 3, 1]
+    (new Set([2, 3, 1]).values()).should.eql([2, 3, 1])
 
   it "size should be reported as 0 for a newly initialsed set",  ->
-    set = new hx.Set
-    expect(set.size) .toEqual 0
+    (new Set).size.should.equal(0)
 
   it "add should work",  ->
-    set = new hx.Set
-    set.add 2
-    set.add 4
-    set.add 7
-    expect(set.values()) .toEqual [2, 4, 7]
-    expect(set.size) .toEqual 3
+    set = new Set
+    set.add(2)
+    set.add(4)
+    set.add(7)
+    set.values().should.eql([2, 4, 7])
+    set.size.should.equal(3)
 
   it "clear should work", ->
-    set = new hx.Set
+    set = new Set
     [8, 7, 6, 5].forEach((d) -> set.add d)
     set.clear()
-    expect(set.values()) .toEqual []
-    expect(set.size) .toEqual 0
+    set.values().should.eql []
+    set.size.should.equal 0
 
   it "delete should work",  ->
-    set = new hx.Set
+    set = new Set
     [8, 7, 6, 5].forEach((d) -> set.add d)
     set.delete 6
-    expect(set.values()) .toEqual [8, 7, 5]
-    expect(set.size) .toEqual 3
+    set.values().should.eql [8, 7, 5]
+    set.size.should.equal 3
 
   it "delete for non existant entry should do nothing",  ->
-    set = new hx.Set
+    set = new Set
     [8, 7, 6, 5].forEach((d) -> set.add d)
     set.delete 20000
-    expect(set.values()) .toEqual [8, 7, 6, 5]
-    expect(set.size) .toEqual 4
+    set.values().should.eql [8, 7, 6, 5]
+    set.size.should.equal 4
 
   it "forEach should work",  ->
-    set = new hx.Set
+    set = new Set
     [3, 3, 2, 1, 3].forEach((d) -> set.add d)
     items = []
     set.forEach (d) -> items.push d
-    expect(items) .toEqual [3, 2, 1]
+    items.should.eql [3, 2, 1]
 
   it "forEach should work with a different this",  ->
-    set = new hx.Set
+    set = new Set
     [3, 3, 2, 1, 3].forEach((d) -> set.add d)
     items = []
     set.forEach(((d) -> this.push d), items)
-    expect(items) .toEqual [3, 2, 1]
+    items.should.eql [3, 2, 1]
 
   it "has should work",  ->
-    set = new hx.Set
+    set = new Set
     [3, 3, 2, 1, 3].forEach((d) -> set.add d)
-    expect(set.has(-1)) .toEqual false
-    expect(set.has(0)) .toEqual false
-    expect(set.has(1)) .toEqual true
-    expect(set.has(2)) .toEqual true
-    expect(set.has(3)) .toEqual true
-    expect(set.has(4)) .toEqual false
-    expect(set.has(5)) .toEqual false
-    expect(set.has(NaN)) .toEqual false
+    set.has(-1).should.equal false
+    set.has(0).should.equal false
+    set.has(1).should.equal true
+    set.has(2).should.equal true
+    set.has(3).should.equal true
+    set.has(4).should.equal false
+    set.has(5).should.equal false
+    set.has(NaN).should.equal false
 
   it "entries should return the same data as values (albeit duplicated)", ->
-    set = new hx.Set
+    set = new Set
     [3, 2, 1].forEach((d) -> set.add d)
-    expect(set.entries()) .toEqual set.values().map((d) -> [d, d])
-    expect(set.values()) .toEqual [3, 2, 1]
+    set.entries().should.eql set.values().map((d) -> [d, d])
+    set.values().should.eql [3, 2, 1]
 
   it "keys should return the same data as values", ->
-    set = new hx.Set
+    set = new Set
     [3, 2, 1].forEach((d) -> set.add d)
-    expect(set.keys()) .toEqual set.values()
-    expect(set.keys()) .toEqual [3, 2, 1]
+    set.keys().should.eql set.values()
+    set.keys().should.eql [3, 2, 1]
 
   it "size should be correct after adding and removing several items",  ->
-    set = new hx.Set
-    expect(set.size) .toEqual 0
+    set = new Set
+    set.size.should.equal 0
     set.add 42
-    expect(set.size) .toEqual 1
+    set.size.should.equal 1
     set.add 43
-    expect(set.size) .toEqual 2
+    set.size.should.equal 2
     set.add 42
-    expect(set.size) .toEqual 2
+    set.size.should.equal 2
     set.add 44
-    expect(set.size) .toEqual 3
+    set.size.should.equal 3
     set.add 45
-    expect(set.size) .toEqual 4
+    set.size.should.equal 4
     set.delete 42
-    expect(set.size) .toEqual 3
+    set.size.should.equal 3
     set.delete 0
-    expect(set.size) .toEqual 3
+    set.size.should.equal 3
     set.clear()
-    expect(set.size) .toEqual 0
+    set.size.should.equal 0
 
   it "adding a value to a set repeatedly should have no effect", ->
-    set = new hx.Set
+    set = new Set
     set.add(1)
     set.add(2)
-    expect(set.size) .toEqual 2
+    set.size.should.equal 2
     set.add(1)
     set.add(2)
     set.add(1)
     set.add(3)
-    expect(set.size) .toEqual 3
+    set.size.should.equal 3
 
   it "NaN should work", ->
-    set = new hx.Set
+    set = new Set
     set.add(52)
     set.add(NaN)
-    expect(set.keys()) .toEqual [52, NaN]
+    set.keys().should.eql [52, NaN]
 
   it "using NaN should update the size correctly", ->
-    set = new hx.Set
+    set = new Set
     set.add(NaN)
     set.add(52)
-    expect(set.size) .toEqual 2
+    set.size.should.equal 2
     set.delete(NaN)
-    expect(set.size) .toEqual 1
+    set.size.should.equal 1
 

--- a/modules/view/test/spec.coffee
+++ b/modules/view/test/spec.coffee
@@ -1,75 +1,46 @@
 describe 'hx-view', ->
   it "should create elements of a given type using the default view enter fn", ->
-    noDivsToCreate = 3
-    root = hx.detached 'div'
-    root.view 'cool-element-type'
-      .apply [1..noDivsToCreate]
-    noDivsCreated = root.selectAll 'cool-element-type'
-      .size()
-    expect noDivsCreated
-      .toEqual noDivsToCreate
+    selection = hx.detached('div')
+    selection.view('element-type').apply([1..3])
+    selection.selectAll('element-type').size().should.equal(3)
 
   it "should create elements of a given class using the default view enter fn", ->
-    noDivsToCreate = 3
-    root = hx.detached 'div'
-    root.view '.cool-class'
-      .apply [1..noDivsToCreate]
-    noDivsCreated = root.selectAll '.cool-class'
-      .size()
-    expect noDivsCreated
-      .toEqual noDivsToCreate
+    selection = hx.detached('div')
+    selection.view('.class').apply([1..3])
+    selection.selectAll('.class').size().should.equal(3)
 
-      
   it "should create slightly more complicated elements with the default view enter fn", ->
-    noDivsToCreate = 3
-    root = hx.detached 'div'
-    root.view 'cool-element-type.cool-class-onion.cool-class-lemon'
-      .apply [1..noDivsToCreate]
-    noDivsCreated = root.selectAll 'cool-element-type.cool-class-onion.cool-class-lemon'
-      .size()
-    expect noDivsCreated
-      .toEqual noDivsToCreate
+    selection = hx.detached('div')
+    selection.view('element-type.class-onion.class-lemon').apply([1..3])
+    selection.selectAll('element-type.class-onion.class-lemon').size().should.equal(3)
+
 
   it "should support update functions", ->
-    root = hx.detached 'div'
-    noDivsToCreate = 3
-    root.view '.cool-class'
-      .update (datum, node) ->
-        hx.select node
-          .text datum + 1
-      .apply [1..noDivsToCreate]
-    text = root.selectAll '.cool-class'
-      .text()
-    expect text
-      .toEqual ["2", "3", "4"]
+    selection = hx.detached('div')
+
+    selection.view('.class')
+      .update (datum, node) -> hx.select(node).text(datum + 1)
+      .apply([1..3])
+
+    selection.selectAll('.class').text().should.eql(["2", "3", "4"])
 
   it "should create additional elements as needed", ->
-    root = hx.detached 'div'
-    noDivsToCreate = 3
-    root.view '.cool-class'
-      .update (datum, node) ->
-        hx.select node
-          .text datum + 1
-      .apply [1..noDivsToCreate]
-      .apply [1..noDivsToCreate + 1]
+    selection = hx.detached('div')
 
-    text = root.selectAll '.cool-class'
-      .text()
-    expect text
-      .toEqual ["2", "3", "4", "5"]
+    selection.view('.class')
+      .update (datum, node) -> hx.select(node).text(datum + 1)
+      .apply([1..3])
+      .apply([1..4])
+
+    selection.selectAll('.class').text().should.eql(["2", "3", "4", "5"])
 
   it "should remove additional elements as needed", ->
-    root = hx.detached 'div'
-    noDivsToCreate = 3
-    root.view '.cool-class'
-      .update (datum, node) ->
-        hx.select node
-          .text datum + 1
-      .apply [1..noDivsToCreate]
-      .apply [1..noDivsToCreate - 1]
+    selection = hx.detached('div')
 
-    text = root.selectAll '.cool-class'
-      .text()
-    expect text
-      .toEqual ["2", "3"]
+    selection.view('.class')
+      .update (datum, node) -> hx.select(node).text(datum + 1)
+      .apply([1..3])
+      .apply([1..2])
+
+    selection.selectAll('.class').text().should.eql(["2", "3"])
 

--- a/package.json
+++ b/package.json
@@ -32,10 +32,12 @@
   "devDependencies": {
     "chai": "^3.3.0",
     "chai-as-promised": "^5.1.0",
+    "chai-spies": "^0.7.1",
     "istanbul": "^0.4.1",
     "jasmine-core": "^2.3.4",
     "karma": "^0.13.10",
     "karma-chai": "^0.1.0",
+    "karma-chai-spies": "^0.1.4",
     "karma-chrome-launcher": "^0.2.1",
     "karma-coffee-preprocessor": "^0.3.0",
     "karma-coverage": "^0.5.2",


### PR DESCRIPTION
There is a mix of chai and jasmine used throughout hexagon - it would be nice to get them all using the same same thing (ideally mocha + chai)

The changes made in this branch have already been merged into the webpack branch.