### PR TITLE
Update list of node versions to test in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
-  - "4.1"
-  - "4.0"
+  - "4"
   - "0.12"
   - "0.11"
-  - "iojs"
 script: npm test && npm run combine-coverage && npm run upload-coverage


### PR DESCRIPTION
It will now test only the latest version of 4.x.x (along with 0.12,  0.11). iojs support dropped