### PR TITLE
Fix unselecting api-selected row bug

### DIFF
--- a/modules/data-table/main/index.coffee
+++ b/modules/data-table/main/index.coffee
@@ -287,7 +287,9 @@ class DataTable extends hx.EventEmitter
       else
         options[name]
 
-    rowToArray = (headers, obj) -> headers.map (header) -> obj.cells[header.id]
+    rowToArray = (headers, obj) -> headers.map (header) ->
+      console.log obj unless obj.cells
+      obj.cells[header.id]
 
     # build the main structure of the table in a detached container
     container = hx.detached('div').class('hx-data-table-content')

--- a/modules/data-table/main/index.coffee
+++ b/modules/data-table/main/index.coffee
@@ -287,9 +287,7 @@ class DataTable extends hx.EventEmitter
       else
         options[name]
 
-    rowToArray = (headers, obj) -> headers.map (header) ->
-      console.log obj unless obj.cells
-      obj.cells[header.id]
+    rowToArray = (headers, obj) -> headers.map (header) -> obj.cells[header.id]
 
     # build the main structure of the table in a detached container
     container = hx.detached('div').class('hx-data-table-content')

--- a/modules/data-table/main/index.coffee
+++ b/modules/data-table/main/index.coffee
@@ -236,7 +236,9 @@ class DataTable extends hx.EventEmitter
       if @singleSelection() and hx.isArray(value) and value.length
         value = [value[0]]
       @_.selectedRows = new hx.Set(value)
-      @emit('selectedrowschange', {value: @_.selectedRows.values(), cause: 'api'})
+      newSelectedRows = @_.selectedRows.values()
+      @emit('selectedrowschange', {value: newSelectedRows, cause: 'api'})
+      @_.lastSelected = newSelectedRows[newSelectedRows.length - 1]
       @render(cb)
       this
     else
@@ -397,32 +399,33 @@ class DataTable extends hx.EventEmitter
 
           # build the grouped header
           if headers.some((header) -> header.groups?)
-              maxHeaderDepth = Math.max.apply(null, headers.filter((e) -> e.groups?).map((e) -> e.groups.length))
+            relevantHeaders = headers.filter((e) -> e.groups?).map((e) -> e.groups.length)
+            maxHeaderDepth = Math.max.apply(null,  relevantHeaders)
 
-              # Map over to populate columns with groups of '' where not included
-              headerGroups = headers.map (e) ->
-                groups = e.groups or []
-                groups.push '' while groups.length < maxHeaderDepth
-                groups
+            # Map over to populate columns with groups of '' where not included
+            headerGroups = headers.map (e) ->
+              groups = e.groups or []
+              groups.push '' while groups.length < maxHeaderDepth
+              groups
 
-              for row in [maxHeaderDepth-1..0] by -1
-                groupedRow = headerRow.insertBefore 'tr'
-                groupedRow.append('th').class('hx-data-table-control') if options.selectEnabled or options.collapsibleRenderer?
-                count = 1
-                for column in [1..headerGroups.length] by 1
-                  col = headerGroups[column]
-                  prevCol = headerGroups[column-1]
-                  if col? and prevCol?
-                    parent = col.slice(row, maxHeaderDepth).toString()
-                    prevParent = prevCol.slice(row, maxHeaderDepth).toString()
+            for row in [maxHeaderDepth-1..0] by -1
+              groupedRow = headerRow.insertBefore 'tr'
+              groupedRow.append('th').class('hx-data-table-control') if options.selectEnabled or options.collapsibleRenderer?
+              count = 1
+              for column in [1..headerGroups.length] by 1
+                col = headerGroups[column]
+                prevCol = headerGroups[column-1]
+                if col? and prevCol?
+                  parent = col.slice(row, maxHeaderDepth).toString()
+                  prevParent = prevCol.slice(row, maxHeaderDepth).toString()
 
-                  if column is headerGroups.length or col[row] isnt prevCol[row] or parent isnt prevParent
-                    groupedRow.append('th')
-                      .attr('colspan', count)
-                      .class('hx-data-table-cell-grouped')
-                      .text(prevCol[row])
-                    count = 0
-                  count++
+                if column is headerGroups.length or col[row] isnt prevCol[row] or parent isnt prevParent
+                  groupedRow.append('th')
+                    .attr('colspan', count)
+                    .class('hx-data-table-cell-grouped')
+                    .text(prevCol[row])
+                  count = 0
+                count++
 
 
           # add the 'select all' checkbox to the header
@@ -433,7 +436,7 @@ class DataTable extends hx.EventEmitter
             headerCheckBox = headerControlBox.append('div').class('hx-data-table-checkbox')
               .on 'click', 'hx.data-table', =>
                 if rows.length > 0
-                  enabledRows = rows.filter (row) => options.rowEnabledLookup(row)
+                  enabledRows = rows.filter (row) -> options.rowEnabledLookup(row)
                   selectMulti(0, rows.length - 1, not enabledRows.every((row) => @_.selectedRows.has(options.rowIDLookup(row))))
             headerCheckBox.append('i').class('hx-icon hx-icon-check')
 
