### PR TITLE
Fix the dropdown tests

### DIFF
--- a/modules/autocomplete/main/index.coffee
+++ b/modules/autocomplete/main/index.coffee
@@ -341,7 +341,7 @@ class AutoComplete extends hx.EventEmitter
       menu.on 'dropdown.change', 'hx.autocomplete', (visible) ->
         if !!visible
           _.initialValue = input.value()
-          menu.dropdown.useScroll = true
+          menu.dropdown._.useScroll = true
         else
           _.checkValidity()
           return

--- a/modules/autocomplete/main/index.coffee
+++ b/modules/autocomplete/main/index.coffee
@@ -139,7 +139,7 @@ buildAutoComplete = (searchTerm, fromCallback, loading) ->
     if items.length > 0
       _.menu.items(items)
       if _.menu.dropdown.isOpen()
-        _.menu.dropdown.dropdownContent _.menu.dropdown.dropdown.node()
+        _.menu.dropdown._.dropdownContent _.menu.dropdown._.dropdown.node()
       else
         _.menu.dropdown.show()
     else # Hide the dropdown as there are no items

--- a/modules/dropdown/main/index.coffee
+++ b/modules/dropdown/main/index.coffee
@@ -1,16 +1,95 @@
-### istanbul ignore next: ignore coffeescript's extend function ###
 
-getWindowMeasurement = (horizontal, scroll) ->
-  if horizontal
-    if scroll then window.scrollX
-    else window.innerWidth
-  else
-    if scroll then window.scrollY
-    else window.innerHeight
+dropdownAnimateSlideDistance = 8
 
 checkFixedPos = (node) ->
   elem = hx.select(node)
   if elem.size() > 0 and elem.style('position') is 'fixed' then true
+
+calculateDropdownPosition = (alignments, rect, dropdownRect, windowRect, spacing, ddMaxHeight, parentFixed, scrollbarWidth) ->
+  horizontalPos = rect.x
+  verticalPos = rect.y
+
+  if alignments[0] is 'r' then horizontalPos = rect.x + rect.width
+  if alignments[1] is 'b' then verticalPos = rect.y + rect.height
+  if alignments[2] is 'r' then horizontalPos -= dropdownRect.width
+  if alignments[3] is 'b' then verticalPos -= dropdownRect.height
+
+  if alignments[0] isnt alignments[2]
+    switch alignments[2]
+      when 'l' then horizontalPos += spacing
+      when 'r' then horizontalPos -= spacing
+
+  if alignments[1] isnt alignments[3]
+    switch alignments[3]
+      when 't' then verticalPos += spacing
+      when 'b'
+        invertY = true
+        verticalPos -= spacing
+
+  # these checks move the dropdown when it flows outside the window boundaries
+  if horizontalPos < 0 then horizontalPos = 0
+  if (horizontalWindow = (horizontalPos + dropdownRect.width - windowRect.innerWidth + scrollbarWidth)) > 0
+    horizontalPos -= horizontalWindow
+
+  if verticalPos < 0 then verticalPos = 0
+
+  ddHeight = if not isNaN(ddMaxHeight)
+    Math.min(ddMaxHeight, dropdownRect.height)
+  else
+    dropdownRect.height
+
+  if (verticalWindow = (verticalPos + ddHeight - windowRect.innerHeight )) > 0
+    movedVertical = true
+    verticalPos -= verticalWindow
+
+  # inverval intersection check
+  checkOverlap = (posA, posB, rectA, rectB) ->
+    # posA/B are dropdown sides (left/right or top/bottom)  - [ ]
+    # rectA/B are selection sides (left/right or top/bottom) - | |
+    complete = posA < rectA and posB > rectB # [ | | ]
+    partialA = posB >= rectB and posA < rectB and posA >= rectA # | [ | ]
+    partialB = posA <= rectA and posB > rectA and posB <= rectB # [ | ] |
+
+    if complete or partialA then 2
+    else if partialB then 1
+    else 0
+
+  horizontalOverlap = checkOverlap(horizontalPos, (horizontalPos + dropdownRect.width), rect.x, (rect.x + rect.width))
+  verticalOverlap = checkOverlap(verticalPos, (verticalPos + dropdownRect.height), rect.y, (rect.y + rect.height))
+
+  # if both are greater than 0 then dd overlaps selection
+  if horizontalOverlap > 0 and verticalOverlap > 0
+    # dropdown overlaps at the top of the selection so should be moved down
+    if verticalOverlap > 1 and not movedVertical
+      invertY = false
+      verticalPos = rect.y + rect.height + spacing
+    else
+      invertY = true
+      verticalPos = rect.y - dropdownRect.height - spacing
+
+      # check if dropdown goes off the screen after being moved up
+      if verticalPos < 0
+        invertY = false
+        verticalPos = rect.y + rect.height + spacing
+
+
+  if not parentFixed
+    horizontalPos += windowRect.scrollX
+    verticalPos += windowRect.scrollY
+
+  # switches the dropdown position so it scales from the bottom instead of the top
+  yPos = 'top'
+  if invertY
+    yPos = 'bottom'
+    bodyDiff = document.body.scrollHeight - document.body.clientHeight
+    verticalPos = document.body.scrollHeight - verticalPos - bodyDiff - dropdownRect.height
+
+  {
+    y: verticalPos,
+    x: horizontalPos,
+    yPos: yPos,
+    xPos: 'left'
+  }
 
 class Dropdown extends hx.EventEmitter
 
@@ -31,11 +110,11 @@ class Dropdown extends hx.EventEmitter
 
     setupDropdown = switch
       when hx.isString(dropdownContent)
-        (node) => hx.select(node).html(dropdownContent)
+        (node) -> hx.select(node).html(dropdownContent)
       when hx.isFunction(dropdownContent)
-        (node) => dropdownContent(node)
+        (node) -> dropdownContent(node)
       else
-        console.error('dropdown: dropdownContent is not a valid type ' +selector)
+        hx.consoleWarning('dropdown: dropdownContent is not a valid type. dropdownContent: ', dropdownContent)
         () ->
 
     clickDetector = new hx.ClickDetector
@@ -97,122 +176,55 @@ class Dropdown extends hx.EventEmitter
       _.dropdown = hx.select(hx._.dropdown.attachToSelector).append('div').attr('class', 'hx-dropdown')
 
       if @options.ddClass.length > 0
-        _.dropdown.classed @options.ddClass, true
+        _.dropdown.classed(@options.ddClass, true)
 
       _.setupDropdown(_.dropdown.node())
       _.clickDetector.removeAllExceptions()
       _.clickDetector.addException(_.dropdown.node())
       _.clickDetector.addException(_.selection.node())
 
+      _.dropdown.style('display', 'block')
+
+      rect = _.selection.box()
+      dropdownRect = _.dropdown.box()
+      ddMaxHeight = _.dropdown.style('max-height').replace('px','')
+      parentFixed = hx.checkParents(_.selection.node(), checkFixedPos)
+
+      {xPos, yPos, x, y} = calculateDropdownPosition(
+        _.alignments,
+        { x: rect.left, y: rect.top, width: rect.width, height: rect.height },
+        { width: dropdownRect.width, height: dropdownRect.height },
+        { scrollX: window.scrollX, scrollY: window.scrollY, innerWidth: window.innerWidth, innerHeight: window.innerHeight }
+        @options.spacing,
+        ddMaxHeight,
+        parentFixed,
+        hx.scrollbarSize()
+      )
+
       # Gets the maximum z-index of all the parent elements
       parentZIndex = hx.parentZIndex(_.selection.node(), true)
-
       if parentZIndex > 0
         _.dropdown.style('z-index', parentZIndex + 1)
 
-      rect = _.selection.box()
-      _.dropdown.style('display', 'block')
-      if @options.matchWidth then _.dropdown.style('min-width', rect.width + 'px')
-      dropdownRect = _.dropdown.box()
-      ddMaxHeight = _.dropdown.style('max-height').replace('px','')
-
-      horizontalPos = rect.left
-      verticalPos = rect.top
-
-      if _.alignments[0] is 'r' then horizontalPos = rect.right
-      if _.alignments[1] is 'b' then verticalPos = rect.bottom
-      if _.alignments[2] is 'r' then horizontalPos -= dropdownRect.width
-      if _.alignments[3] is 'b' then verticalPos -= dropdownRect.height
-
-      if _.alignments[0] isnt _.alignments[2]
-        switch _.alignments[2]
-          when 'l' then horizontalPos += @options.spacing
-          when 'r' then horizontalPos -= @options.spacing
-
-      if _.alignments[1] isnt _.alignments[3]
-        switch _.alignments[3]
-          when 't' then verticalPos += @options.spacing
-          when 'b'
-            invertY = true
-            verticalPos -= @options.spacing
-
-      scrollbarWidth = hx.scrollbarSize()
-
-      # these checks move the dropdown when it flows outside the window boundaries
-      if horizontalPos < 0 then horizontalPos = 0
-      if (horizontalWindow = (horizontalPos + dropdownRect.width - getWindowMeasurement(true) + scrollbarWidth)) > 0
-        horizontalPos -= horizontalWindow
-
-      if verticalPos < 0 then verticalPos = 0
-
-      ddHeight = if not isNaN(ddMaxHeight)
-        Math.min(ddMaxHeight, dropdownRect.height)
-      else
-        dropdownRect.height
-
-      if (verticalWindow = (verticalPos + ddHeight - getWindowMeasurement() )) > 0
-        movedVertical = true
-        verticalPos -= verticalWindow
-
-      # inverval intersection check
-      checkOverlap = (posA, posB, rectA, rectB) ->
-        # posA/B are dropdown sides (left/right or top/bottom)  - [ ]
-        # rectA/B are selection sides (left/right or top/bottom) - | |
-        complete = posA < rectA and posB > rectB # [ | | ]
-        partialA = posB >= rectB and posA < rectB and posA >= rectA # | [ | ]
-        partialB = posA <= rectA and posB > rectA and posB <= rectB # [ | ] |
-
-        if complete or partialA then 2
-        else if partialB then 1
-        else 0
-
-      horizontalOverlap = checkOverlap(horizontalPos, (horizontalPos + dropdownRect.width), rect.left, (rect.left + rect.width))
-      verticalOverlap = checkOverlap(verticalPos, (verticalPos + dropdownRect.height), rect.top, (rect.top + rect.height))
-
-      # if both are greater than 0 then dd overlaps selection
-      if horizontalOverlap > 0 and verticalOverlap > 0
-        # dropdown overlaps at the top of the selection so should be moved down
-        if verticalOverlap > 1 and not movedVertical
-          invertY = false
-          verticalPos = rect.top + rect.height + @options.spacing
-        else
-          invertY = true
-          verticalPos = rect.top - dropdownRect.height - @options.spacing
-
-          # check if dropdown goes off the screen after being moved up
-          if verticalPos < 0
-            invertY = false
-            verticalPos = rect.top + rect.height + @options.spacing
-
-      parentFixed = hx.checkParents(_.selection.node(), checkFixedPos)
       if parentFixed
         _.dropdown.style('position','fixed')
-      else
-        verticalPos += getWindowMeasurement(false, true)
-        horizontalPos += getWindowMeasurement(true, true)
 
-      yPos = 'top'
-
-      # switches the dropdown position so it scales from the bottom instead of the top
-      if invertY
-        yPos = 'bottom'
-        bodyDiff = document.body.scrollHeight - document.body.clientHeight
-        verticalPos = document.body.scrollHeight - verticalPos - bodyDiff - dropdownRect.height
-
-      _.dropdown.style('top', 'auto')
-        .style(yPos, verticalPos + 'px')
-        .style('left', horizontalPos + 'px')
-        .style('width', dropdownRect.width + 'px')
+      if @options.matchWidth then _.dropdown.style('min-width', rect.width + 'px')
 
       _.dropdown
+        .style('top', 'auto')
+        .style('bottom', 'auto')
+        .style('left', 'auto')
+        .style('right', 'auto')
+        .style(xPos, x + 'px')
+        .style(yPos, (y + dropdownAnimateSlideDistance) + 'px')
         .style('height', '0px')
-        .style(yPos, (verticalPos + 8) + 'px')
         .style('opacity', 0)
         .morph()
           .with('fadein', 150)
           .and('expandv', 150)
           .and =>
-            _.dropdown.animate().style(yPos, verticalPos + 'px', 150)
+            _.dropdown.animate().style(yPos, y + 'px', 150)
           .then =>
             if _.useScroll and _.dropdown?
               _.dropdown.style('overflow-y','auto')
@@ -229,9 +241,9 @@ class Dropdown extends hx.EventEmitter
     _ = @_
     if _.visible
       _.visible = false
-      @emit('hidestart') # future proofing for adition of animations
+      @emit('hidestart') # future proofing for addition of animations
       @emit('change', false)
-      @emit('hideend') # future proofing for adition of animations
+      @emit('hideend') # future proofing for addition of animations
       cb?()
       _.dropdown.remove()
       _.dropdown = undefined

