### PR TITLE
Ensure that the locale is initialised to something

### DIFF
--- a/modules/preferences/main/index.coffee
+++ b/modules/preferences/main/index.coffee
@@ -207,8 +207,8 @@ class Preferences extends hx.EventEmitter
       modal: modal
     }
 
-    defaultLocaleId = moment?.locale() or navigator.language or 'en'
-    if not lookupLocale(defaultLocaleId)
+    defaultLocaleId = moment?.locale() or navigator.language
+    if not (hx.isString(defaultLocaleId) and lookupLocale(defaultLocaleId))
       defaultLocaleId = 'en'
     @locale defaultLocaleId
     @timezone moment?.tz?.guess() or 'UTC+00:00'

--- a/modules/preferences/main/index.coffee
+++ b/modules/preferences/main/index.coffee
@@ -207,7 +207,10 @@ class Preferences extends hx.EventEmitter
       modal: modal
     }
 
-    @locale moment?.locale() or navigator.language or 'en'
+    defaultLocaleId = moment?.locale() or navigator.language or 'en'
+    if not lookupLocale(defaultLocaleId)
+      defaultLocaleId = 'en'
+    @locale defaultLocaleId
     @timezone moment?.tz?.guess() or 'UTC+00:00'
 
   timezone: (timezone) ->

--- a/modules/preferences/test/spec.coffee
+++ b/modules/preferences/test/spec.coffee
@@ -68,4 +68,3 @@ describe 'hx-preferences', ->
         spy = chai.spy.on(hx, 'consoleWarning')
         hx.preferences.timezone('America').should.equal(hx.preferences)
         spy.should.have.been.called()
-


### PR DESCRIPTION
When navigator.language is set to a non supported locale, if will fall back to 'en'