@@ -467,7 +470,10 @@ class DataTable extends hx.EventEmitter
 
           @updateSelected = =>
             rowDivs = tbody.selectAll('.hx-data-table-row').classed('hx-data-table-row-selected', false)
-            checkBoxDivs = container.select('.hx-sticky-table-header-left').select('tbody').selectAll('.hx-data-table-row').classed('hx-data-table-row-selected', false)
+            checkBoxDivs = container.select('.hx-sticky-table-header-left')
+              .select('tbody')
+              .selectAll('.hx-data-table-row')
+              .classed('hx-data-table-row-selected', false)
 
             if @_.selectedRows.size > 0
               for row, rowIndex in rows
@@ -480,7 +486,9 @@ class DataTable extends hx.EventEmitter
             selection.classed('hx-data-table-has-page-selection', pageHasSelection and not options.singleSelection)
             selection.classed('hx-data-table-has-selection', @_.selectedRows.size > 0 and not options.singleSelection)
             if totalCount isnt undefined
-              selection.select('.hx-data-table-status-bar').select('.hx-data-table-status-bar-text').text(@_.selectedRows.size + ' of ' + totalCount + ' selected.')
+              selection.select('.hx-data-table-status-bar')
+                .select('.hx-data-table-status-bar-text')
+                .text(@_.selectedRows.size + ' of ' + totalCount + ' selected.')
 
           # handles multi row selection ('select all' and shift selection)
           selectMulti = (start, end, force) =>
@@ -510,12 +518,13 @@ class DataTable extends hx.EventEmitter
 
             if options.rowSelectableLookup(row)
               id = options.rowIDLookup(row)
-              @_.selectedRows[if @_.selectedRows.has(id) then 'delete' else 'add'](id)
+              deleteOrAdd = if @_.selectedRows.has(id) then 'delete' else 'add'
+              @_.selectedRows[deleteOrAdd](id)
               @emit 'selectedrowschange', {row: row, rowValue: @_.selectedRows.has(id), value: @selectedRows(), cause: 'user'}
             @updateSelected()
 
           # Deal with collapsible rows
-          buildCollapsible = =>
+          buildCollapsible = ->
             contentRow = hx.detached('tr').class('hx-data-table-collapsible-content-row')
             hiddenRow = hx.detached('tr').class('hx-data-table-collapsible-row-spacer')
 
@@ -576,7 +585,7 @@ class DataTable extends hx.EventEmitter
                   checkbox.append('i').class('hx-icon hx-icon-check')
 
                   if options.rowEnabledLookup(row)
-                    checkbox.on 'click', 'hx.data-table', (e) =>
+                    checkbox.on 'click', 'hx.data-table', (e) ->
                       e.stopPropagation() # prevent collapsibles being toggled by tick selection in compact mode
                       selectRow(row, rowIndex, e.shiftKey)
 
@@ -627,7 +636,8 @@ class DataTable extends hx.EventEmitter
 
           # set up the sticky headers
           stickFirstColumn = options.selectEnabled or options.collapsibleRenderer?
-          @_.stickyHeaders = new hx.StickyTableHeaders(container.node(), {stickFirstColumn: stickFirstColumn and (filteredCount is undefined or filteredCount > 0), fullWidth: true} )
+          stickyOpts = {stickFirstColumn: stickFirstColumn and (filteredCount is undefined or filteredCount > 0), fullWidth: true}
+          @_.stickyHeaders = new hx.StickyTableHeaders(container.node(), stickyOpts)
 
           # restore horizontal scroll position
           selection.select('.hx-data-table-content .hx-sticky-table-wrapper').node().scrollLeft = scrollLeft if scrollLeft?

--- a/modules/data-table/test/spec.coffee
+++ b/modules/data-table/test/spec.coffee
@@ -1,8 +1,8 @@
 
 describe 'data-table', ->
   beforeAll ->
-    #hx.select('head').append('link').attr('rel', 'stylesheet').attr('href', '/base/target/modules/data-table/dependencies/hexagon.css')
-    #hx.select('head').append('link').attr('rel', 'stylesheet').attr('href', '/base/target/modules/data-table/hexagon.css')
+    # hx.select('head').append('link').attr('rel', 'stylesheet').attr('href', '/base/target/modules/data-table/dependencies/hexagon.css')
+    # hx.select('head').append('link').attr('rel', 'stylesheet').attr('href', '/base/target/modules/data-table/hexagon.css')
 
 
   # Used to mimic an event call for a node
@@ -617,7 +617,8 @@ describe 'data-table', ->
       describe 'retainHorizontalScrollOnRender', ->
         describe 'true', ->
           it 'should restore the horizontal scroll when re-rendering', (done) ->
-            testTable {containerWidth: 100, tableOptions: {compact: false, retainHorizontalScrollOnRender: true, retainVerticalScrollOnRender: false}}, done, (container, dt, options, data) ->
+            tableOpts = {containerWidth: 100, tableOptions: {compact: false, retainHorizontalScrollOnRender: true, retainVerticalScrollOnRender: false}}
+            testTable tableOpts, done, (container, dt, options, data) ->
               container.select('.hx-sticky-table-wrapper').node().scrollLeft = 5
               container.select('.hx-sticky-table-wrapper').node().scrollLeft.should.equal(5)
               dt.render()