--- a/modules/dropdown/main/index.coffee
+++ b/modules/dropdown/main/index.coffee
@@ -23,7 +23,6 @@ calculateDropdownPosition = (alignments, selectionRect, dropdownRect, windowRect
 
   # adjust the position of the drop-down when there is not enough space
 
-
   # slide into view (in the appropriate direction)
   if direction is 'down' or direction is 'up'
     x = hx.clamp(0, windowRect.width - dropdownRect.width, x)
@@ -48,16 +47,11 @@ calculateDropdownPosition = (alignments, selectionRect, dropdownRect, windowRect
   else if direction is 'right' and x > windowRect.width - dropdownRect.width and selectionRect.x - dropdownRect.width > 0
     direction = 'left'
     x = selectionRect.x - dropdownRect.width
-    if alignments[0] is alignments[2]
-      x += selectionRect.width
 
   # flip from upwards to downwards (if needed and there is the space to)
   else if direction is 'left' and x < 0 and selectionRect.x + selectionRect.width +  dropdownRect.width < windowRect.width
     direction = 'right'
     x = selectionRect.x + selectionRect.width
-    if alignments[0] is alignments[2]
-      x -= selectionRect.width
-
 
   {
     x: x,

--- a/modules/dropdown/main/theme.scss
+++ b/modules/dropdown/main/theme.scss
@@ -2,4 +2,5 @@
   background: $background-col;
   box-shadow: 0px 2px 2px 2px $shadow-col;
   border-color: $border-col;
+  margin-top: $spacing * 1px;
 }

--- a/modules/dropdown/main/theme.um
+++ b/modules/dropdown/main/theme.um
@@ -4,7 +4,6 @@
     @type size
     @description: The default spacing for dropdowns
     @default: 0
-    @includeWithJs 0
 
   @option background-col
     @type color

--- a/modules/dropdown/test/spec.coffee
+++ b/modules/dropdown/test/spec.coffee
@@ -81,7 +81,7 @@ describe 'hx-dropdown', ->
     button = makeButton()
 
   afterEach ->
-    hx.component(id).cleanUp()
+    hx.component(id)?.cleanUp()
     hx.selectAll('.hx-dropdown').remove()
     button = undefined
     fixture.clear()
@@ -335,204 +335,395 @@ describe 'hx-dropdown', ->
   #   , 300
   #   clock.tick(301)
 
-  it 'should shift the dropdown down if shifting it up has moved it off the top of the screen', ->
-    dd = new hx.Dropdown(id, content, {align: 'up'})
+  # it 'should shift the dropdown down if shifting it up has moved it off the top of the screen', ->
+  #   dd = new hx.Dropdown(id, content, {align: 'up'})
 
-    button.style('top', '5px')
+  #   button.style('top', '5px')
 
-    buttonBox = roundAll button.box()
-    dd.show()
-    setTimeout ->
-      ddBox = roundAll dd._.dropdown.box()
-      ddBox.top.should.equal(buttonBox.top + buttonBox.height + getSpacing(dd))
-      ddBox.left.should.equal(buttonBox.left)
-    , 300
-    clock.tick(301)
-
-
-  describe 'align', ->
-    button = undefined
-    buttonBox = undefined
-    dd = undefined
-    ddBox = undefined
-
-    beforeEach ->
-      buttonBox = roundAll button.box()
-
-    describe 'should align correctly when align is set to', ->
-      tests = [
-          align: null
-          check: ->
-            ddBox.left.should.equal(buttonBox.left)
-            ddBox.top.should.equal(buttonBox.bottom + getSpacing(dd))
-        ,
-          align: 'up'
-          check: ->
-            ddBox.left.should.equal(buttonBox.left)
-            ddBox.top.should.equal(buttonBox.top - ddBox.height - getSpacing(dd))
-        ,
-          align: 'down'
-          check: ->
-            ddBox.left.should.equal(buttonBox.left)
-            ddBox.top.should.equal(buttonBox.bottom + getSpacing(dd))
-        ,
-          align: 'left'
-          check: ->
-            ddBox.right.should.equal(buttonBox.left - getSpacing(dd))
-            ddBox.top.should.equal(buttonBox.top)
-        ,
-          align: 'right'
-          check: ->
-            ddBox.left.should.equal(buttonBox.right + getSpacing(dd))
-            ddBox.top.should.equal(buttonBox.top)
-        ,
-          align: 'lbrb'
-          check: ->
-            ddBox.right.should.equal(buttonBox.left - getSpacing(dd))
-            ddBox.bottom.should.equal(buttonBox.bottom)
-        ,
-          align: 'lbrt'
-          check: ->
-            ddBox.right.should.equal(buttonBox.left - getSpacing(dd))
-            ddBox.top.should.equal(buttonBox.top + buttonBox.height + getSpacing(dd))
-        ,
-          align: 'ltrb'
-          check: ->
-            ddBox.right.should.equal(buttonBox.left - getSpacing(dd))
-            ddBox.bottom.should.equal(buttonBox.top - getSpacing(dd))
-        ,
-          align: 'rblt'
-          check: ->
-            ddBox.left.should.equal(buttonBox.right + getSpacing(dd))
-            ddBox.top.should.equal(buttonBox.bottom + getSpacing(dd))
-        ,
-          align: 'rblb'
-          check: ->
-            ddBox.left.should.equal(buttonBox.right + getSpacing(dd))
-            ddBox.bottom.should.equal(buttonBox.bottom)
-        ,
-          align: 'rbrt'
-          check: ->
-            ddBox.right.should.equal(buttonBox.right)
-            ddBox.top.should.equal(buttonBox.bottom + getSpacing(dd))
-        ,
-          align: 'rtlb'
-          check: ->
-            ddBox.left.should.equal(buttonBox.right + getSpacing(dd))
-            ddBox.top.should.equal(buttonBox.top - ddBox.height - getSpacing(dd))
-        ,
-          align: 'rtrb'
-          check: ->
-            ddBox.right.should.equal(buttonBox.right)
-            ddBox.bottom.should.equal(buttonBox.top - getSpacing(dd))
-      ]
-
-      t = (test, index) ->
-        it test.align, ->
-          dd = new hx.Dropdown(id, content, {
-            align: test.align or undefined
-          })
-          dd.show()
-          setTimeout ->
-            ddBox = roundAll dd._.dropdown.box()
-            test.check()
-          , 300
-          clock.tick(301)
-
-        if index < tests.length
-          t(tests[index], index + 1)
-
-      t(tests[0], 1)
+  #   buttonBox = roundAll button.box()
+  #   dd.show()
+  #   setTimeout ->
+  #     ddBox = roundAll dd._.dropdown.box()
+  #     ddBox.top.should.equal(buttonBox.top + buttonBox.height + getSpacing(dd))
+  #     ddBox.left.should.equal(buttonBox.left)
+  #   , 300
+  #   clock.tick(301)
 
 
-    describe 'shouldnt flow outside the screen when the dropdown is on the', ->
-      scrollbarWidth = hx.scrollbarSize()
-      moveBy = 10000
+  # describe 'align', ->
+  #   button = undefined
+  #   buttonBox = undefined
+  #   dd = undefined
+  #   ddBox = undefined
 
-      tests = [
-        pos: 'left'
-        check: ->
-          ddBox.left.should.equal(0)
-      ,
-        pos: 'top'
-        check: ->
-          ddBox.top.should.equal(0)
-      ,
-        pos: 'right'
-        check: ->
-          ddBox.left.should.equal(window.innerWidth - ddBox.width - scrollbarWidth)
-      ,
-        pos: 'bottom'
-        check: ->
-          ddBox.top.should.equal(window.innerHeight - ddBox.height)
-      ]
+  #   beforeEach ->
+  #     buttonBox = roundAll button.box()
 
-      t = (test, index) ->
-        it ': ' + test.pos, ->
-          button.style('top', '')
-            .style('right', '')
-            .style('bottom', '')
-            .style('left', '')
-            .style('left', '')
-            .style('margin-left', '')
-            .style('margin-top', '')
-            .style(test.pos, '-' + moveBy + 'px')
+  #   describe 'should align correctly when align is set to', ->
+  #     tests = [
+  #         align: null
+  #         check: ->
+  #           ddBox.left.should.equal(buttonBox.left)
+  #           ddBox.top.should.equal(buttonBox.bottom + getSpacing(dd))
+  #       ,
+  #         align: 'up'
+  #         check: ->
+  #           ddBox.left.should.equal(buttonBox.left)
+  #           ddBox.top.should.equal(buttonBox.top - ddBox.height - getSpacing(dd))
+  #       ,
+  #         align: 'down'
+  #         check: ->
+  #           ddBox.left.should.equal(buttonBox.left)
+  #           ddBox.top.should.equal(buttonBox.bottom + getSpacing(dd))
+  #       ,
+  #         align: 'left'
+  #         check: ->
+  #           ddBox.right.should.equal(buttonBox.left - getSpacing(dd))
+  #           ddBox.top.should.equal(buttonBox.top)
+  #       ,
+  #         align: 'right'
+  #         check: ->
+  #           ddBox.left.should.equal(buttonBox.right + getSpacing(dd))
+  #           ddBox.top.should.equal(buttonBox.top)
+  #       ,
+  #         align: 'lbrb'
+  #         check: ->
+  #           ddBox.right.should.equal(buttonBox.left - getSpacing(dd))
+  #           ddBox.bottom.should.equal(buttonBox.bottom)
+  #       ,
+  #         align: 'lbrt'
+  #         check: ->
+  #           ddBox.right.should.equal(buttonBox.left - getSpacing(dd))
+  #           ddBox.top.should.equal(buttonBox.top + buttonBox.height + getSpacing(dd))
+  #       ,
+  #         align: 'ltrb'
+  #         check: ->
+  #           ddBox.right.should.equal(buttonBox.left - getSpacing(dd))
+  #           ddBox.bottom.should.equal(buttonBox.top - getSpacing(dd))
+  #       ,
+  #         align: 'rblt'
+  #         check: ->
+  #           ddBox.left.should.equal(buttonBox.right + getSpacing(dd))
+  #           ddBox.top.should.equal(buttonBox.bottom + getSpacing(dd))
+  #       ,
+  #         align: 'rblb'
+  #         check: ->
+  #           ddBox.left.should.equal(buttonBox.right + getSpacing(dd))
+  #           ddBox.bottom.should.equal(buttonBox.bottom)
+  #       ,
+  #         align: 'rbrt'
+  #         check: ->
+  #           ddBox.right.should.equal(buttonBox.right)
+  #           ddBox.top.should.equal(buttonBox.bottom + getSpacing(dd))
+  #       ,
+  #         align: 'rtlb'
+  #         check: ->
+  #           ddBox.left.should.equal(buttonBox.right + getSpacing(dd))
+  #           ddBox.top.should.equal(buttonBox.top - ddBox.height - getSpacing(dd))
+  #       ,
+  #         align: 'rtrb'
+  #         check: ->
+  #           ddBox.right.should.equal(buttonBox.right)
+  #           ddBox.bottom.should.equal(buttonBox.top - getSpacing(dd))
+  #     ]
 
-          dd = new hx.Dropdown(id, content)
-          dd.show()
-          setTimeout ->
-            ddBox = roundAll dd._.dropdown.box()
-            test.check()
-          , 300
-          clock.tick(301)
+  #     t = (test, index) ->
+  #       it test.align, ->
+  #         dd = new hx.Dropdown(id, content, {
+  #           align: test.align or undefined
+  #         })
+  #         dd.show()
+  #         setTimeout ->
+  #           ddBox = roundAll dd._.dropdown.box()
+  #           test.check()
+  #         , 300
+  #         clock.tick(301)
 
-        if index < tests.length
-          t(tests[index], index + 1)
+  #       if index < tests.length
+  #         t(tests[index], index + 1)
 
-      t(tests[0], 1)
+  #     t(tests[0], 1)
 
-    describe 'shouldnt overlap the parent element when align is set to', ->
-      tests = [
-        align: 'rbrb'
-        check: ->
-          ddBox.top.should.equal(buttonBox.bottom + getSpacing(dd))
-          ddBox.right.should.equal(buttonBox.right)
-      ,
-        align: 'lblb'
-        check: ->
-          ddBox.top.should.equal(buttonBox.bottom + getSpacing(dd))
-          ddBox.left.should.equal(buttonBox.left)
-      ,
-        align: 'rtrt'
-        check: ->
-          ddBox.bottom.should.equal(buttonBox.top - getSpacing(dd))
-          ddBox.right.should.equal(buttonBox.right)
-      ,
-        align: 'ltlt'
-        check: ->
-          ddBox.bottom.should.equal(buttonBox.top - getSpacing(dd))
-          ddBox.left.should.equal(buttonBox.left)
-      ,
-        align: 'cover'
-        check: ->
-          ddBox.top.should.equal(buttonBox.bottom + getSpacing(dd))
-          ddBox.left.should.equal(buttonBox.left)
-      ]
 
-      t = (test, index) ->
-        it test.align, ->
-          if test.align is 'cover'
-            test.align = null
-            coverContent = '<div style="width:200px; height: 100px">Content</div>'
-          dd = new hx.Dropdown(id, coverContent or content, {align: test.align or undefined })
-          dd.show()
-          setTimeout ->
-            ddBox = roundAll dd._.dropdown.box()
-            test.check()
-          , 300
-          clock.tick(301)
+  #   describe 'shouldnt flow outside the screen when the dropdown is on the', ->
+  #     scrollbarWidth = hx.scrollbarSize()
+  #     moveBy = 10000
 
-        if index < tests.length
-          t(tests[index], index + 1)
+  #     tests = [
+  #       pos: 'left'
+  #       check: ->
+  #         ddBox.left.should.equal(0)
+  #     ,
+  #       pos: 'top'
+  #       check: ->
+  #         ddBox.top.should.equal(0)
+  #     ,
+  #       pos: 'right'
+  #       check: ->
+  #         ddBox.left.should.equal(window.innerWidth - ddBox.width - scrollbarWidth)
+  #     ,
+  #       pos: 'bottom'
+  #       check: ->
+  #         ddBox.top.should.equal(window.innerHeight - ddBox.height)
+  #     ]
 
-      t(tests[0], 1)
+  #     t = (test, index) ->
+  #       it ': ' + test.pos, ->
+  #         button.style('top', '')
+  #           .style('right', '')
+  #           .style('bottom', '')
+  #           .style('left', '')
+  #           .style('left', '')
+  #           .style('margin-left', '')
+  #           .style('margin-top', '')
+  #           .style(test.pos, '-' + moveBy + 'px')
+
+  #         dd = new hx.Dropdown(id, content)
+  #         dd.show()
+  #         setTimeout ->
+  #           ddBox = roundAll dd._.dropdown.box()
+  #           test.check()
+  #         , 300
+  #         clock.tick(301)
+
+  #       if index < tests.length
+  #         t(tests[index], index + 1)
+
+  #     t(tests[0], 1)
+
+  #   describe 'shouldnt overlap the parent element when align is set to', ->
+  #     tests = [
+  #       align: 'rbrb'
+  #       check: ->
+  #         ddBox.top.should.equal(buttonBox.bottom + getSpacing(dd))
+  #         ddBox.right.should.equal(buttonBox.right)
+  #     ,
+  #       align: 'lblb'
+  #       check: ->
+  #         ddBox.top.should.equal(buttonBox.bottom + getSpacing(dd))
+  #         ddBox.left.should.equal(buttonBox.left)
+  #     ,
+  #       align: 'rtrt'
+  #       check: ->
+  #         ddBox.bottom.should.equal(buttonBox.top - getSpacing(dd))
+  #         ddBox.right.should.equal(buttonBox.right)
+  #     ,
+  #       align: 'ltlt'
+  #       check: ->
+  #         ddBox.bottom.should.equal(buttonBox.top - getSpacing(dd))
+  #         ddBox.left.should.equal(buttonBox.left)
+  #     ,
+  #       align: 'cover'
+  #       check: ->
+  #         ddBox.top.should.equal(buttonBox.bottom + getSpacing(dd))
+  #         ddBox.left.should.equal(buttonBox.left)
+  #     ]
+
+  #     t = (test, index) ->
+  #       it test.align, ->
+  #         if test.align is 'cover'
+  #           test.align = null
+  #           coverContent = '<div style="width:200px; height: 100px">Content</div>'
+  #         dd = new hx.Dropdown(id, coverContent or content, {align: test.align or undefined })
+  #         dd.show()
+  #         setTimeout ->
+  #           ddBox = roundAll dd._.dropdown.box()
+  #           test.check()
+  #         , 300
+  #         clock.tick(301)
+
+  #       if index < tests.length
+  #         t(tests[index], index + 1)
+
+  #     t(tests[0], 1)
+
+  describe 'calculateDropdownPosition', ->
+
+    checkNoSpaceToFlip = (alignments) ->
+      selectionRect = { x: 500, y: 50, width: 100, height: 100 }
+      dropdownRect = { width: 200, height: 200 }
+      windowRect = { width: 1000, height: 200 }
+      ddMaxHeight = undefined
+      scrollbarWidth = 0
+
+      hx._.dropdown.calculateDropdownPosition(
+        alignments.split(''),
+        selectionRect,
+        dropdownRect,
+        windowRect,
+        ddMaxHeight,
+        scrollbarWidth
+      )
+
+    check = (selectionX, selectionY, alignments) ->
+      selectionRect = { x: selectionX, y: selectionY, width: 100, height: 100 }
+      dropdownRect = { width: 200, height: 200 }
+      windowRect = { width: 1000, height: 1000 }
+      ddMaxHeight = undefined
+      scrollbarWidth = 0
+
+      hx._.dropdown.calculateDropdownPosition(
+        alignments,
+        selectionRect,
+        dropdownRect,
+        windowRect,
+        ddMaxHeight,
+        scrollbarWidth
+      )
+
+    # downwards tests
+    describe 'lblt', ->
+      it 'ample space', -> check(500, 500, 'lblt').should.eql({ x: 500, y: 600, direction: 'down' })
+      it 'not enough space to flip', -> checkNoSpaceToFlip('lblt').should.eql({ x: 500, y: 150, direction: 'down' })
+      it 'shifted left', -> check(850, 500, 'lblt').should.eql({ x: 800, y: 600, direction: 'down' })
+      it 'shifted right', -> check(-50, 500, 'lblt').should.eql({ x: 0, y: 600, direction: 'down' })
+      it 'flipped', -> check(500, 850, 'lblt').should.eql({ x: 500, y: 650, direction: 'up' })
+      it 'flipped shifted left', -> check(850, 850, 'lblt').should.eql({ x: 800, y: 650, direction: 'up' })
+      it 'flipped shifted right', -> check(-50, 850, 'lblt').should.eql({ x: 0, y: 650, direction: 'up' })
+
+    describe 'rblt', ->
+      it 'ample space', -> check(500, 500, 'rblt').should.eql({ x: 600, y: 600, direction: 'down' })
+      it 'not enough space to flip', -> checkNoSpaceToFlip('rblt').should.eql({ x: 600, y: 150, direction: 'down' })
+      it 'shifted left', -> check(750, 500, 'rblt').should.eql({ x: 800, y: 600, direction: 'down' })
+      it 'shifted right', -> check(-150, 500, 'rblt').should.eql({ x: 0, y: 600, direction: 'down' })
+      it 'flipped', -> check(500, 850, 'rblt').should.eql({ x: 600, y: 650, direction: 'up' })
+      it 'flipped shifted left', -> check(750, 850, 'rblt').should.eql({ x: 800, y: 650, direction: 'up' })
+      it 'flipped shifted right', -> check(-150, 850, 'rblt').should.eql({ x: 0, y: 650, direction: 'up' })
+
+    describe 'ltlt', ->
+      it 'ample space', -> check(500, 500, 'ltlt').should.eql({ x: 500, y: 500, direction: 'down' })
+      it 'not enough space to flip', -> checkNoSpaceToFlip('ltlt').should.eql({ x: 500, y: 50, direction: 'down' })
+      it 'shifted left', -> check(850, 500, 'ltlt').should.eql({ x: 800, y: 500, direction: 'down' })
+      it 'shifted right', -> check(-50, 500, 'ltlt').should.eql({ x: 0, y: 500, direction: 'down' })
+      it 'flipped', -> check(500, 850, 'ltlt').should.eql({ x: 500, y: 750, direction: 'up' })
+      it 'flipped shifted left', -> check(850, 850, 'ltlt').should.eql({ x: 800, y: 750, direction: 'up' })
+      it 'flipped shifted right', -> check(-50, 850, 'ltlt').should.eql({ x: 0, y: 750, direction: 'up' })
+
+    describe 'lbrt', ->
+      it 'ample space', -> check(500, 500, 'lbrt').should.eql({ x: 300, y: 600, direction: 'down' })
+      it 'not enough space to flip', -> checkNoSpaceToFlip('lbrt').should.eql({ x: 300, y: 150, direction: 'down' })
+      it 'shifted left', -> check(1050, 500, 'lbrt').should.eql({ x: 800, y: 600, direction: 'down' })
+      it 'shifted right', -> check(150, 500, 'lbrt').should.eql({ x: 0, y: 600, direction: 'down' })
+      it 'flipped', -> check(500, 850, 'lbrt').should.eql({ x: 300, y: 650, direction: 'up' })
+      it 'flipped shifted left', -> check(1050, 850, 'lbrt').should.eql({ x: 800, y: 650, direction: 'up' })
+      it 'flipped shifted right', -> check(150, 850, 'lbrt').should.eql({ x: 0, y: 650, direction: 'up' })
+
+    describe 'rbrt', ->
+      it 'ample space', -> check(500, 500, 'rbrt').should.eql({ x: 400, y: 600, direction: 'down' })
+      it 'not enough space to flip', -> checkNoSpaceToFlip('rbrt').should.eql({ x: 400, y: 150, direction: 'down' })
+      it 'shifted left', -> check(950, 500, 'rbrt').should.eql({ x: 800, y: 600, direction: 'down' })
+      it 'shifted right', -> check(50, 500, 'rbrt').should.eql({ x: 0, y: 600, direction: 'down' })
+      it 'flipped', -> check(500, 850, 'rbrt').should.eql({ x: 400, y: 650, direction: 'up' })
+      it 'flipped shifted left', -> check(950, 850, 'rbrt').should.eql({ x: 800, y: 650, direction: 'up' })
+      it 'flipped shifted right', -> check(50, 850, 'rbrt').should.eql({ x: 0, y: 650, direction: 'up' })
+
+    describe 'rtrt', ->
+      it 'ample space', -> check(500, 500, 'rtrt').should.eql({ x: 400, y: 500, direction: 'down' })
+      it 'not enough space to flip', -> checkNoSpaceToFlip('rtrt').should.eql({ x: 400, y: 50, direction: 'down' })
+      it 'shifted left', -> check(950, 500, 'rtrt').should.eql({ x: 800, y: 500, direction: 'down' })
+      it 'shifted right', -> check(50, 500, 'rtrt').should.eql({ x: 0, y: 500, direction: 'down' })
+      it 'flipped', -> check(500, 850, 'rtrt').should.eql({ x: 400, y: 750, direction: 'up' })
+      it 'flipped shifted left', -> check(950, 850, 'rtrt').should.eql({ x: 800, y: 750, direction: 'up' })
+      it 'flipped shifted right', -> check(50, 850, 'rtrt').should.eql({ x: 0, y: 750, direction: 'up' })
+
+    # upwards tests
+    describe 'lblb', ->
+      it 'ample space', -> check(500, 500, 'lblb').should.eql({ x: 500, y: 400, direction: 'up' })
+      it 'not enough space to flip', -> checkNoSpaceToFlip('lblb').should.eql({ x: 500, y: -50, direction: 'up' })
+      it 'shifted left', -> check(850, 500, 'lblb').should.eql({ x: 800, y: 400, direction: 'up' })
+      it 'shifted right', -> check(-50, 500, 'lblb').should.eql({ x: 0, y: 400, direction: 'up' })
+      it 'flipped', -> check(500, 50, 'lblb').should.eql({ x: 500, y: 50, direction: 'down' })
+      it 'flipped shifted left', -> check(950, 50, 'lblb').should.eql({ x: 800, y: 50, direction: 'down' })
+      it 'flipped shifted right', -> check(-50, 50, 'lblb').should.eql({ x: 0, y: 50, direction: 'down' })
+
+    describe 'ltlb', ->
+      it 'ample space', -> check(500, 500, 'ltlb').should.eql({ x: 500, y: 300, direction: 'up' })
+      it 'not enough space to flip', -> checkNoSpaceToFlip('ltlb').should.eql({ x: 500, y: -150, direction: 'up' })
+      it 'shifted left', -> check(850, 500, 'ltlb').should.eql({ x: 800, y: 300, direction: 'up' })
+      it 'shifted right', -> check(-50, 500, 'ltlb').should.eql({ x: 0, y: 300, direction: 'up' })
+      it 'flipped', -> check(500, 150, 'ltlb').should.eql({ x: 500, y: 250, direction: 'down' })
+      it 'flipped shifted left', -> check(850, 150, 'ltlb').should.eql({ x: 800, y: 250, direction: 'down' })
+      it 'flipped shifted right', -> check(-50, 150, 'ltlb').should.eql({ x: 0, y: 250, direction: 'down' })
+
+    describe 'rtlb', ->
+      it 'ample space', -> check(500, 500, 'rtlb').should.eql({ x: 600, y: 300, direction: 'up' })
+      it 'not enough space to flip', -> checkNoSpaceToFlip('rtlb').should.eql({ x: 600, y: -150, direction: 'up' })
+      it 'shifted left', -> check(750, 500, 'rtlb').should.eql({ x: 800, y: 300, direction: 'up' })
+      it 'shifted right', -> check(-150, 500, 'rtlb').should.eql({ x: 0, y: 300, direction: 'up' })
+      it 'flipped', -> check(500, 150, 'rtlb').should.eql({ x: 600, y: 250, direction: 'down' })
+      it 'flipped shifted left', -> check(850, 150, 'rtlb').should.eql({ x: 800, y: 250, direction: 'down' })
+      it 'flipped shifted right', -> check(-150, 150, 'rtlb').should.eql({ x: 0, y: 250, direction: 'down' })
+
+    describe 'rbrb', ->
+      it 'ample space', -> check(500, 500, 'rbrb').should.eql({ x: 400, y: 400, direction: 'up' })
+      it 'not enough space to flip', -> checkNoSpaceToFlip('rbrb').should.eql({ x: 400, y: -50, direction: 'up' })
+      it 'shifted left', -> check(950, 500, 'rbrb').should.eql({ x: 800, y: 400, direction: 'up' })
+      it 'shifted right', -> check(50, 500, 'rbrb').should.eql({ x: 0, y: 400, direction: 'up' })
+      it 'flipped', -> check(500, 50, 'rbrb').should.eql({ x: 400, y: 50, direction: 'down' })
+      it 'flipped shifted left', -> check(950, 50, 'rbrb').should.eql({ x: 800, y: 50, direction: 'down' })
+      it 'flipped shifted right', -> check(50, 50, 'rbrb').should.eql({ x: 0, y: 50, direction: 'down' })
+
+    describe 'ltrb', ->
+      it 'ample space', -> check(500, 500, 'ltrb').should.eql({ x: 300, y: 300, direction: 'up' })
+      it 'not enough space to flip', -> checkNoSpaceToFlip('ltrb').should.eql({ x: 300, y: -150, direction: 'up' })
+      it 'shifted left', -> check(1050, 500, 'ltrb').should.eql({ x: 800, y: 300, direction: 'up' })
+      it 'shifted right', -> check(50, 500, 'ltrb').should.eql({ x: 0, y: 300, direction: 'up' })
+      it 'flipped', -> check(500, 50, 'ltrb').should.eql({ x: 300, y: 150, direction: 'down' })
+      it 'flipped shifted left', -> check(1050, 50, 'ltrb').should.eql({ x: 800, y: 150, direction: 'down' })
+      it 'flipped shifted right', -> check(50, 50, 'ltrb').should.eql({ x: 0, y: 150, direction: 'down' })
+
+    describe 'rtrb', ->
+      it 'ample space', -> check(500, 500, 'rtrb').should.eql({ x: 400, y: 300, direction: 'up' })
+      it 'not enough space to flip', -> checkNoSpaceToFlip('rtrb').should.eql({ x: 400, y: -150, direction: 'up' })
+      it 'shifted left', -> check(950, 500, 'rtrb').should.eql({ x: 800, y: 300, direction: 'up' })
+      it 'shifted right', -> check(50, 500, 'rtrb').should.eql({ x: 0, y: 300, direction: 'up' })
+      it 'flipped', -> check(500, 50, 'rtrb').should.eql({ x: 400, y: 150, direction: 'down' })
+      it 'flipped shifted left', -> check(950, 50, 'rtrb').should.eql({ x: 800, y: 150, direction: 'down' })
+      it 'flipped shifted right', -> check(50, 50, 'rtrb').should.eql({ x: 0, y: 150, direction: 'down' })
+
+
+    #XXX: direction right - requires special handling for flipping, since it cannot shift horizontally, but can vertically
+    # rightwards tests
+    # describe 'rblb', ->
+    #   it 'ample space', -> check(500, 500, 'rblb').should.eql({ x: 600, y: 400, direction: 'right' })
+    #   it 'not enough space to flip', -> checkNoSpaceToFlip('rblb').should.eql({ x: 600, y: -50, direction: 'right' })
+    #   it 'shifted left', -> check(850, 500, 'rblb').should.eql({ x: 800, y: 400, direction: 'right' })
+    #   it 'shifted right', -> check(-150, 500, 'rblb').should.eql({ x: 0, y: 400, direction: 'right' })
+    #   it 'flipped', -> check(500, 50, 'rblb').should.eql({ x: 600, y: 50, direction: 'left' })
+    #   it 'flipped shifted left', -> check(850, 50, 'rblb').should.eql({ x: 800, y: 50, direction: 'left' })
+    #   it 'flipped shifted right', -> check(-150, 50, 'rblb').should.eql({ x: 0, y: 50, direction: 'left' })
+
+    # describe 'rtlt', ->
+    #   it 'ample space', -> check(500, 500, 'rtlt').should.eql({ x: 600, y: 500, direction: 'right' })
+    #   it 'not enough space to flip', -> checkNoSpaceToFlip('rtlt').should.eql({ x: 600, y: 50, direction: 'right' })
+    #   it 'shifted left', -> check(750, 500, 'rtlt').should.eql({ x: 800, y: 500, direction: 'right' })
+    #   it 'shifted right', -> check(-150, 500, 'rtlt').should.eql({ x: 0, y: 500, direction: 'right' })
+    #   it 'flipped', -> check(500, 850, 'rtlt').should.eql({ x: 600, y: 750, direction: 'left' })
+    #   it 'flipped shifted left', -> check(750, 850, 'rtlt').should.eql({ x: 800, y: 750, direction: 'left' })
+    #   it 'flipped shifted right', -> check(-150, 850, 'rtlt').should.eql({ x: 0, y: 750, direction: 'left' })
+
+    #XXX: direction right - requires special handling for flipping, since it cannot shift horizontally, but can vertically
+    # leftwards tests
+    # describe 'ltrt', ->
+    #   it 'ample space', -> check(500, 500, 'ltrt').should.eql({ x: 300, y: 500, direction: 'left' })
+    #   it 'not enough space to flip', -> checkNoSpaceToFlip('ltrt').should.eql({ x: 300, y: 50, direction: 'left' })
+    #   it 'shifted left', -> check(1050, 500, 'ltrt').should.eql({ x: 800, y: 500, direction: 'left' })
+    #   it 'shifted right', -> check(150, 500, 'ltrt').should.eql({ x: 0, y: 500, direction: 'left' })
+    #   it 'flipped', -> check(500, 850, 'ltrt').should.eql({ x: 300, y: 750, direction: 'right' })
+    #   it 'flipped shifted left', -> check(1050, 850, 'ltrt').should.eql({ x: 800, y: 750, direction: 'right' })
+    #   it 'flipped shifted right', -> check(150, 850, 'ltrt').should.eql({ x: 0, y: 750, direction: 'right' })
+
+    # describe 'lbrb', ->
+    #   it 'ample space', -> check(500, 500, 'lbrb').should.eql({ x: 300, y: 400, direction: 'left' })
+    #   it 'not enough space to flip', -> checkNoSpaceToFlip('lbrb').should.eql({ x: 300, y: -50, direction: 'left' })
+    #   it 'shifted left', -> check(1050, 500, 'lbrb').should.eql({ x: 800, y: 400, direction: 'left' })
+    #   it 'shifted right', -> check(150, 500, 'lbrb').should.eql({ x: 0, y: 400, direction: 'left' })
+    #   it 'flipped', -> check(500, 50, 'lbrb').should.eql({ x: 300, y: 50, direction: 'right' })
+    #   it 'flipped shifted left', -> check(1050, 50, 'lbrb').should.eql({ x: 800, y: 50, direction: 'right' })
+    #   it 'flipped shifted right', -> check(150, 50, 'lbrb').should.eql({ x: 0, y: 50, direction: 'right' })
+
+
+
+
+
+

--- a/modules/dropdown/test/spec.coffee
+++ b/modules/dropdown/test/spec.coffee
@@ -40,10 +40,6 @@ describe 'hx-dropdown', ->
 
     hx._.dropdown.attachToSelector = '#dropdown-fixture'
 
-    hx.select('body')
-      .style('height', '1000px')
-      .style('width', '1000px')
-
     fixture = hx.select('body').append('div')
       .style('padding', '0')
       .style('margin', '0')
@@ -77,6 +73,8 @@ describe 'hx-dropdown', ->
       .style('position', '')
       .clear()
 
+    hx._.dropdown.attachToSelector = 'body'
+
   beforeEach ->
     button = makeButton()
 
@@ -88,11 +86,13 @@ describe 'hx-dropdown', ->
 
 
   it 'should throw an error when passing in the wrong thing for dropdownContent', ->
-    chai.spy.on(hx, 'consoleWarning')
+    oldConsoleWarning = hx.consoleWarning
+    hx.consoleWarning = chai.spy()
     invalidDropdownContent = {}
     dd = new hx.Dropdown(id, invalidDropdownContent)
     dd.show()
     hx.consoleWarning.should.have.been.called.with('dropdown: dropdownContent is not a valid type. dropdownContent: ', invalidDropdownContent)
+    hx.consoleWarning = oldConsoleWarning
 
   it 'should create a dropdown object with the correct default options', ->
     dd = new hx.Dropdown(id, content)
@@ -140,18 +140,6 @@ describe 'hx-dropdown', ->
   it 'should set the spacing correctly', ->
     dd = new hx.Dropdown(id, content, {spacing: 10} )
     getSpacing(dd).should.equal(10)
-
-
-  # it 'should use the spacing correctly', ->
-  #   dd = new hx.Dropdown(id, content, {spacing: 10})
-  #   dd.show()
-  #   buttonBox = button.box()
-  #   clock.tick(301)
-  #   console.log(hx.select('body').node())
-  #   ddBox = dd._.dropdown.box()
-  #   ddBox.left.should.equal(buttonBox.left)
-  #   ddBox.top.should.equal(buttonBox.top + buttonBox.height + getSpacing(dd))
-
 
   it 'should set the matchWidth property correctly', ->
     dd = new hx.Dropdown(id, content, {matchWidth: false} )
@@ -248,11 +236,13 @@ describe 'hx-dropdown', ->
     document.__hx__.eventEmitter.emit('pointerup', { event: {target: fixture.node()}})
     dd.hide.should.have.been.called()
 
-  # it 'should detect parent z-index and set the index to be 1 greater', ->
-  #   fixture.style('z-index', 100)
-  #   dd = new hx.Dropdown(id, content)
-  #   dd.show()
-  #   dd._.dropdown.style('z-index').should.equal('101')
+  it 'should detect parent z-index and set the index to be 1 greater', ->
+    fixture
+      .style('position', 'fixed')
+      .style('z-index', 100)
+    dd = new hx.Dropdown(id, content)
+    dd.show()
+    dd._.dropdown.style('z-index').should.equal('101')
 
   it 'should detect parent position and match it correctly', ->
     fixture.style('position', 'fixed')
@@ -315,245 +305,7 @@ describe 'hx-dropdown', ->
     dd._.dropdown.style('min-width').should.equal(button.style('width'))
     clock.tick(301)
 
-  # it 'should detect the maxHeight properly', ->
-  #   hx.select('head').append('style').attr('id','style').attr('type', 'text/css').text("""
-  #     .hx-dropdown{
-  #       max-height: 5px;
-  #     }
-  #   """)
-
-  #   buttonBox = roundAll button.box()
-
-  #   dd = new hx.Dropdown(id, content)
-  #   dd.show()
-  #   setTimeout ->
-  #     ddBox = roundAll dd._.dropdown.box()
-  #     dd._.dropdown.style('max-height').should.equal('5px')
-  #     ddBox.left.should.equal(buttonBox.left)
-  #     ddBox.height.should.equal(5)
-  #     hx.select('#style').remove()
-  #   , 300
-  #   clock.tick(301)
-
-  # it 'should shift the dropdown down if shifting it up has moved it off the top of the screen', ->
-  #   dd = new hx.Dropdown(id, content, {align: 'up'})
-
-  #   button.style('top', '5px')
-
-  #   buttonBox = roundAll button.box()
-  #   dd.show()
-  #   setTimeout ->
-  #     ddBox = roundAll dd._.dropdown.box()
-  #     ddBox.top.should.equal(buttonBox.top + buttonBox.height + getSpacing(dd))
-  #     ddBox.left.should.equal(buttonBox.left)
-  #   , 300
-  #   clock.tick(301)
-
-
-  # describe 'align', ->
-  #   button = undefined
-  #   buttonBox = undefined
-  #   dd = undefined
-  #   ddBox = undefined
-
-  #   beforeEach ->
-  #     buttonBox = roundAll button.box()
-
-  #   describe 'should align correctly when align is set to', ->
-  #     tests = [
-  #         align: null
-  #         check: ->
-  #           ddBox.left.should.equal(buttonBox.left)
-  #           ddBox.top.should.equal(buttonBox.bottom + getSpacing(dd))
-  #       ,
-  #         align: 'up'
-  #         check: ->
-  #           ddBox.left.should.equal(buttonBox.left)
-  #           ddBox.top.should.equal(buttonBox.top - ddBox.height - getSpacing(dd))
-  #       ,
-  #         align: 'down'
-  #         check: ->
-  #           ddBox.left.should.equal(buttonBox.left)
-  #           ddBox.top.should.equal(buttonBox.bottom + getSpacing(dd))
-  #       ,
-  #         align: 'left'
-  #         check: ->
-  #           ddBox.right.should.equal(buttonBox.left - getSpacing(dd))
-  #           ddBox.top.should.equal(buttonBox.top)
-  #       ,
-  #         align: 'right'
-  #         check: ->
-  #           ddBox.left.should.equal(buttonBox.right + getSpacing(dd))
-  #           ddBox.top.should.equal(buttonBox.top)
-  #       ,
-  #         align: 'lbrb'
-  #         check: ->
-  #           ddBox.right.should.equal(buttonBox.left - getSpacing(dd))
-  #           ddBox.bottom.should.equal(buttonBox.bottom)
-  #       ,
-  #         align: 'lbrt'
-  #         check: ->
-  #           ddBox.right.should.equal(buttonBox.left - getSpacing(dd))
-  #           ddBox.top.should.equal(buttonBox.top + buttonBox.height + getSpacing(dd))
-  #       ,
-  #         align: 'ltrb'
-  #         check: ->
-  #           ddBox.right.should.equal(buttonBox.left - getSpacing(dd))
-  #           ddBox.bottom.should.equal(buttonBox.top - getSpacing(dd))
-  #       ,
-  #         align: 'rblt'
-  #         check: ->
-  #           ddBox.left.should.equal(buttonBox.right + getSpacing(dd))
-  #           ddBox.top.should.equal(buttonBox.bottom + getSpacing(dd))
-  #       ,
-  #         align: 'rblb'
-  #         check: ->
-  #           ddBox.left.should.equal(buttonBox.right + getSpacing(dd))
-  #           ddBox.bottom.should.equal(buttonBox.bottom)
-  #       ,
-  #         align: 'rbrt'
-  #         check: ->
-  #           ddBox.right.should.equal(buttonBox.right)
-  #           ddBox.top.should.equal(buttonBox.bottom + getSpacing(dd))
-  #       ,
-  #         align: 'rtlb'
-  #         check: ->
-  #           ddBox.left.should.equal(buttonBox.right + getSpacing(dd))
-  #           ddBox.top.should.equal(buttonBox.top - ddBox.height - getSpacing(dd))
-  #       ,
-  #         align: 'rtrb'
-  #         check: ->
-  #           ddBox.right.should.equal(buttonBox.right)
-  #           ddBox.bottom.should.equal(buttonBox.top - getSpacing(dd))
-  #     ]
-
-  #     t = (test, index) ->
-  #       it test.align, ->
-  #         dd = new hx.Dropdown(id, content, {
-  #           align: test.align or undefined
-  #         })
-  #         dd.show()
-  #         setTimeout ->
-  #           ddBox = roundAll dd._.dropdown.box()
-  #           test.check()
-  #         , 300
-  #         clock.tick(301)
-
-  #       if index < tests.length
-  #         t(tests[index], index + 1)
-
-  #     t(tests[0], 1)
-
-
-  #   describe 'shouldnt flow outside the screen when the dropdown is on the', ->
-  #     scrollbarWidth = hx.scrollbarSize()
-  #     moveBy = 10000
-
-  #     tests = [
-  #       pos: 'left'
-  #       check: ->
-  #         ddBox.left.should.equal(0)
-  #     ,
-  #       pos: 'top'
-  #       check: ->
-  #         ddBox.top.should.equal(0)
-  #     ,
-  #       pos: 'right'
-  #       check: ->
-  #         ddBox.left.should.equal(window.innerWidth - ddBox.width - scrollbarWidth)
-  #     ,
-  #       pos: 'bottom'
-  #       check: ->
-  #         ddBox.top.should.equal(window.innerHeight - ddBox.height)
-  #     ]
-
-  #     t = (test, index) ->
-  #       it ': ' + test.pos, ->
-  #         button.style('top', '')
-  #           .style('right', '')
-  #           .style('bottom', '')
-  #           .style('left', '')
-  #           .style('left', '')
-  #           .style('margin-left', '')
-  #           .style('margin-top', '')
-  #           .style(test.pos, '-' + moveBy + 'px')
-
-  #         dd = new hx.Dropdown(id, content)
-  #         dd.show()
-  #         setTimeout ->
-  #           ddBox = roundAll dd._.dropdown.box()
-  #           test.check()
-  #         , 300
-  #         clock.tick(301)
-
-  #       if index < tests.length
-  #         t(tests[index], index + 1)
-
-  #     t(tests[0], 1)
-
-  #   describe 'shouldnt overlap the parent element when align is set to', ->
-  #     tests = [
-  #       align: 'rbrb'
-  #       check: ->
-  #         ddBox.top.should.equal(buttonBox.bottom + getSpacing(dd))
-  #         ddBox.right.should.equal(buttonBox.right)
-  #     ,
-  #       align: 'lblb'
-  #       check: ->
-  #         ddBox.top.should.equal(buttonBox.bottom + getSpacing(dd))
-  #         ddBox.left.should.equal(buttonBox.left)
-  #     ,
-  #       align: 'rtrt'
-  #       check: ->
-  #         ddBox.bottom.should.equal(buttonBox.top - getSpacing(dd))
-  #         ddBox.right.should.equal(buttonBox.right)
-  #     ,
-  #       align: 'ltlt'
-  #       check: ->
-  #         ddBox.bottom.should.equal(buttonBox.top - getSpacing(dd))
-  #         ddBox.left.should.equal(buttonBox.left)
-  #     ,
-  #       align: 'cover'
-  #       check: ->
-  #         ddBox.top.should.equal(buttonBox.bottom + getSpacing(dd))
-  #         ddBox.left.should.equal(buttonBox.left)
-  #     ]
-
-  #     t = (test, index) ->
-  #       it test.align, ->
-  #         if test.align is 'cover'
-  #           test.align = null
-  #           coverContent = '<div style="width:200px; height: 100px">Content</div>'
-  #         dd = new hx.Dropdown(id, coverContent or content, {align: test.align or undefined })
-  #         dd.show()
-  #         setTimeout ->
-  #           ddBox = roundAll dd._.dropdown.box()
-  #           test.check()
-  #         , 300
-  #         clock.tick(301)
-
-  #       if index < tests.length
-  #         t(tests[index], index + 1)
-
-  #     t(tests[0], 1)
-
   describe 'calculateDropdownPosition', ->
-
-    checkNoSpaceToFlip = (alignments) ->
-      selectionRect = { x: 500, y: 50, width: 100, height: 100 }
-      dropdownRect = { width: 200, height: 200 }
-      windowRect = { width: 1000, height: 200 }
-      ddMaxHeight = undefined
-      scrollbarWidth = 0
-
-      hx._.dropdown.calculateDropdownPosition(
-        alignments.split(''),
-        selectionRect,
-        dropdownRect,
-        windowRect,
-        ddMaxHeight,
-        scrollbarWidth
-      )
 
     check = (selectionX, selectionY, alignments) ->
       selectionRect = { x: selectionX, y: selectionY, width: 100, height: 100 }
@@ -571,10 +323,44 @@ describe 'hx-dropdown', ->
         scrollbarWidth
       )
 
+
+    checkNoSpaceToFlipH = (alignments) ->
+      selectionRect = { x: 50, y: 500, width: 100, height: 100 }
+      dropdownRect = { width: 200, height: 200 }
+      windowRect = { width: 200, height: 1000 }
+      ddMaxHeight = undefined
+      scrollbarWidth = 0
+
+      hx._.dropdown.calculateDropdownPosition(
+        alignments.split(''),
+        selectionRect,
+        dropdownRect,
+        windowRect,
+        ddMaxHeight,
+        scrollbarWidth
+      )
+
+    checkNoSpaceToFlipV = (alignments) ->
+      selectionRect = { x: 500, y: 50, width: 100, height: 100 }
+      dropdownRect = { width: 200, height: 200 }
+      windowRect = { width: 1000, height: 200 }
+      ddMaxHeight = undefined
+      scrollbarWidth = 0
+
+      hx._.dropdown.calculateDropdownPosition(
+        alignments.split(''),
+        selectionRect,
+        dropdownRect,
+        windowRect,
+        ddMaxHeight,
+        scrollbarWidth
+      )
+
+
     # downwards tests
     describe 'lblt', ->
       it 'ample space', -> check(500, 500, 'lblt').should.eql({ x: 500, y: 600, direction: 'down' })
-      it 'not enough space to flip', -> checkNoSpaceToFlip('lblt').should.eql({ x: 500, y: 150, direction: 'down' })
+      it 'not enough space to flip', -> checkNoSpaceToFlipV('lblt').should.eql({ x: 500, y: 150, direction: 'down' })
       it 'shifted left', -> check(850, 500, 'lblt').should.eql({ x: 800, y: 600, direction: 'down' })
       it 'shifted right', -> check(-50, 500, 'lblt').should.eql({ x: 0, y: 600, direction: 'down' })
       it 'flipped', -> check(500, 850, 'lblt').should.eql({ x: 500, y: 650, direction: 'up' })
@@ -583,7 +369,7 @@ describe 'hx-dropdown', ->
 
     describe 'rblt', ->
       it 'ample space', -> check(500, 500, 'rblt').should.eql({ x: 600, y: 600, direction: 'down' })
-      it 'not enough space to flip', -> checkNoSpaceToFlip('rblt').should.eql({ x: 600, y: 150, direction: 'down' })
+      it 'not enough space to flip', -> checkNoSpaceToFlipV('rblt').should.eql({ x: 600, y: 150, direction: 'down' })
       it 'shifted left', -> check(750, 500, 'rblt').should.eql({ x: 800, y: 600, direction: 'down' })
       it 'shifted right', -> check(-150, 500, 'rblt').should.eql({ x: 0, y: 600, direction: 'down' })
       it 'flipped', -> check(500, 850, 'rblt').should.eql({ x: 600, y: 650, direction: 'up' })
@@ -592,7 +378,7 @@ describe 'hx-dropdown', ->
 
     describe 'ltlt', ->
       it 'ample space', -> check(500, 500, 'ltlt').should.eql({ x: 500, y: 500, direction: 'down' })
-      it 'not enough space to flip', -> checkNoSpaceToFlip('ltlt').should.eql({ x: 500, y: 50, direction: 'down' })
+      it 'not enough space to flip', -> checkNoSpaceToFlipV('ltlt').should.eql({ x: 500, y: 50, direction: 'down' })
       it 'shifted left', -> check(850, 500, 'ltlt').should.eql({ x: 800, y: 500, direction: 'down' })
       it 'shifted right', -> check(-50, 500, 'ltlt').should.eql({ x: 0, y: 500, direction: 'down' })
       it 'flipped', -> check(500, 850, 'ltlt').should.eql({ x: 500, y: 750, direction: 'up' })
@@ -601,7 +387,7 @@ describe 'hx-dropdown', ->
 
     describe 'lbrt', ->
       it 'ample space', -> check(500, 500, 'lbrt').should.eql({ x: 300, y: 600, direction: 'down' })
-      it 'not enough space to flip', -> checkNoSpaceToFlip('lbrt').should.eql({ x: 300, y: 150, direction: 'down' })
+      it 'not enough space to flip', -> checkNoSpaceToFlipV('lbrt').should.eql({ x: 300, y: 150, direction: 'down' })
       it 'shifted left', -> check(1050, 500, 'lbrt').should.eql({ x: 800, y: 600, direction: 'down' })
       it 'shifted right', -> check(150, 500, 'lbrt').should.eql({ x: 0, y: 600, direction: 'down' })
       it 'flipped', -> check(500, 850, 'lbrt').should.eql({ x: 300, y: 650, direction: 'up' })
@@ -610,7 +396,7 @@ describe 'hx-dropdown', ->
 
     describe 'rbrt', ->
       it 'ample space', -> check(500, 500, 'rbrt').should.eql({ x: 400, y: 600, direction: 'down' })
-      it 'not enough space to flip', -> checkNoSpaceToFlip('rbrt').should.eql({ x: 400, y: 150, direction: 'down' })
+      it 'not enough space to flip', -> checkNoSpaceToFlipV('rbrt').should.eql({ x: 400, y: 150, direction: 'down' })
       it 'shifted left', -> check(950, 500, 'rbrt').should.eql({ x: 800, y: 600, direction: 'down' })
       it 'shifted right', -> check(50, 500, 'rbrt').should.eql({ x: 0, y: 600, direction: 'down' })
       it 'flipped', -> check(500, 850, 'rbrt').should.eql({ x: 400, y: 650, direction: 'up' })
@@ -619,7 +405,7 @@ describe 'hx-dropdown', ->
 
     describe 'rtrt', ->
       it 'ample space', -> check(500, 500, 'rtrt').should.eql({ x: 400, y: 500, direction: 'down' })
-      it 'not enough space to flip', -> checkNoSpaceToFlip('rtrt').should.eql({ x: 400, y: 50, direction: 'down' })
+      it 'not enough space to flip', -> checkNoSpaceToFlipV('rtrt').should.eql({ x: 400, y: 50, direction: 'down' })
       it 'shifted left', -> check(950, 500, 'rtrt').should.eql({ x: 800, y: 500, direction: 'down' })
       it 'shifted right', -> check(50, 500, 'rtrt').should.eql({ x: 0, y: 500, direction: 'down' })
       it 'flipped', -> check(500, 850, 'rtrt').should.eql({ x: 400, y: 750, direction: 'up' })
@@ -629,7 +415,7 @@ describe 'hx-dropdown', ->
     # upwards tests
     describe 'lblb', ->
       it 'ample space', -> check(500, 500, 'lblb').should.eql({ x: 500, y: 400, direction: 'up' })
-      it 'not enough space to flip', -> checkNoSpaceToFlip('lblb').should.eql({ x: 500, y: -50, direction: 'up' })
+      it 'not enough space to flip', -> checkNoSpaceToFlipV('lblb').should.eql({ x: 500, y: -50, direction: 'up' })
       it 'shifted left', -> check(850, 500, 'lblb').should.eql({ x: 800, y: 400, direction: 'up' })
       it 'shifted right', -> check(-50, 500, 'lblb').should.eql({ x: 0, y: 400, direction: 'up' })
       it 'flipped', -> check(500, 50, 'lblb').should.eql({ x: 500, y: 50, direction: 'down' })
@@ -638,7 +424,7 @@ describe 'hx-dropdown', ->
 
     describe 'ltlb', ->
       it 'ample space', -> check(500, 500, 'ltlb').should.eql({ x: 500, y: 300, direction: 'up' })
-      it 'not enough space to flip', -> checkNoSpaceToFlip('ltlb').should.eql({ x: 500, y: -150, direction: 'up' })
+      it 'not enough space to flip', -> checkNoSpaceToFlipV('ltlb').should.eql({ x: 500, y: -150, direction: 'up' })
       it 'shifted left', -> check(850, 500, 'ltlb').should.eql({ x: 800, y: 300, direction: 'up' })
       it 'shifted right', -> check(-50, 500, 'ltlb').should.eql({ x: 0, y: 300, direction: 'up' })
       it 'flipped', -> check(500, 150, 'ltlb').should.eql({ x: 500, y: 250, direction: 'down' })
@@ -647,7 +433,7 @@ describe 'hx-dropdown', ->
 
     describe 'rtlb', ->
       it 'ample space', -> check(500, 500, 'rtlb').should.eql({ x: 600, y: 300, direction: 'up' })
-      it 'not enough space to flip', -> checkNoSpaceToFlip('rtlb').should.eql({ x: 600, y: -150, direction: 'up' })
+      it 'not enough space to flip', -> checkNoSpaceToFlipV('rtlb').should.eql({ x: 600, y: -150, direction: 'up' })
       it 'shifted left', -> check(750, 500, 'rtlb').should.eql({ x: 800, y: 300, direction: 'up' })
       it 'shifted right', -> check(-150, 500, 'rtlb').should.eql({ x: 0, y: 300, direction: 'up' })
       it 'flipped', -> check(500, 150, 'rtlb').should.eql({ x: 600, y: 250, direction: 'down' })
@@ -656,7 +442,7 @@ describe 'hx-dropdown', ->
 
     describe 'rbrb', ->
       it 'ample space', -> check(500, 500, 'rbrb').should.eql({ x: 400, y: 400, direction: 'up' })
-      it 'not enough space to flip', -> checkNoSpaceToFlip('rbrb').should.eql({ x: 400, y: -50, direction: 'up' })
+      it 'not enough space to flip', -> checkNoSpaceToFlipV('rbrb').should.eql({ x: 400, y: -50, direction: 'up' })
       it 'shifted left', -> check(950, 500, 'rbrb').should.eql({ x: 800, y: 400, direction: 'up' })
       it 'shifted right', -> check(50, 500, 'rbrb').should.eql({ x: 0, y: 400, direction: 'up' })
       it 'flipped', -> check(500, 50, 'rbrb').should.eql({ x: 400, y: 50, direction: 'down' })
@@ -665,7 +451,7 @@ describe 'hx-dropdown', ->
 
     describe 'ltrb', ->
       it 'ample space', -> check(500, 500, 'ltrb').should.eql({ x: 300, y: 300, direction: 'up' })
-      it 'not enough space to flip', -> checkNoSpaceToFlip('ltrb').should.eql({ x: 300, y: -150, direction: 'up' })
+      it 'not enough space to flip', -> checkNoSpaceToFlipV('ltrb').should.eql({ x: 300, y: -150, direction: 'up' })
       it 'shifted left', -> check(1050, 500, 'ltrb').should.eql({ x: 800, y: 300, direction: 'up' })
       it 'shifted right', -> check(50, 500, 'ltrb').should.eql({ x: 0, y: 300, direction: 'up' })
       it 'flipped', -> check(500, 50, 'ltrb').should.eql({ x: 300, y: 150, direction: 'down' })
@@ -674,55 +460,50 @@ describe 'hx-dropdown', ->
 
     describe 'rtrb', ->
       it 'ample space', -> check(500, 500, 'rtrb').should.eql({ x: 400, y: 300, direction: 'up' })
-      it 'not enough space to flip', -> checkNoSpaceToFlip('rtrb').should.eql({ x: 400, y: -150, direction: 'up' })
+      it 'not enough space to flip', -> checkNoSpaceToFlipV('rtrb').should.eql({ x: 400, y: -150, direction: 'up' })
       it 'shifted left', -> check(950, 500, 'rtrb').should.eql({ x: 800, y: 300, direction: 'up' })
       it 'shifted right', -> check(50, 500, 'rtrb').should.eql({ x: 0, y: 300, direction: 'up' })
       it 'flipped', -> check(500, 50, 'rtrb').should.eql({ x: 400, y: 150, direction: 'down' })
       it 'flipped shifted left', -> check(950, 50, 'rtrb').should.eql({ x: 800, y: 150, direction: 'down' })
       it 'flipped shifted right', -> check(50, 50, 'rtrb').should.eql({ x: 0, y: 150, direction: 'down' })
 
-
-    #XXX: direction right - requires special handling for flipping, since it cannot shift horizontally, but can vertically
     # rightwards tests
-    # describe 'rblb', ->
-    #   it 'ample space', -> check(500, 500, 'rblb').should.eql({ x: 600, y: 400, direction: 'right' })
-    #   it 'not enough space to flip', -> checkNoSpaceToFlip('rblb').should.eql({ x: 600, y: -50, direction: 'right' })
-    #   it 'shifted left', -> check(850, 500, 'rblb').should.eql({ x: 800, y: 400, direction: 'right' })
-    #   it 'shifted right', -> check(-150, 500, 'rblb').should.eql({ x: 0, y: 400, direction: 'right' })
-    #   it 'flipped', -> check(500, 50, 'rblb').should.eql({ x: 600, y: 50, direction: 'left' })
-    #   it 'flipped shifted left', -> check(850, 50, 'rblb').should.eql({ x: 800, y: 50, direction: 'left' })
-    #   it 'flipped shifted right', -> check(-150, 50, 'rblb').should.eql({ x: 0, y: 50, direction: 'left' })
+    describe 'rtlt', ->
+      it 'ample space', -> check(500, 500, 'rtlt').should.eql({ x: 600, y: 500, direction: 'right' })
+      it 'not enough space to flip', -> checkNoSpaceToFlipH('rtlt').should.eql({ x: 150, y: 500, direction: 'right' })
+      it 'shifted down', -> check(500, -50, 'rtlt').should.eql({ x: 600, y: 0, direction: 'right' })
+      it 'shifted up', -> check(500, 850, 'rtlt').should.eql({ x: 600, y: 800, direction: 'right' })
+      it 'flipped', -> check(750, 500, 'rtlt').should.eql({ x: 550, y: 500, direction: 'left' })
+      it 'flipped shifted down', -> check(750, -50, 'rtlt').should.eql({ x: 550, y: 0, direction: 'left' })
+      it 'flipped shifted up', -> check(750, 850, 'rtlt').should.eql({ x: 550, y: 800, direction: 'left' })
 
-    # describe 'rtlt', ->
-    #   it 'ample space', -> check(500, 500, 'rtlt').should.eql({ x: 600, y: 500, direction: 'right' })
-    #   it 'not enough space to flip', -> checkNoSpaceToFlip('rtlt').should.eql({ x: 600, y: 50, direction: 'right' })
-    #   it 'shifted left', -> check(750, 500, 'rtlt').should.eql({ x: 800, y: 500, direction: 'right' })
-    #   it 'shifted right', -> check(-150, 500, 'rtlt').should.eql({ x: 0, y: 500, direction: 'right' })
-    #   it 'flipped', -> check(500, 850, 'rtlt').should.eql({ x: 600, y: 750, direction: 'left' })
-    #   it 'flipped shifted left', -> check(750, 850, 'rtlt').should.eql({ x: 800, y: 750, direction: 'left' })
-    #   it 'flipped shifted right', -> check(-150, 850, 'rtlt').should.eql({ x: 0, y: 750, direction: 'left' })
+    describe 'rblb', ->
+      it 'ample space', -> check(500, 500, 'rblb').should.eql({ x: 600, y: 400, direction: 'right' })
+      it 'not enough space to flip', -> checkNoSpaceToFlipH('rblb').should.eql({ x: 150, y: 400, direction: 'right' })
+      it 'shifted down', -> check(500, 50, 'rblb').should.eql({ x: 600, y: 0, direction: 'right' })
+      it 'shifted up', -> check(500, 950, 'rblb').should.eql({ x: 600, y: 800, direction: 'right' })
+      it 'flipped', -> check(750, 500, 'rblb').should.eql({ x: 550, y: 400, direction: 'left' })
+      it 'flipped shifted down', -> check(750, 50, 'rblb').should.eql({ x: 550, y: 0, direction: 'left' })
+      it 'flipped shifted up', -> check(750, 950, 'rblb').should.eql({ x: 550, y: 800, direction: 'left' })
 
-    #XXX: direction right - requires special handling for flipping, since it cannot shift horizontally, but can vertically
     # leftwards tests
-    # describe 'ltrt', ->
-    #   it 'ample space', -> check(500, 500, 'ltrt').should.eql({ x: 300, y: 500, direction: 'left' })
-    #   it 'not enough space to flip', -> checkNoSpaceToFlip('ltrt').should.eql({ x: 300, y: 50, direction: 'left' })
-    #   it 'shifted left', -> check(1050, 500, 'ltrt').should.eql({ x: 800, y: 500, direction: 'left' })
-    #   it 'shifted right', -> check(150, 500, 'ltrt').should.eql({ x: 0, y: 500, direction: 'left' })
-    #   it 'flipped', -> check(500, 850, 'ltrt').should.eql({ x: 300, y: 750, direction: 'right' })
-    #   it 'flipped shifted left', -> check(1050, 850, 'ltrt').should.eql({ x: 800, y: 750, direction: 'right' })
-    #   it 'flipped shifted right', -> check(150, 850, 'ltrt').should.eql({ x: 0, y: 750, direction: 'right' })
+    describe 'ltrt', ->
+      it 'ample space', -> check(500, 500, 'ltrt').should.eql({ x: 300, y: 500, direction: 'left' })
+      it 'not enough space to flip', -> checkNoSpaceToFlipH('ltrt').should.eql({ x: -150, y: 500, direction: 'left' })
+      it 'shifted down', -> check(500, -50, 'ltrt').should.eql({ x: 300, y: 0, direction: 'left' })
+      it 'shifted up', -> check(500, 850, 'ltrt').should.eql({ x: 300, y: 800, direction: 'left' })
+      it 'flipped', -> check(150, 500, 'ltrt').should.eql({ x: 250, y: 500, direction: 'right' })
+      it 'flipped shifted down', -> check(150, -50, 'ltrt').should.eql({ x: 250, y: 0, direction: 'right' })
+      it 'flipped shifted up', -> check(150, 850, 'ltrt').should.eql({ x: 250, y: 800, direction: 'right' })
 
-    # describe 'lbrb', ->
-    #   it 'ample space', -> check(500, 500, 'lbrb').should.eql({ x: 300, y: 400, direction: 'left' })
-    #   it 'not enough space to flip', -> checkNoSpaceToFlip('lbrb').should.eql({ x: 300, y: -50, direction: 'left' })
-    #   it 'shifted left', -> check(1050, 500, 'lbrb').should.eql({ x: 800, y: 400, direction: 'left' })
-    #   it 'shifted right', -> check(150, 500, 'lbrb').should.eql({ x: 0, y: 400, direction: 'left' })
-    #   it 'flipped', -> check(500, 50, 'lbrb').should.eql({ x: 300, y: 50, direction: 'right' })
-    #   it 'flipped shifted left', -> check(1050, 50, 'lbrb').should.eql({ x: 800, y: 50, direction: 'right' })
-    #   it 'flipped shifted right', -> check(150, 50, 'lbrb').should.eql({ x: 0, y: 50, direction: 'right' })
-
-
+    describe 'lbrb', ->
+      it 'ample space', -> check(500, 500, 'lbrb').should.eql({ x: 300, y: 400, direction: 'left' })
+      it 'not enough space to flip', -> checkNoSpaceToFlipH('lbrb').should.eql({ x: -150, y: 400, direction: 'left' })
+      it 'shifted down', -> check(500, 50, 'lbrb').should.eql({ x: 300, y: 0, direction: 'left' })
+      it 'shifted up', -> check(500, 950, 'lbrb').should.eql({ x: 300, y: 800, direction: 'left' })
+      it 'flipped', -> check(150, 500, 'lbrb').should.eql({ x: 250, y: 400, direction: 'right' })
+      it 'flipped shifted down', -> check(150, 50, 'lbrb').should.eql({ x: 250, y: 0, direction: 'right' })
+      it 'flipped shifted up', -> check(150, 950, 'lbrb').should.eql({ x: 250, y: 800, direction: 'right' })
 
 
 

--- a/modules/dropdown/test/spec.coffee
+++ b/modules/dropdown/test/spec.coffee
@@ -96,12 +96,12 @@ describe 'hx-dropdown', ->
   it 'should create a dropdown object with the correct default options', ->
     dd = new hx.Dropdown(id, content)
 
-    expect(dd.selection).toEqual(button)
+    expect(dd._.selection).toEqual(button)
     expect(getSpacing(dd)).toEqual(0)
     expect(dd.options.matchWidth).toEqual(true)
-    expect(dd.alignments).toEqual('lblt'.split(''))
-    expect(dd.dropdown).not.toBeDefined()
-    expect(dd.visible).toEqual(false)
+    expect(dd._.alignments).toEqual('lblt'.split(''))
+    expect(dd._.dropdown).not.toBeDefined()
+    expect(dd._.visible).toEqual(false)
     expect(dd.options.ddClass).toEqual('')
     expect(dd.options.mode).toEqual('click')
 
@@ -109,32 +109,32 @@ describe 'hx-dropdown', ->
   it 'should set the mode correctly for click', ->
     dd = new hx.Dropdown(id, content, {mode: 'click'})
 
-    expect(dd.selection.node().__hx__.eventEmitter.has('click')).toEqual(true)
-    expect(dd.selection.node().__hx__.eventEmitter.has('mouseover')).toEqual(false)
-    expect(dd.selection.node().__hx__.eventEmitter.has('mouseout')).toEqual(false)
+    expect(dd._.selection.node().__hx__.eventEmitter.has('click')).toEqual(true)
+    expect(dd._.selection.node().__hx__.eventEmitter.has('mouseover')).toEqual(false)
+    expect(dd._.selection.node().__hx__.eventEmitter.has('mouseout')).toEqual(false)
 
     dd = new hx.Dropdown(id, content, {mode: 'hover'})
-    expect(dd.selection.node().__hx__.eventEmitter.has('click')).toEqual(true)
-    expect(dd.selection.node().__hx__.eventEmitter.has('mouseover')).toEqual(true)
-    expect(dd.selection.node().__hx__.eventEmitter.has('mouseout')).toEqual(true)
+    expect(dd._.selection.node().__hx__.eventEmitter.has('click')).toEqual(true)
+    expect(dd._.selection.node().__hx__.eventEmitter.has('mouseover')).toEqual(true)
+    expect(dd._.selection.node().__hx__.eventEmitter.has('mouseout')).toEqual(true)
 
 
   it 'should set the alignment correctly', ->
     dd = new hx.Dropdown(id, content, {align: 'rbrb'})
-    expect(dd.alignments).toEqual('rbrb'.split(''))
+    expect(dd._.alignments).toEqual('rbrb'.split(''))
 
   it 'should use the right alignment option when a named align value is used', ->
     dd = new hx.Dropdown(id, content, {align: 'up'})
-    expect(dd.alignments).toEqual('ltlb'.split(''))
+    expect(dd._.alignments).toEqual('ltlb'.split(''))
 
     dd = new hx.Dropdown(id, content, {align: 'down'})
-    expect(dd.alignments).toEqual('lblt'.split(''))
+    expect(dd._.alignments).toEqual('lblt'.split(''))
 
     dd = new hx.Dropdown(id, content, {align: 'left'})
-    expect(dd.alignments).toEqual('ltrt'.split(''))
+    expect(dd._.alignments).toEqual('ltrt'.split(''))
 
     dd = new hx.Dropdown(id, content, {align: 'right'})
-    expect(dd.alignments).toEqual('rtlt'.split(''))
+    expect(dd._.alignments).toEqual('rtlt'.split(''))
 
   it 'should set the spacing correctly', ->
     dd = new hx.Dropdown(id, content, {spacing: 10} )
@@ -147,7 +147,7 @@ describe 'hx-dropdown', ->
   #   buttonBox = button.box()
   #   jasmine.clock().tick(301)
   #   console.log(hx.select('body').node())
-  #   ddBox = dd.dropdown.box()
+  #   ddBox = dd._.dropdown.box()
   #   expect(ddBox.left).toEqual(buttonBox.left)
   #   expect(ddBox.top).toEqual(buttonBox.top + buttonBox.height + getSpacing(dd))
 
@@ -166,7 +166,7 @@ describe 'hx-dropdown', ->
   it 'should call toggle the selector is clicked in click mode', ->
     dd = new hx.Dropdown(id, content)
     spyOn(dd, 'toggle')
-    dd.selection.node().__hx__.eventEmitter.emit('click')
+    dd._.selection.node().__hx__.eventEmitter.emit('click')
     expect(dd.toggle).toHaveBeenCalled()
 
   it 'should call show/hide on mouseover/mouseout in hover mode', ->
@@ -175,13 +175,13 @@ describe 'hx-dropdown', ->
     spyOn(dd, 'hide')
     spyOn(dd, 'toggle')
 
-    dd.selection.node().__hx__.eventEmitter.emit('mouseover')
+    dd._.selection.node().__hx__.eventEmitter.emit('mouseover')
     expect(dd.show).toHaveBeenCalled()
 
-    dd.selection.node().__hx__.eventEmitter.emit('mouseout')
+    dd._.selection.node().__hx__.eventEmitter.emit('mouseout')
     expect(dd.hide).toHaveBeenCalled()
 
-    dd.selection.node().__hx__.eventEmitter.emit('click')
+    dd._.selection.node().__hx__.eventEmitter.emit('click')
     expect(dd.toggle).toHaveBeenCalled()
 
   it 'should correctly detect if the dropdown is open', ->
@@ -198,38 +198,38 @@ describe 'hx-dropdown', ->
 
   it 'should exist on the page when opened and set the visible property to true', ->
     dd = new hx.Dropdown(id, content)
-    expect(dd.visible).toEqual(false)
+    expect(dd._.visible).toEqual(false)
     expect(hx.select('.hx-dropdown').empty()).toEqual(true)
 
-    dd.selection.node().__hx__.eventEmitter.emit('click')
+    dd._.selection.node().__hx__.eventEmitter.emit('click')
 
-    expect(dd.visible).toEqual(true)
+    expect(dd._.visible).toEqual(true)
     expect(hx.select('.hx-dropdown').empty()).toEqual(false)
     expect(hx.select('.hx-dropdown').html()).toEqual(content)
 
   it 'should not do anything if show is called and the dropdown is already open', ->
     dd = new hx.Dropdown(id, content)
-    expect(dd.visible).toEqual(false)
+    expect(dd._.visible).toEqual(false)
     expect(hx.select('.hx-dropdown').empty()).toEqual(true)
 
     dd.show()
-    expect(dd.visible).toEqual(true)
+    expect(dd._.visible).toEqual(true)
     expect(hx.select('.hx-dropdown').empty()).toEqual(false)
     expect(hx.select('.hx-dropdown').html()).toEqual(content)
 
     dd.show()
-    expect(dd.visible).toEqual(true)
+    expect(dd._.visible).toEqual(true)
     expect(hx.select('.hx-dropdown').empty()).toEqual(false)
     expect(hx.select('.hx-dropdown').html()).toEqual(content)
 
   it 'should not do anything if hide is called and the dropdown is already closed', ->
     dd = new hx.Dropdown(id, content)
     spyOn(dd._.clickDetector, 'off')
-    expect(dd.visible).toEqual(false)
+    expect(dd._.visible).toEqual(false)
     expect(hx.select('.hx-dropdown').empty()).toEqual(true)
 
     dd.hide()
-    expect(dd.visible).toEqual(false)
+    expect(dd._.visible).toEqual(false)
     expect(hx.select('.hx-dropdown').empty()).toEqual(true)
     expect(dd._.clickDetector.off).not.toHaveBeenCalled()
 
@@ -251,14 +251,14 @@ describe 'hx-dropdown', ->
   #   fixture.style('z-index', 100)
   #   dd = new hx.Dropdown(id, content)
   #   dd.show()
-  #   expect(dd.dropdown.style('z-index')).toEqual('101')
+  #   expect(dd._.dropdown.style('z-index')).toEqual('101')
 
   it 'should detect parent position and match it correctly', ->
     fixture.style('position', 'fixed')
 
     dd = new hx.Dropdown(id, content)
     dd.show()
-    expect(dd.dropdown.style('position')).toEqual('fixed')
+    expect(dd._.dropdown.style('position')).toEqual('fixed')
 
   it 'should render correctly using a function as content', ->
     populate = (elem) ->
@@ -268,26 +268,26 @@ describe 'hx-dropdown', ->
 
     dd.show()
     # uses fixture bg as hex gets converted to different things by different browsers
-    expect(dd.dropdown.select('.bob').text()).toEqual('Dave')
+    expect(dd._.dropdown.select('.bob').text()).toEqual('Dave')
 
 
   it 'should class the dropdown with the supplied dd class', ->
     dd = new hx.Dropdown(id, content, {ddClass: 'bob'})
     dd.show()
-    expect(dd.dropdown.classed('bob')).toEqual(true)
+    expect(dd._.dropdown.classed('bob')).toEqual(true)
 
   it 'should show and hide correctly', ->
     dd = new hx.Dropdown(id, content)
 
-    expect(dd.visible).toEqual(false)
+    expect(dd._.visible).toEqual(false)
     expect(hx.select('.hx-dropdown').empty()).toEqual(true)
 
     dd.show()
-    expect(dd.visible).toEqual(true)
+    expect(dd._.visible).toEqual(true)
     expect(hx.select('.hx-dropdown').empty()).toEqual(false)
 
     dd.hide()
-    expect(dd.visible).toEqual(false)
+    expect(dd._.visible).toEqual(false)
     expect(hx.select('.hx-dropdown').empty()).toEqual(true)
 
   it 'should set the overflow style when the useScroll option is specified', ->
@@ -295,7 +295,7 @@ describe 'hx-dropdown', ->
     dd.useScroll = true
     dd.show()
     jasmine.clock().tick(300)
-    expect(dd.dropdown.style('overflow-y')).toEqual('auto')
+    expect(dd._.dropdown.style('overflow-y')).toEqual('auto')
 
   it 'shouldnt try to match the width of the parent if matchWidth is false', ->
     button.text('Wider button for testing')
@@ -304,7 +304,7 @@ describe 'hx-dropdown', ->
     dd = new hx.Dropdown(id, content, {matchWidth: false })
 
     dd.show()
-    expect(dd.dropdown.style('min-width')).toEqual('0px')
+    expect(dd._.dropdown.style('min-width')).toEqual('0px')
     jasmine.clock().tick(301)
 
   it 'should try to match the width of the parent if matchWidth is true', ->
@@ -313,7 +313,7 @@ describe 'hx-dropdown', ->
     dd = new hx.Dropdown(id, content, {matchWidt: true })
 
     dd.show()
-    expect(dd.dropdown.style('min-width')).toEqual(button.style('width'))
+    expect(dd._.dropdown.style('min-width')).toEqual(button.style('width'))
     jasmine.clock().tick(301)
 
   # it 'should detect the maxHeight properly', ->
@@ -328,8 +328,8 @@ describe 'hx-dropdown', ->
   #   dd = new hx.Dropdown(id, content)
   #   dd.show()
   #   setTimeout ->
-  #     ddBox = roundAll dd.dropdown.box()
-  #     expect(dd.dropdown.style('max-height')).toEqual('5px')
+  #     ddBox = roundAll dd._.dropdown.box()
+  #     expect(dd._.dropdown.style('max-height')).toEqual('5px')
   #     expect(ddBox.left).toEqual(buttonBox.left)
   #     expect(ddBox.height).toEqual(5)
   #     hx.select('#style').remove()
@@ -344,7 +344,7 @@ describe 'hx-dropdown', ->
     buttonBox = roundAll button.box()
     dd.show()
     setTimeout ->
-      ddBox = roundAll dd.dropdown.box()
+      ddBox = roundAll dd._.dropdown.box()
       expect(ddBox.top).toEqual(buttonBox.top + buttonBox.height + getSpacing(dd))
       expect(ddBox.left).toEqual(buttonBox.left)
     , 300
@@ -435,7 +435,7 @@ describe 'hx-dropdown', ->
           })
           dd.show()
           setTimeout ->
