### PR TITLE
Autocomplete Fix

### DIFF
--- a/modules/autocomplete/main/index.coffee
+++ b/modules/autocomplete/main/index.coffee
@@ -139,7 +139,7 @@ buildAutoComplete = (searchTerm, fromCallback, loading) ->
     if items.length > 0
       _.menu.items(items)
       if _.menu.dropdown.isOpen()
-        _.menu.dropdown._.dropdownContent _.menu.dropdown._.dropdown.node()
+        _.menu.dropdown._.setupDropdown _.menu.dropdown._.dropdown.node()
       else
         _.menu.dropdown.show()
     else # Hide the dropdown as there are no items


### PR DESCRIPTION
fix for #172: stop autocomplete referencing invalid dropdown properties