@@ -626,7 +627,8 @@ describe 'data-table', ->
 
         describe 'false', ->
           it 'should not restore the horizontal scroll when re-rendering', (done) ->
-            testTable {containerWidth: 100, tableOptions: {compact: false, retainHorizontalScrollOnRender: false, retainVerticalScrollOnRender: false}}, done, (container, dt, options, data) ->
+            tableOpts = {containerWidth: 100, tableOptions: {compact: false, retainHorizontalScrollOnRender: false, retainVerticalScrollOnRender: false}}
+            testTable tableOpts, done, (container, dt, options, data) ->
               container.select('.hx-sticky-table-wrapper').node().scrollLeft = 5
               container.select('.hx-sticky-table-wrapper').node().scrollLeft.should.equal(5)
               dt.render()
@@ -637,7 +639,8 @@ describe 'data-table', ->
       describe 'retainVerticalScrollOnRender', ->
         describe 'true', ->
           it 'should restore the vertical scroll when re-rendering', (done) ->
-            testTable {containerHeight: 100, tableOptions: {compact: false, retainHorizontalScrollOnRender: false, retainVerticalScrollOnRender: true}}, done, (container, dt, options, data) ->
+            tableOpts = {containerHeight: 100, tableOptions: {compact: false, retainHorizontalScrollOnRender: false, retainVerticalScrollOnRender: true}}
+            testTable tableOpts, done, (container, dt, options, data) ->
               container.select('.hx-sticky-table-wrapper').node().scrollTop = 5
               container.select('.hx-sticky-table-wrapper').node().scrollTop.should.equal(5)
               dt.render()
@@ -645,7 +648,8 @@ describe 'data-table', ->
 
         describe 'false', ->
           it 'should not restore the vertical scroll when re-rendering', (done) ->
-            testTable {containerHeight: 100, tableOptions: {compact: false, retainHorizontalScrollOnRender: false, retainVerticalScrollOnRender: false}}, done, (container, dt, options, data) ->
+            tableOpts = {containerHeight: 100, tableOptions: {compact: false, retainHorizontalScrollOnRender: false, retainVerticalScrollOnRender: false}}
+            testTable tableOpts, done, (container, dt, options, data) ->
               container.select('.hx-sticky-table-wrapper').node().scrollTop = 5
               container.select('.hx-sticky-table-wrapper').node().scrollTop.should.equal(5)
               dt.render()
@@ -688,6 +692,36 @@ describe 'data-table', ->
 
 
     describe 'selectedRows', ->
+      it 'should be possible for the user to deselect a row selected by the api', (done) ->
+        feed = hx.dataTable.objectFeed
+          headers: [
+            name: 'Name'
+            id: 'name'
+          ]
+          rows: [
+            id: 0
+            cells:
+              name: 'Bob'
+          ]
+        tableSel = hx.detached 'div'
+        tableOpts =
+          feed: feed
+          singleSelection: true
+          selectEnabled: true
+        table = new hx.DataTable tableSel.node(), tableOpts
+        table.selectedRows [0]
+        
+        table.on 'selectedrowschange', (data) ->
+          console.log data
+          if data.cause is 'user'
+            # Row 0 was selected before, so now we're unselecting it
+            data.value.should.eql []
+            done()
+        checkSel = tableSel.select '.hx-sticky-table-wrapper .hx-data-table-checkbox'
+        faker = fakeNodeEvent checkSel.node()
+        faker fakeEvent
+
+
       it "should be able to unselect rows having selected them, when singleSelection is enabled", (done) ->
         testTable {tableOptions: {selectEnabled: true, singleSelection: true}}, done, (container, dt, options, data) ->
           dt.selectedRows ['0'], ->
@@ -1099,7 +1133,7 @@ describe 'data-table', ->
           filterEvent = fakeNodeEvent filterInput.node(), 'input'
           filterInput.value('a')
           filterEvent(fakeEvent)
-          jasmine.clock().tick(201);
+          jasmine.clock().tick(201)
           expect(dt.filter).toHaveBeenCalledWith()
           expect(dt.filter).toHaveBeenCalledWith('a', undefined, 'user')
           jasmine.clock().uninstall()

--- a/modules/data-table/test/spec.coffee
+++ b/modules/data-table/test/spec.coffee
@@ -712,7 +712,6 @@ describe 'data-table', ->
         table.selectedRows [0]
         
         table.on 'selectedrowschange', (data) ->
-          console.log data
           if data.cause is 'user'
             # Row 0 was selected before, so now we're unselecting it
             data.value.should.eql []


### PR DESCRIPTION
fixes #85 . The issue is selectRow clears the selection if @_lastSelected is different from the row you want to select and single selection is enabled, but @_lastSelected isn't set by hx.DataTable::selectedRows.