-            ddBox = roundAll dd.dropdown.box()
+            ddBox = roundAll dd._.dropdown.box()
             test.check()
           , 300
           jasmine.clock().tick(301)
@@ -482,7 +482,7 @@ describe 'hx-dropdown', ->
           dd = new hx.Dropdown(id, content)
           dd.show()
           setTimeout ->
-            ddBox = roundAll dd.dropdown.box()
+            ddBox = roundAll dd._.dropdown.box()
             test.check()
           , 300
           jasmine.clock().tick(301)
@@ -528,7 +528,7 @@ describe 'hx-dropdown', ->
           dd = new hx.Dropdown(id, coverContent or content, {align: test.align or undefined })
           dd.show()
           setTimeout ->
-            ddBox = roundAll dd.dropdown.box()
+            ddBox = roundAll dd._.dropdown.box()
             test.check()
           , 300
           jasmine.clock().tick(301)

--- a/modules/dropdown/test/spec.coffee
+++ b/modules/dropdown/test/spec.coffee
@@ -88,10 +88,11 @@ describe 'hx-dropdown', ->
 
 
   it 'should throw an error when passing in the wrong thing for dropdownContent', ->
-    chai.spy.on(console, 'error')
-    dd = new hx.Dropdown(id, hx.detached('div'))
+    chai.spy.on(hx, 'consoleWarning')
+    invalidDropdownContent = {}
+    dd = new hx.Dropdown(id, invalidDropdownContent)
     dd.show()
