### PR TITLE
Increase the performance of View

### DIFF
--- a/modules/menu/main/index.coffee
+++ b/modules/menu/main/index.coffee
@@ -287,31 +287,30 @@ class Menu extends hx.EventEmitter
           checkEvent(e, self)
         self.emit 'keydown', e
 
-      self.dropdown._.dropdown
-        .on 'click', 'hx.menu', (e) ->
-          # get the closest menu item - uses nodes as blank selection can be
-          # returned if the target is a hx-menu-item
+      self.dropdown._.dropdown?.on 'click', 'hx.menu', (e) ->
+        # get the closest menu item - uses nodes as blank selection can be
+        # returned if the target is a hx-menu-item
 
-          target = if hx.select(e.target).classed('hx-menu-link')
-            e.target
-          else
-            hx.select(e.target).closest('.hx-menu-item').node()
+        target = if hx.select(e.target).classed('hx-menu-link')
+          e.target
+        else
+          hx.select(e.target).closest('.hx-menu-item').node()
 
-          if target
+        if target
 
-            index = -1
+          index = -1
 
-            t = hx.select(target)
-            if t.classed('hx-menu-link')
-              allItems = getAllItems(self)
-              i = 0
-              while index < 0 and i < allItems.length
-                if allItems[i].node is target
-                  index = i
-                  break
-                i += 1
-              setActive(self, index, undefined, true)
-            targetElem.node().focus()
+          t = hx.select(target)
+          if t.classed('hx-menu-link')
+            allItems = getAllItems(self)
+            i = 0
+            while index < 0 and i < allItems.length
+              if allItems[i].node is target
+                index = i
+                break
+              i += 1
+            setActive(self, index, undefined, true)
+          targetElem.node().focus()
 
 
     # pipe the dropdown events through

--- a/modules/view/main/index.coffee
+++ b/modules/view/main/index.coffee
@@ -71,23 +71,22 @@ class View
       viewEnterWarning = (element, selector) ->
         hx.consoleWarning "view enter fn returned", element, "! It didn't match selector", selector, ", so you may encounter odd behavior"
 
+      classes = @selector.split('.')
+      selectorContainsClasses = classes.length > 1
+      classString = classes.slice(1).join(' ')
+
       newNodeSet = enterSet.map (d, i) =>
         datum = d.datum
         element = @new.call @rootSelection, d.datum, i
 
-        if @selector.indexOf('.') >= 0
-          classes = @selector.split('.')
-          isChild = @rootSelection.node().contains(element)
-
-          # Checks isChild first as it's the quickest operation
-          if not isChild
-            viewEnterWarning(element, @selector)
-          else
-            isClassedCorrectly = hx.select(element).classed(classes.slice(1).join(' '))
-            if typeof isClassedCorrectly isnt 'boolean'
-              isClassedCorrectly = isClassedCorrectly.every((e) -> e)
-            viewEnterWarning(element, @selector) unless isClassedCorrectly
-
+        # Checks isChild first as it's the quickest operation
+        isChild = @rootSelection.node().contains(element)
+        if not isChild
+          viewEnterWarning(element, @selector)
+        # Only do this check if the selector actually contains classes to check
+        else if selectorContainsClasses
+          isClassedCorrectly = hx.select(element).classed(classString)
+          viewEnterWarning(element, @selector) unless isClassedCorrectly
 
         hedo = hx.select.getHexagonElementDataObject element
         hedo.datum = datum

--- a/modules/view/main/index.coffee
+++ b/modules/view/main/index.coffee
@@ -2,12 +2,12 @@
 class View
   constructor: (@rootSelection, @selector, @defaultType) ->
     self = this
+    elementType = self.selector.split('.')[0]
+    classes = self.selector.split('.').slice(1).join ' '
     @new = (datum) ->
-      [elementType, classes...] = self.selector.split '.'
-      node = @append elementType or self.defaultType
-        .class classes.join ' '
+      @append elementType or self.defaultType
+        .class classes
         .node()
-      node
     @each = (datum, element) ->
     @old = (datum, element) -> @remove()
   enter: (f) -> @new = f; this
@@ -68,14 +68,26 @@ class View
           for j in [i..data.length-1]
             enterSet.push {datum: data[j]}
 