-    console.error.should.have.been.called.with('dropdown: dropdownContent is not a valid type ' + id)
+    hx.consoleWarning.should.have.been.called.with('dropdown: dropdownContent is not a valid type. dropdownContent: ', invalidDropdownContent)
 
   it 'should create a dropdown object with the correct default options', ->
     dd = new hx.Dropdown(id, content)
@@ -265,9 +266,7 @@ describe 'hx-dropdown', ->
       hx.select(elem).append('div').class('bob').text('Dave')
 
     dd = new hx.Dropdown(id, populate)
-
     dd.show()
-    # uses fixture bg as hex gets converted to different things by different browsers
     dd._.dropdown.select('.bob').text().should.equal('Dave')
 
 

--- a/modules/dropdown/test/spec.coffee
+++ b/modules/dropdown/test/spec.coffee
@@ -7,6 +7,7 @@ describe 'hx-dropdown', ->
   id = '#button'
 
   fixture = undefined
+  clock = undefined
 
   getWindowMeasurement = (horizontal, scroll) ->
     if scroll then 0
@@ -61,14 +62,13 @@ describe 'hx-dropdown', ->
     hx.loop = hx_loop = (f) ->
       g = -> hx_loop_update(f, g)
       hx_loop_update(f, g)
-    jasmine.clock().install()
     baseTime = new Date(2013, 0, 1)
-    jasmine.clock().mockDate(baseTime)
+    clock = sinon.useFakeTimers(baseTime.getTime())
 
   afterAll ->
     fixture.remove()
     hx.loop = savedHxLoop
-    jasmine.clock().uninstall()
+    clock.restore()
     hx.select('body')
       .style('padding', '')
       .style('margin', '')
@@ -88,177 +88,177 @@ describe 'hx-dropdown', ->
 
 
   it 'should throw an error when passing in the wrong thing for dropdownContent', ->
-    spyOn(console, 'error')
+    chai.spy.on(console, 'error')
     dd = new hx.Dropdown(id, hx.detached('div'))
     dd.show()
-    expect(console.error).toHaveBeenCalledWith('dropdown: dropdownContent is not a valid type ' + id)
+    console.error.should.have.been.called.with('dropdown: dropdownContent is not a valid type ' + id)
 
   it 'should create a dropdown object with the correct default options', ->
     dd = new hx.Dropdown(id, content)
 
-    expect(dd._.selection).toEqual(button)
-    expect(getSpacing(dd)).toEqual(0)
-    expect(dd.options.matchWidth).toEqual(true)
-    expect(dd._.alignments).toEqual('lblt'.split(''))
-    expect(dd._.dropdown).not.toBeDefined()
-    expect(dd._.visible).toEqual(false)
-    expect(dd.options.ddClass).toEqual('')
-    expect(dd.options.mode).toEqual('click')
+    dd._.selection.should.eql(button)
+    getSpacing(dd).should.equal(0)
+    dd.options.matchWidth.should.equal(true)
+    dd._.alignments.should.eql('lblt'.split(''))
+    should.not.exist(dd._.dropdown)
+    dd._.visible.should.equal(false)
+    dd.options.ddClass.should.equal('')
+    dd.options.mode.should.equal('click')
 
 
   it 'should set the mode correctly for click', ->
     dd = new hx.Dropdown(id, content, {mode: 'click'})
 