+      viewEnterWarning = (element, selector) ->
+        hx.consoleWarning "view enter fn returned", element, "! It didn't match selector", selector, ", so you may encounter odd behavior"
 
       newNodeSet = enterSet.map (d, i) =>
         datum = d.datum
         element = @new.call @rootSelection, d.datum, i
-        subselection = @rootSelection.selectAll @selector
 
-        unless element in subselection.nodes
-          hx.consoleWarning "view enter fn returned", element, "! It didn't match selector", @selector, ", so you may encounter odd behavior"
+        if @selector.indexOf('.') >= 0
+          classes = @selector.split('.')
+          isChild = @rootSelection.node().contains(element)
+
+          # Checks isChild first as it's the quickest operation
+          if not isChild
+            viewEnterWarning(element, @selector)
+          else
+            isClassedCorrectly = hx.select(element).classed(classes.slice(1).join(' '))
+            if typeof isClassedCorrectly isnt 'boolean'
+              isClassedCorrectly = isClassedCorrectly.every((e) -> e)
+            viewEnterWarning(element, @selector) unless isClassedCorrectly
+
 
         hedo = hx.select.getHexagonElementDataObject element
         hedo.datum = datum

--- a/modules/view/test/spec.coffee
+++ b/modules/view/test/spec.coffee
@@ -1,19 +1,50 @@
 describe 'hx-view', ->
+  origConsoleWarning = hx.consoleWarning
+
+  beforeEach ->
+    hx.consoleWarning = chai.spy()
+
+  afterEach ->
+    hx.consoleWarning = origConsoleWarning
+
   it "should create elements of a given type using the default view enter fn", ->
     selection = hx.detached('div')
     selection.view('element-type').apply([1..3])
     selection.selectAll('element-type').size().should.equal(3)
+    hx.consoleWarning.should.not.have.been.called()
 
   it "should create elements of a given class using the default view enter fn", ->
     selection = hx.detached('div')
     selection.view('.class').apply([1..3])
     selection.selectAll('.class').size().should.equal(3)
+    hx.consoleWarning.should.not.have.been.called()
 
   it "should create slightly more complicated elements with the default view enter fn", ->
     selection = hx.detached('div')
     selection.view('element-type.class-onion.class-lemon').apply([1..3])
     selection.selectAll('element-type.class-onion.class-lemon').size().should.equal(3)
+    hx.consoleWarning.should.not.have.been.called()
 
+  it "should show a warning when the returned element does not match the selector passed in", ->
+    selection = hx.detached('div')
+    selection.view('.class')
+      .enter (datum) -> @append('div').node()
+      .apply([1..3])
+    hx.consoleWarning.should.have.been.called()
+
+  it "should show a warning when the returned element does not match the selector passed in with extra classes added", ->
+    selection = hx.detached('div')
+    selection.view('.class')
+      .enter (datum) -> @append('div').class('dave').node()
+      .apply([1..3])
+    hx.consoleWarning.should.have.been.called()
+
+  it "should show a warning when the returned element is not a child of the view", ->
+    selection = hx.detached('div')
+    selection.view('.class')
+      .enter (datum) -> hx.detached('div').class('class').node()
+      .apply([1..3])
+    hx.consoleWarning.should.have.been.called()
 
   it "should support update functions", ->
     selection = hx.detached('div')
@@ -23,6 +54,7 @@ describe 'hx-view', ->
       .apply([1..3])
 
     selection.selectAll('.class').text().should.eql(["2", "3", "4"])
+    hx.consoleWarning.should.not.have.been.called()
 
   it "should create additional elements as needed", ->
     selection = hx.detached('div')
@@ -33,6 +65,7 @@ describe 'hx-view', ->
       .apply([1..4])
 
     selection.selectAll('.class').text().should.eql(["2", "3", "4", "5"])
+    hx.consoleWarning.should.not.have.been.called()
 
   it "should remove additional elements as needed", ->
     selection = hx.detached('div')
@@ -43,4 +76,5 @@ describe 'hx-view', ->
       .apply([1..2])
 
     selection.selectAll('.class').text().should.eql(["2", "3"])
+    hx.consoleWarning.should.not.have.been.called()
 


### PR DESCRIPTION
fix for #148 

The below test case shows an autocomplete with 10000 items which renders in around 1 second, as opposed to previously when it rendered in around 30-40 seconds.
```html
<input id="test" />
<script>
  new hx.AutoComplete('#test', hx.range(10000))
</script>
```