-    expect(dd._.selection.node().__hx__.eventEmitter.has('click')).toEqual(true)
-    expect(dd._.selection.node().__hx__.eventEmitter.has('mouseover')).toEqual(false)
-    expect(dd._.selection.node().__hx__.eventEmitter.has('mouseout')).toEqual(false)
+    dd._.selection.node().__hx__.eventEmitter.has('click').should.equal(true)
+    dd._.selection.node().__hx__.eventEmitter.has('mouseover').should.equal(false)
+    dd._.selection.node().__hx__.eventEmitter.has('mouseout').should.equal(false)
 
     dd = new hx.Dropdown(id, content, {mode: 'hover'})
-    expect(dd._.selection.node().__hx__.eventEmitter.has('click')).toEqual(true)
-    expect(dd._.selection.node().__hx__.eventEmitter.has('mouseover')).toEqual(true)
-    expect(dd._.selection.node().__hx__.eventEmitter.has('mouseout')).toEqual(true)
+    dd._.selection.node().__hx__.eventEmitter.has('click').should.equal(true)
+    dd._.selection.node().__hx__.eventEmitter.has('mouseover').should.equal(true)
+    dd._.selection.node().__hx__.eventEmitter.has('mouseout').should.equal(true)
 
 
   it 'should set the alignment correctly', ->
     dd = new hx.Dropdown(id, content, {align: 'rbrb'})
-    expect(dd._.alignments).toEqual('rbrb'.split(''))
+    dd._.alignments.should.eql('rbrb'.split(''))
 
   it 'should use the right alignment option when a named align value is used', ->
     dd = new hx.Dropdown(id, content, {align: 'up'})
-    expect(dd._.alignments).toEqual('ltlb'.split(''))
+    dd._.alignments.should.eql('ltlb'.split(''))
 
     dd = new hx.Dropdown(id, content, {align: 'down'})
-    expect(dd._.alignments).toEqual('lblt'.split(''))
+    dd._.alignments.should.eql('lblt'.split(''))
 
     dd = new hx.Dropdown(id, content, {align: 'left'})
-    expect(dd._.alignments).toEqual('ltrt'.split(''))
+    dd._.alignments.should.eql('ltrt'.split(''))
 
     dd = new hx.Dropdown(id, content, {align: 'right'})
-    expect(dd._.alignments).toEqual('rtlt'.split(''))
+    dd._.alignments.should.eql('rtlt'.split(''))
 
   it 'should set the spacing correctly', ->
     dd = new hx.Dropdown(id, content, {spacing: 10} )
-    expect(getSpacing(dd)).toEqual(10)
+    getSpacing(dd).should.equal(10)
 
 
   # it 'should use the spacing correctly', ->
   #   dd = new hx.Dropdown(id, content, {spacing: 10})
   #   dd.show()
   #   buttonBox = button.box()
-  #   jasmine.clock().tick(301)
+  #   clock.tick(301)
   #   console.log(hx.select('body').node())
   #   ddBox = dd._.dropdown.box()
-  #   expect(ddBox.left).toEqual(buttonBox.left)
-  #   expect(ddBox.top).toEqual(buttonBox.top + buttonBox.height + getSpacing(dd))
+  #   ddBox.left.should.equal(buttonBox.left)
+  #   ddBox.top.should.equal(buttonBox.top + buttonBox.height + getSpacing(dd))
 
 
   it 'should set the matchWidth property correctly', ->
     dd = new hx.Dropdown(id, content, {matchWidth: false} )
-    expect(dd.options.matchWidth).toEqual(false)
+    dd.options.matchWidth.should.equal(false)
 
     dd = new hx.Dropdown(id, content, {matchWidth: true} )
-    expect(dd.options.matchWidth).toEqual(true)
+    dd.options.matchWidth.should.equal(true)
 
   it 'should set the ddClass correctly', ->
     dd = new hx.Dropdown(id, content, { ddClass: 'bob' })
-    expect(dd.options.ddClass).toEqual('bob')
+    dd.options.ddClass.should.equal('bob')
 
   it 'should call toggle the selector is clicked in click mode', ->
     dd = new hx.Dropdown(id, content)
-    spyOn(dd, 'toggle')
+    chai.spy.on(dd, 'toggle')
     dd._.selection.node().__hx__.eventEmitter.emit('click')
-    expect(dd.toggle).toHaveBeenCalled()
+    dd.toggle.should.have.been.called()
 
   it 'should call show/hide on mouseover/mouseout in hover mode', ->
     dd = new hx.Dropdown(id, content, {mode: 'hover'})
-    spyOn(dd, 'show')
-    spyOn(dd, 'hide')
-    spyOn(dd, 'toggle')
+    chai.spy.on(dd, 'show')
+    chai.spy.on(dd, 'hide')
+    chai.spy.on(dd, 'toggle')
 
     dd._.selection.node().__hx__.eventEmitter.emit('mouseover')
-    expect(dd.show).toHaveBeenCalled()
+    dd.show.should.have.been.called()
 
     dd._.selection.node().__hx__.eventEmitter.emit('mouseout')
-    expect(dd.hide).toHaveBeenCalled()
+    dd.hide.should.have.been.called()
 
     dd._.selection.node().__hx__.eventEmitter.emit('click')
-    expect(dd.toggle).toHaveBeenCalled()
+    dd.toggle.should.have.been.called()
 
   it 'should correctly detect if the dropdown is open', ->
     dd = new hx.Dropdown(id, content)
-    expect(dd.isOpen()).toEqual(false)
+    dd.isOpen().should.equal(false)
     dd.show()
-    expect(dd.isOpen()).toEqual(true)
+    dd.isOpen().should.equal(true)
     dd.hide()
-    expect(dd.isOpen()).toEqual(false)
+    dd.isOpen().should.equal(false)
     dd.toggle()
-    expect(dd.isOpen()).toEqual(true)
+    dd.isOpen().should.equal(true)
     dd.toggle()
-    expect(dd.isOpen()).toEqual(false)
+    dd.isOpen().should.equal(false)
 
   it 'should exist on the page when opened and set the visible property to true', ->
     dd = new hx.Dropdown(id, content)
-    expect(dd._.visible).toEqual(false)
-    expect(hx.select('.hx-dropdown').empty()).toEqual(true)
+    dd._.visible.should.equal(false)
+    hx.select('.hx-dropdown').empty().should.equal(true)
 
     dd._.selection.node().__hx__.eventEmitter.emit('click')
 
-    expect(dd._.visible).toEqual(true)
-    expect(hx.select('.hx-dropdown').empty()).toEqual(false)
-    expect(hx.select('.hx-dropdown').html()).toEqual(content)
+    dd._.visible.should.equal(true)
+    hx.select('.hx-dropdown').empty().should.equal(false)
+    hx.select('.hx-dropdown').html().should.equal(content)
 
   it 'should not do anything if show is called and the dropdown is already open', ->
     dd = new hx.Dropdown(id, content)
-    expect(dd._.visible).toEqual(false)
-    expect(hx.select('.hx-dropdown').empty()).toEqual(true)
+    dd._.visible.should.equal(false)
+    hx.select('.hx-dropdown').empty().should.equal(true)
 
     dd.show()
-    expect(dd._.visible).toEqual(true)
-    expect(hx.select('.hx-dropdown').empty()).toEqual(false)
-    expect(hx.select('.hx-dropdown').html()).toEqual(content)
+    dd._.visible.should.equal(true)
+    hx.select('.hx-dropdown').empty().should.equal(false)
+    hx.select('.hx-dropdown').html().should.equal(content)
 
     dd.show()
-    expect(dd._.visible).toEqual(true)
-    expect(hx.select('.hx-dropdown').empty()).toEqual(false)
-    expect(hx.select('.hx-dropdown').html()).toEqual(content)
+    dd._.visible.should.equal(true)
+    hx.select('.hx-dropdown').empty().should.equal(false)
+    hx.select('.hx-dropdown').html().should.equal(content)
 
   it 'should not do anything if hide is called and the dropdown is already closed', ->
     dd = new hx.Dropdown(id, content)
-    spyOn(dd._.clickDetector, 'off')
-    expect(dd._.visible).toEqual(false)
-    expect(hx.select('.hx-dropdown').empty()).toEqual(true)
+    chai.spy.on(dd._.clickDetector, 'off')
+    dd._.visible.should.equal(false)
+    hx.select('.hx-dropdown').empty().should.equal(true)
 
     dd.hide()
-    expect(dd._.visible).toEqual(false)
-    expect(hx.select('.hx-dropdown').empty()).toEqual(true)
-    expect(dd._.clickDetector.off).not.toHaveBeenCalled()
+    dd._.visible.should.equal(false)
+    hx.select('.hx-dropdown').empty().should.equal(true)
+    dd._.clickDetector.off.should.have.not.been.called()
 
   it 'should call the clean up the click detector', ->
     dd = new hx.Dropdown(id, content)
-    spyOn(dd._.clickDetector, 'cleanUp')
+    chai.spy.on(dd._.clickDetector, 'cleanUp')
     dd.cleanUp()
-    expect(dd._.clickDetector.cleanUp).toHaveBeenCalled()
+    dd._.clickDetector.cleanUp.should.have.been.called()
 
   it 'should call hide when an element other than the button is clicked', ->
     dd = new hx.Dropdown(id, content)
-    spyOn(dd, 'hide')
+    chai.spy.on(dd, 'hide')
     dd.show()
     document.__hx__.eventEmitter.emit('pointerdown', { event: {target: fixture.node()}})
     document.__hx__.eventEmitter.emit('pointerup', { event: {target: fixture.node()}})
-    expect(dd.hide).toHaveBeenCalled()
+    dd.hide.should.have.been.called()
 
   # it 'should detect parent z-index and set the index to be 1 greater', ->
   #   fixture.style('z-index', 100)
   #   dd = new hx.Dropdown(id, content)
   #   dd.show()
-  #   expect(dd._.dropdown.style('z-index')).toEqual('101')
+  #   dd._.dropdown.style('z-index').should.equal('101')
 
   it 'should detect parent position and match it correctly', ->
     fixture.style('position', 'fixed')
 
     dd = new hx.Dropdown(id, content)
     dd.show()
-    expect(dd._.dropdown.style('position')).toEqual('fixed')
+    dd._.dropdown.style('position').should.equal('fixed')
 
   it 'should render correctly using a function as content', ->
     populate = (elem) ->
@@ -268,34 +268,34 @@ describe 'hx-dropdown', ->
 
     dd.show()
     # uses fixture bg as hex gets converted to different things by different browsers
-    expect(dd._.dropdown.select('.bob').text()).toEqual('Dave')
+    dd._.dropdown.select('.bob').text().should.equal('Dave')
 
 
   it 'should class the dropdown with the supplied dd class', ->
     dd = new hx.Dropdown(id, content, {ddClass: 'bob'})
     dd.show()
-    expect(dd._.dropdown.classed('bob')).toEqual(true)
+    dd._.dropdown.classed('bob').should.equal(true)
 
   it 'should show and hide correctly', ->
     dd = new hx.Dropdown(id, content)
 
-    expect(dd._.visible).toEqual(false)
-    expect(hx.select('.hx-dropdown').empty()).toEqual(true)
+    dd._.visible.should.equal(false)
+    hx.select('.hx-dropdown').empty().should.equal(true)
 
     dd.show()
-    expect(dd._.visible).toEqual(true)
-    expect(hx.select('.hx-dropdown').empty()).toEqual(false)
+    dd._.visible.should.equal(true)
+    hx.select('.hx-dropdown').empty().should.equal(false)
 
     dd.hide()
-    expect(dd._.visible).toEqual(false)
-    expect(hx.select('.hx-dropdown').empty()).toEqual(true)
+    dd._.visible.should.equal(false)
+    hx.select('.hx-dropdown').empty().should.equal(true)
 
-  it 'should set the overflow style when the useScroll option is specified', ->
+  it 'should set the overflow style when the useScroll (private) option is specified', ->
     dd = new hx.Dropdown(id, content)
-    dd.useScroll = true
+    dd._.useScroll = true
     dd.show()
-    jasmine.clock().tick(300)
-    expect(dd._.dropdown.style('overflow-y')).toEqual('auto')
+    clock.tick(300)
+    dd._.dropdown.style('overflow-y').should.equal('auto')
 
   it 'shouldnt try to match the width of the parent if matchWidth is false', ->
     button.text('Wider button for testing')
@@ -304,8 +304,8 @@ describe 'hx-dropdown', ->
     dd = new hx.Dropdown(id, content, {matchWidth: false })
 
     dd.show()
-    expect(dd._.dropdown.style('min-width')).toEqual('0px')
-    jasmine.clock().tick(301)
+    dd._.dropdown.style('min-width').should.equal('0px')
+    clock.tick(301)
 
   it 'should try to match the width of the parent if matchWidth is true', ->
     button.text('Wider button for testing')
@@ -313,8 +313,8 @@ describe 'hx-dropdown', ->
     dd = new hx.Dropdown(id, content, {matchWidt: true })
 
     dd.show()
-    expect(dd._.dropdown.style('min-width')).toEqual(button.style('width'))
-    jasmine.clock().tick(301)
+    dd._.dropdown.style('min-width').should.equal(button.style('width'))
+    clock.tick(301)
 
   # it 'should detect the maxHeight properly', ->
   #   hx.select('head').append('style').attr('id','style').attr('type', 'text/css').text("""
@@ -329,12 +329,12 @@ describe 'hx-dropdown', ->
   #   dd.show()
   #   setTimeout ->
   #     ddBox = roundAll dd._.dropdown.box()
-  #     expect(dd._.dropdown.style('max-height')).toEqual('5px')
-  #     expect(ddBox.left).toEqual(buttonBox.left)
-  #     expect(ddBox.height).toEqual(5)
+  #     dd._.dropdown.style('max-height').should.equal('5px')
+  #     ddBox.left.should.equal(buttonBox.left)
+  #     ddBox.height.should.equal(5)
   #     hx.select('#style').remove()
   #   , 300
-  #   jasmine.clock().tick(301)
+  #   clock.tick(301)
 
   it 'should shift the dropdown down if shifting it up has moved it off the top of the screen', ->
     dd = new hx.Dropdown(id, content, {align: 'up'})
@@ -345,10 +345,10 @@ describe 'hx-dropdown', ->
     dd.show()
     setTimeout ->
       ddBox = roundAll dd._.dropdown.box()
-      expect(ddBox.top).toEqual(buttonBox.top + buttonBox.height + getSpacing(dd))
-      expect(ddBox.left).toEqual(buttonBox.left)
+      ddBox.top.should.equal(buttonBox.top + buttonBox.height + getSpacing(dd))
+      ddBox.left.should.equal(buttonBox.left)
     , 300
-    jasmine.clock().tick(301)
+    clock.tick(301)
 
 
   describe 'align', ->
@@ -364,68 +364,68 @@ describe 'hx-dropdown', ->
       tests = [
           align: null
           check: ->
-            expect(ddBox.left).toEqual(buttonBox.left)
-            expect(ddBox.top).toEqual(buttonBox.bottom + getSpacing(dd))
+            ddBox.left.should.equal(buttonBox.left)
+            ddBox.top.should.equal(buttonBox.bottom + getSpacing(dd))
         ,
           align: 'up'
           check: ->
-            expect(ddBox.left).toEqual(buttonBox.left)
-            expect(ddBox.top).toEqual(buttonBox.top - ddBox.height - getSpacing(dd))
+            ddBox.left.should.equal(buttonBox.left)
+            ddBox.top.should.equal(buttonBox.top - ddBox.height - getSpacing(dd))
         ,
           align: 'down'
           check: ->
-            expect(ddBox.left).toEqual(buttonBox.left)
-            expect(ddBox.top).toEqual(buttonBox.bottom + getSpacing(dd))
+            ddBox.left.should.equal(buttonBox.left)
+            ddBox.top.should.equal(buttonBox.bottom + getSpacing(dd))
         ,
           align: 'left'
           check: ->
-            expect(ddBox.right).toEqual(buttonBox.left - getSpacing(dd))
-            expect(ddBox.top).toEqual(buttonBox.top)
+            ddBox.right.should.equal(buttonBox.left - getSpacing(dd))
+            ddBox.top.should.equal(buttonBox.top)
         ,
           align: 'right'
           check: ->
-            expect(ddBox.left).toEqual(buttonBox.right + getSpacing(dd))
-            expect(ddBox.top).toEqual(buttonBox.top)
+            ddBox.left.should.equal(buttonBox.right + getSpacing(dd))
+            ddBox.top.should.equal(buttonBox.top)
         ,
           align: 'lbrb'
           check: ->
-            expect(ddBox.right).toEqual(buttonBox.left - getSpacing(dd))
-            expect(ddBox.bottom).toEqual(buttonBox.bottom)
+            ddBox.right.should.equal(buttonBox.left - getSpacing(dd))
+            ddBox.bottom.should.equal(buttonBox.bottom)
         ,
           align: 'lbrt'
           check: ->
-            expect(ddBox.right).toEqual(buttonBox.left - getSpacing(dd))
-            expect(ddBox.top).toEqual(buttonBox.top + buttonBox.height + getSpacing(dd))
+            ddBox.right.should.equal(buttonBox.left - getSpacing(dd))
+            ddBox.top.should.equal(buttonBox.top + buttonBox.height + getSpacing(dd))
         ,
           align: 'ltrb'
           check: ->
-            expect(ddBox.right).toEqual(buttonBox.left - getSpacing(dd))
-            expect(ddBox.bottom).toEqual(buttonBox.top - getSpacing(dd))
+            ddBox.right.should.equal(buttonBox.left - getSpacing(dd))
+            ddBox.bottom.should.equal(buttonBox.top - getSpacing(dd))
         ,
           align: 'rblt'
           check: ->
-            expect(ddBox.left).toEqual(buttonBox.right + getSpacing(dd))
-            expect(ddBox.top).toEqual(buttonBox.bottom + getSpacing(dd))
+            ddBox.left.should.equal(buttonBox.right + getSpacing(dd))
+            ddBox.top.should.equal(buttonBox.bottom + getSpacing(dd))
         ,
           align: 'rblb'
           check: ->
-            expect(ddBox.left).toEqual(buttonBox.right + getSpacing(dd))
-            expect(ddBox.bottom).toEqual(buttonBox.bottom)
+            ddBox.left.should.equal(buttonBox.right + getSpacing(dd))
+            ddBox.bottom.should.equal(buttonBox.bottom)
         ,
           align: 'rbrt'
           check: ->
-            expect(ddBox.right).toEqual(buttonBox.right)
-            expect(ddBox.top).toEqual(buttonBox.bottom + getSpacing(dd))
+            ddBox.right.should.equal(buttonBox.right)
+            ddBox.top.should.equal(buttonBox.bottom + getSpacing(dd))
         ,
           align: 'rtlb'
           check: ->
-            expect(ddBox.left).toEqual(buttonBox.right + getSpacing(dd))
-            expect(ddBox.top).toEqual(buttonBox.top - ddBox.height - getSpacing(dd))
+            ddBox.left.should.equal(buttonBox.right + getSpacing(dd))
+            ddBox.top.should.equal(buttonBox.top - ddBox.height - getSpacing(dd))
         ,
           align: 'rtrb'
           check: ->
-            expect(ddBox.right).toEqual(buttonBox.right)
-            expect(ddBox.bottom).toEqual(buttonBox.top - getSpacing(dd))
+            ddBox.right.should.equal(buttonBox.right)
+            ddBox.bottom.should.equal(buttonBox.top - getSpacing(dd))
       ]
 
       t = (test, index) ->
@@ -438,7 +438,7 @@ describe 'hx-dropdown', ->
             ddBox = roundAll dd._.dropdown.box()
             test.check()
           , 300
-          jasmine.clock().tick(301)
+          clock.tick(301)
 
         if index < tests.length
           t(tests[index], index + 1)
@@ -453,19 +453,19 @@ describe 'hx-dropdown', ->
       tests = [
         pos: 'left'
         check: ->
-          expect(ddBox.left).toEqual(0)
+          ddBox.left.should.equal(0)
       ,
         pos: 'top'
         check: ->
-          expect(ddBox.top).toEqual(0)
+          ddBox.top.should.equal(0)
       ,
         pos: 'right'
         check: ->
-          expect(ddBox.left).toEqual(window.innerWidth - ddBox.width - scrollbarWidth)
+          ddBox.left.should.equal(window.innerWidth - ddBox.width - scrollbarWidth)
       ,
         pos: 'bottom'
         check: ->
-          expect(ddBox.top).toEqual(window.innerHeight - ddBox.height)
+          ddBox.top.should.equal(window.innerHeight - ddBox.height)
       ]
 
       t = (test, index) ->
@@ -485,7 +485,7 @@ describe 'hx-dropdown', ->
             ddBox = roundAll dd._.dropdown.box()
             test.check()
           , 300
-          jasmine.clock().tick(301)
+          clock.tick(301)
 
         if index < tests.length
           t(tests[index], index + 1)
@@ -496,28 +496,28 @@ describe 'hx-dropdown', ->
       tests = [
         align: 'rbrb'
         check: ->
-          expect(ddBox.top).toEqual(buttonBox.bottom + getSpacing(dd))
-          expect(ddBox.right).toEqual(buttonBox.right)
+          ddBox.top.should.equal(buttonBox.bottom + getSpacing(dd))
+          ddBox.right.should.equal(buttonBox.right)
       ,
         align: 'lblb'
         check: ->
-          expect(ddBox.top).toEqual(buttonBox.bottom + getSpacing(dd))
-          expect(ddBox.left).toEqual(buttonBox.left)
+          ddBox.top.should.equal(buttonBox.bottom + getSpacing(dd))
+          ddBox.left.should.equal(buttonBox.left)
       ,
         align: 'rtrt'
         check: ->
-          expect(ddBox.bottom).toEqual(buttonBox.top - getSpacing(dd))
-          expect(ddBox.right).toEqual(buttonBox.right)
+          ddBox.bottom.should.equal(buttonBox.top - getSpacing(dd))
+          ddBox.right.should.equal(buttonBox.right)
       ,
         align: 'ltlt'
         check: ->
-          expect(ddBox.bottom).toEqual(buttonBox.top - getSpacing(dd))
-          expect(ddBox.left).toEqual(buttonBox.left)
+          ddBox.bottom.should.equal(buttonBox.top - getSpacing(dd))
+          ddBox.left.should.equal(buttonBox.left)
       ,
         align: 'cover'
         check: ->
-          expect(ddBox.top).toEqual(buttonBox.bottom + getSpacing(dd))
-          expect(ddBox.left).toEqual(buttonBox.left)
+          ddBox.top.should.equal(buttonBox.bottom + getSpacing(dd))
+          ddBox.left.should.equal(buttonBox.left)
       ]
 
       t = (test, index) ->
@@ -531,7 +531,7 @@ describe 'hx-dropdown', ->
             ddBox = roundAll dd._.dropdown.box()
             test.check()
           , 300
-          jasmine.clock().tick(301)
+          clock.tick(301)
 
         if index < tests.length
           t(tests[index], index + 1)

--- a/modules/dropdown/test/spec.coffee
+++ b/modules/dropdown/test/spec.coffee
@@ -91,14 +91,12 @@ describe 'hx-dropdown', ->
     spyOn(console, 'error')
     dd = new hx.Dropdown(id, hx.detached('div'))
     dd.show()
-    expect(console.error).toHaveBeenCalledWith('hexagon: dropdownContent is not a valid type ' + id)
+    expect(console.error).toHaveBeenCalledWith('dropdown: dropdownContent is not a valid type ' + id)
 
   it 'should create a dropdown object with the correct default options', ->
     dd = new hx.Dropdown(id, content)
 
-    expect(dd.selector).toEqual(id)
     expect(dd.selection).toEqual(button)
-    expect(dd.dropdownContent).toEqual(content)
     expect(getSpacing(dd)).toEqual(0)
     expect(dd.options.matchWidth).toEqual(true)
     expect(dd.alignments).toEqual('lblt'.split(''))
@@ -226,20 +224,20 @@ describe 'hx-dropdown', ->
 
   it 'should not do anything if hide is called and the dropdown is already closed', ->
     dd = new hx.Dropdown(id, content)
-    spyOn(dd.clickDetector, 'off')
+    spyOn(dd._.clickDetector, 'off')
     expect(dd.visible).toEqual(false)
     expect(hx.select('.hx-dropdown').empty()).toEqual(true)
 
     dd.hide()
     expect(dd.visible).toEqual(false)
     expect(hx.select('.hx-dropdown').empty()).toEqual(true)
-    expect(dd.clickDetector.off).not.toHaveBeenCalled()
+    expect(dd._.clickDetector.off).not.toHaveBeenCalled()
 
   it 'should call the clean up the click detector', ->
     dd = new hx.Dropdown(id, content)
-    spyOn(dd.clickDetector, 'cleanUp')
+    spyOn(dd._.clickDetector, 'cleanUp')
     dd.cleanUp()
-    expect(dd.clickDetector.cleanUp).toHaveBeenCalled()
+    expect(dd._.clickDetector.cleanUp).toHaveBeenCalled()
 
   it 'should call hide when an element other than the button is clicked', ->
     dd = new hx.Dropdown(id, content)

--- a/modules/dropdown/test/spec.coffee
+++ b/modules/dropdown/test/spec.coffee
@@ -58,8 +58,7 @@ describe 'hx-dropdown', ->
     hx.loop = hx_loop = (f) ->
       g = -> hx_loop_update(f, g)
       hx_loop_update(f, g)
-    baseTime = new Date(2013, 0, 1)
-    clock = sinon.useFakeTimers(baseTime.getTime())
+    clock = sinon.useFakeTimers()
 
   afterAll ->
     fixture.remove()

--- a/modules/inline-picker/main/index.coffee
+++ b/modules/inline-picker/main/index.coffee
@@ -43,7 +43,7 @@ class InlinePicker extends hx.InlineMorphSection
       options.renderer = @picker.renderer()
 
     @picker.menu.dropdown.on 'showstart', 'hx.inline-picker', =>
-      this.detector.addException(@picker.menu.dropdown.dropdown.node())
+      this.detector.addException(@picker.menu.dropdown._.dropdown.node())
 
     super(@selector, enterEditMode, exitEditMode, options)
 

--- a/modules/menu/main/index.coffee
+++ b/modules/menu/main/index.coffee
@@ -31,7 +31,7 @@ getAllItems = (menu) ->
 # If setActive is called on click, the dropdown is already hidden so
 # offsetParent checking doesn't work.
 setActive = (menu, pos, up, click) ->
-  menu.dropdown.dropdown?.selectAll('.hx-menu-item').classed('hx-menu-active',false)
+  menu.dropdown._.dropdown?.selectAll('.hx-menu-item').classed('hx-menu-active',false)
   if pos >= 0
     allItems = getAllItems(menu)
     node = allItems[pos].node
@@ -56,7 +56,7 @@ setActive = (menu, pos, up, click) ->
       return undefined
     else
       menu.cursorPos = pos
-      if (dNode = menu.dropdown.dropdown?.node())? and not click
+      if (dNode = menu.dropdown._.dropdown?.node())? and not click
         menuNode = hx.select(node).classed('hx-menu-active',true)
 
         mNode = menuNode.node()
@@ -242,8 +242,8 @@ class Menu extends hx.EventEmitter
     @dropdown = new hx.Dropdown(@selector, dropdownContent, @options.dropdownOptions)
 
     @dropdown.on 'showend', =>
-      if @dropdown.dropdown?
-        node = @dropdown.dropdown.node()
+      if @dropdown._.dropdown?
+        node = @dropdown._.dropdown.node()
         ddNode = hx.select(node)
         if node.scrollTop < node.scrollHeight - node.clientHeight
           ddNode.style('width', ddNode.width() + hx.scrollbarSize() + 'px')
@@ -278,7 +278,7 @@ class Menu extends hx.EventEmitter
       self.cursorPos = -1
 
       if !isInput
-        targetElem = self.dropdown.dropdown
+        targetElem = self.dropdown._.dropdown
         targetElem.attr('tabindex','-1')
         targetElem.node().focus()
 
@@ -287,7 +287,7 @@ class Menu extends hx.EventEmitter
           checkEvent(e, self)
         self.emit 'keydown', e
 
-      self.dropdown.dropdown
+      self.dropdown._.dropdown
         .on 'click', 'hx.menu', (e) ->
           # get the closest menu item - uses nodes as blank selection can be
           # returned if the target is a hx-menu-item


### PR DESCRIPTION
This change does a couple of things:
 - Moves all things in dropdown that are not documented onto an underscore object
 - Separates the calculation of the dropdown position from the dom querying and dom manipulation (which will hopefully make the tests not fail occasionally)
 - Converts the tests over to use chai