### PR TITLE
Configurable user facing text

### DIFF
--- a/modules/user-facing-text/main/index.coffee
+++ b/modules/user-facing-text/main/index.coffee
@@ -1,52 +1,42 @@
-class UserFacingText extends hx.EventEmitter
-  constructor: ->
-    super
-    @_ =
-      localisedText: {}
-
-  localisedText: (stringPath, locales) ->
-    if arguments.length
-      strings = if hx.isString(stringPath)
-        [stringPath]
-      else stringPath
-
-      if locales?
-        newText = tmp = {}
-        for string, i in strings
-          if i is strings.length - 1
-            # Merge the locales to prevent mutation
-            tmp[string] = hx.merge locales
-          else
-            tmp[string] = {}
-            tmp = tmp[string]
-
-        @_.localisedText = hx.merge.defined(@_.localisedText, newText)
-        @emit 'change'
-        this
-      else
-        localisedText = undefined
-        tmp = @_.localisedText
-        for string, i in strings
-          if i is strings.length - 1
-            localisedText = tmp[string]
-          else if tmp?
-            tmp = tmp[string]
-          else
-            break
-        if not localisedText
-          hx.consoleWarning 'hx.userFacingText.localisedText: No text was found for locale for the path ' + stringPath
-        else
-          localisedText[hx.preferences.locale()] || localisedText['en'] # There must be a fallback in english.
-    else
-      @_.localisedText
-
-
-globalUserFacingText = new UserFacingText
+_ =
+  localisedText: {}
 
 userFacingText = (stringPath, locales) ->
-  globalUserFacingText.localisedText.apply(globalUserFacingText, arguments)
+  if arguments.length
+    strings = if hx.isString(stringPath)
+      [stringPath]
+    else stringPath
+
+    if locales?
+      newText = tmp = {}
+      for string, i in strings
+        if i is strings.length - 1
+          # Merge the locales to prevent mutation
+          tmp[string] = hx.merge locales
+        else
+          tmp[string] = {}
+          tmp = tmp[string]
+      _.localisedText = hx.merge.defined(_.localisedText, newText)
+      this
+    else
+      textObject = undefined
+      tmp = _.localisedText
+      for string, i in strings
+        if i is strings.length - 1
+          textObject = tmp[string]
+        else if tmp?
+          tmp = tmp[string]
+        else
+          break
+      if not textObject
+        hx.consoleWarning 'hx.userFacingText.localisedText: No text was found for locale for the path ' + stringPath
+      else
+        textObject[hx.preferences.locale()] || textObject['en'] # There must be a fallback in english.
+  else
+    _.localisedText
 
 hx.userFacingText = userFacingText
+hx.userFacingText.emitter = userFacingTextEmitter
 
 # For tests
-hx.userFacingText._ = globalUserFacingText._
+hx.userFacingText._ = _

--- a/modules/user-facing-text/main/index.coffee
+++ b/modules/user-facing-text/main/index.coffee
@@ -13,9 +13,11 @@ completeGetterSetter = (object) ->
   else
     hx.clone _.localisedText
 
+isValid = (value) -> hx.isString(value) and value.length
+
 partialGetterSetter = (module, key, value) ->
-  if hx.isString(module) and module.length and hx.isString(key) and key.length
-    if hx.isString(value) and value.length
+  if isValid(module) and isValid(string)
+    if isValid(value)
       _.localisedText[module] ?= {}
       _.localisedText[module][key] = value
       _.initialValues[module] ?= {}

--- a/modules/user-facing-text/main/index.coffee
+++ b/modules/user-facing-text/main/index.coffee
@@ -16,7 +16,7 @@ completeGetterSetter = (object) ->
 isValid = (value) -> hx.isString(value) and value.length
 
 partialGetterSetter = (module, key, value) ->
-  if isValid(module) and isValid(string)
+  if isValid(module) and isValid(key)
     if isValid(value)
       _.localisedText[module] ?= {}
       _.localisedText[module][key] = value

--- a/modules/user-facing-text/main/index.coffee
+++ b/modules/user-facing-text/main/index.coffee
@@ -1,0 +1,52 @@
+class UserFacingText extends hx.EventEmitter
+  constructor: ->
+    super
+    @_ =
+      localisedText: {}
+
+  localisedText: (stringPath, locales) ->
+    if arguments.length
+      strings = if hx.isString(stringPath)
+        [stringPath]
+      else stringPath
+
+      if locales?
+        newText = tmp = {}
+        for string, i in strings
+          if i is strings.length - 1
+            # Merge the locales to prevent mutation
+            tmp[string] = hx.merge locales
+          else
+            tmp[string] = {}
+            tmp = tmp[string]
+
+        @_.localisedText = hx.merge.defined(@_.localisedText, newText)
+        @emit 'change'
+        this
+      else
+        localisedText = undefined
+        tmp = @_.localisedText
+        for string, i in strings
+          if i is strings.length - 1
+            localisedText = tmp[string]
+          else if tmp?
+            tmp = tmp[string]
+          else
+            break
+        if not localisedText
+          hx.consoleWarning 'hx.userFacingText.localisedText: No text was found for locale for the path ' + stringPath
+        else
+          localisedText[hx.preferences.locale()] || localisedText['en'] # There must be a fallback in english.
+    else
+      @_.localisedText
+
+
+globalUserFacingText = new UserFacingText
+
+userFacingText = (stringPath, locales) ->
+  globalUserFacingText.localisedText.apply(globalUserFacingText, arguments)
+
+hx.userFacingText = userFacingText
+
+# For tests
+hx.userFacingText._ = globalUserFacingText._

--- a/modules/user-facing-text/main/index.coffee
+++ b/modules/user-facing-text/main/index.coffee
@@ -4,14 +4,17 @@ _ =
 
 completeGetterSetter = (object) ->
   if arguments.length
-    for module of object
-      for key of object[module]
-        partialGetterSetter(module, key, object[module][key])
+    if hx.isPlainObject(object)
+      for module of object
+        for key of object[module]
+          partialGetterSetter(module, key, object[module][key])
+    else
+      hx.consoleWarning "hx.userFacingText: Expected a plain object but was instead passed: #{object}"
   else
     hx.clone _.localisedText
 
 partialGetterSetter = (module, key, value) ->
-  if module and module.length and key and key.length
+  if hx.isString(module) and module.length and hx.isString(key) and key.length
     if hx.isString(value) and value.length
       _.localisedText[module] ?= {}
       _.localisedText[module][key] = value
@@ -20,16 +23,17 @@ partialGetterSetter = (module, key, value) ->
       true
     else if not value?
       text = _.localisedText[module]?[key]
-      unless text
+      if text
+        text
+      else
         hx.consoleWarning "hx.userFacingText: No text was found for key: #{key} in module: #{module}"
-      text
     else
       hx.consoleWarning "hx.userFacingText: The value provided must be a string but was passed value: #{value}"
   else
     hx.consoleWarning "hx.userFacingText: A module and key are expected as strings but was passed module: #{module} and key: #{key}"
 
 userFacingText = ->
-  if hx.isObject(arguments[0]) or arguments.length is 0
+  if arguments.length <= 1
     completeGetterSetter.apply(this, arguments)
   else
     partialGetterSetter.apply(this, arguments)

--- a/modules/user-facing-text/main/index.coffee
+++ b/modules/user-facing-text/main/index.coffee
@@ -1,6 +1,8 @@
 _ =
   localisedText: {}
 
+userFacingTextEmitter = new hx.EventEmitter
+
 userFacingText = (stringPath, locales) ->
   if arguments.length
     strings = if hx.isString(stringPath)
@@ -16,18 +18,19 @@ userFacingText = (stringPath, locales) ->
         else
           tmp[string] = {}
           tmp = tmp[string]
+      userFacingTextEmitter.emit('change')
       _.localisedText = hx.merge.defined(_.localisedText, newText)
-      this
+      return
     else
       textObject = undefined
       tmp = _.localisedText
       for string, i in strings
         if i is strings.length - 1
           textObject = tmp[string]
-        else if tmp?
+        else if tmp and tmp[string]
           tmp = tmp[string]
-        else
-          break
+        else break
+
       if not textObject
         hx.consoleWarning 'hx.userFacingText.localisedText: No text was found for locale for the path ' + stringPath
       else

--- a/modules/user-facing-text/module.json
+++ b/modules/user-facing-text/module.json
@@ -1,0 +1,13 @@
+{
+  "dependencies": [
+    "preferences",
+    "util",
+    "event-emitter"
+  ],
+  "keywords": [
+    "user",
+    "facing",
+    "text",
+    "locale"
+  ]
+}

--- a/modules/user-facing-text/test/spec.coffee
+++ b/modules/user-facing-text/test/spec.coffee
@@ -1,0 +1,90 @@
+describe 'User Facing Text', ->
+  initialText = hx.merge hx.userFacingText._.localisedText
+  trivialLocale = {'en': 'Thing'}
+  trivialLocaleWithFrench = {'en': 'English Thing', 'fr': 'French Thing'}
+
+  beforeEach ->
+    hx.userFacingText._.localisedText = {}
+
+  after ->
+    hx.userFacingText._.localisedText = initialText
+
+  it 'should register text using a string path', ->
+    hx.userFacingText('thing', trivialLocale)
+
+    # Must not be the same object but must have the same values
+    hx.userFacingText._.localisedText.thing.should.not.equal(trivialLocale)
+    hx.userFacingText._.localisedText.thing.should.eql(trivialLocale)
+
+  it 'should register text using an array path', ->
+    hx.userFacingText(['thing1', 'thing2', 'thing3'], trivialLocale)
+    should.exist(hx.userFacingText._.localisedText.thing1)
+    should.exist(hx.userFacingText._.localisedText.thing1.thing2)
+    should.exist(hx.userFacingText._.localisedText.thing1.thing2.thing3)
+
+    hx.userFacingText._.localisedText.thing1.thing2.thing3.should.not.equal(trivialLocale)
+    hx.userFacingText._.localisedText.thing1.thing2.thing3.should.eql(trivialLocale)
+
+  it 'should merge text for existing locales using a string path', ->
+    hx.userFacingText('thing', trivialLocale)
+
+    hx.userFacingText._.localisedText.thing.should.not.equal(trivialLocale)
+    hx.userFacingText._.localisedText.thing.should.eql(trivialLocale)
+
+    hx.userFacingText('thing', trivialLocaleWithFrench)
+
+    hx.userFacingText._.localisedText.thing.should.not.equal(trivialLocaleWithFrench)
+    hx.userFacingText._.localisedText.thing.should.eql(trivialLocaleWithFrench)
+
+  it 'should merge text for existing locales using an array path', ->
+    hx.userFacingText(['thing1', 'thing2', 'thing3'], trivialLocale)
+
+    should.exist(hx.userFacingText._.localisedText.thing1)
+    should.exist(hx.userFacingText._.localisedText.thing1.thing2)
+    should.exist(hx.userFacingText._.localisedText.thing1.thing2.thing3)
+
+    hx.userFacingText._.localisedText.thing1.thing2.thing3.should.not.equal(trivialLocale)
+    hx.userFacingText._.localisedText.thing1.thing2.thing3.should.eql(trivialLocale)
+
+    hx.userFacingText(['thing1', 'thing2', 'thing3'], trivialLocaleWithFrench)
+
+    should.exist(hx.userFacingText._.localisedText.thing1)
+    should.exist(hx.userFacingText._.localisedText.thing1.thing2)
+    should.exist(hx.userFacingText._.localisedText.thing1.thing2.thing3)
+
+    hx.userFacingText._.localisedText.thing1.thing2.thing3.should.not.equal(trivialLocaleWithFrench)
+    hx.userFacingText._.localisedText.thing1.thing2.thing3.should.eql(trivialLocaleWithFrench)
+
+  it 'should return an object with all defined locale texts', ->
+    hx.userFacingText('thing1', trivialLocale)
+    hx.userFacingText('thing2', trivialLocaleWithFrench)
+    hx.userFacingText().should.eql({'thing1': trivialLocale, 'thing2': trivialLocaleWithFrench})
+
+  it 'should return the text for the correct locale', ->
+    hx.userFacingText('thing1', trivialLocaleWithFrench)
+
+    hx.preferences.supportedLocales([
+      {value: 'en', full: 'English'},
+      {value: 'fr', full: 'French'}
+    ])
+
+    hx.preferences.locale('en')
+    hx.userFacingText('thing1').should.equal('English Thing')
+
+    hx.preferences.locale('fr')
+    hx.userFacingText('thing1').should.equal('French Thing')
+
+  it 'should fall back to english when text for a locale is not defined', ->
+    hx.userFacingText('thing', trivialLocale)
+
+    hx.preferences.supportedLocales([
+      {value: 'en', full: 'English'},
+      {value: 'fr', full: 'French'}
+    ])
+
+    hx.preferences.locale('en')
+    hx.userFacingText('thing').should.equal('Thing')
+
+    hx.preferences.locale('fr')
+    hx.userFacingText('thing').should.equal('Thing')
+

--- a/modules/user-facing-text/test/spec.coffee
+++ b/modules/user-facing-text/test/spec.coffee
@@ -1,67 +1,78 @@
 describe 'User Facing Text', ->
-  initialText = hx.merge hx.userFacingText._.localisedText
-  trivialLocale = {'en': 'Thing'}
-  trivialLocaleWithFrench = {'en': 'English Thing', 'fr': 'French Thing'}
+  origText = hx.merge hx.userFacingText._.localisedText
+  origConsoleWarning = hx.consoleWarning
+
+  localeObj = {'en': 'Thing'}
+  localeObjWithFrench = {'en': 'English Thing', 'fr': 'French Thing'}
 
   beforeEach ->
+    hx.consoleWarning = chai.spy()
     hx.userFacingText._.localisedText = {}
 
   after ->
-    hx.userFacingText._.localisedText = initialText
+    hx.userFacingText._.localisedText = origText
+    hx.consoleWarning = origConsoleWarning
 
   it 'should register text using a string path', ->
-    hx.userFacingText('thing', trivialLocale)
+    hx.userFacingText('thing', localeObj)
 
     # Must not be the same object but must have the same values
-    hx.userFacingText._.localisedText.thing.should.not.equal(trivialLocale)
-    hx.userFacingText._.localisedText.thing.should.eql(trivialLocale)
+    hx.userFacingText._.localisedText.thing.should.not.equal(localeObj)
+    hx.userFacingText._.localisedText.thing.should.eql(localeObj)
+    hx.consoleWarning.should.not.have.been.called()
 
   it 'should register text using an array path', ->
-    hx.userFacingText(['thing1', 'thing2', 'thing3'], trivialLocale)
+    hx.userFacingText(['thing1', 'thing2', 'thing3'], localeObj)
     should.exist(hx.userFacingText._.localisedText.thing1)
     should.exist(hx.userFacingText._.localisedText.thing1.thing2)
     should.exist(hx.userFacingText._.localisedText.thing1.thing2.thing3)
 
-    hx.userFacingText._.localisedText.thing1.thing2.thing3.should.not.equal(trivialLocale)
-    hx.userFacingText._.localisedText.thing1.thing2.thing3.should.eql(trivialLocale)
+    hx.userFacingText._.localisedText.thing1.thing2.thing3.should.not.equal(localeObj)
+    hx.userFacingText._.localisedText.thing1.thing2.thing3.should.eql(localeObj)
+    hx.consoleWarning.should.not.have.been.called()
 
   it 'should merge text for existing locales using a string path', ->
-    hx.userFacingText('thing', trivialLocale)
+    hx.userFacingText('thing', localeObj)
 
-    hx.userFacingText._.localisedText.thing.should.not.equal(trivialLocale)
-    hx.userFacingText._.localisedText.thing.should.eql(trivialLocale)
+    hx.userFacingText._.localisedText.thing.should.not.equal(localeObj)
+    hx.userFacingText._.localisedText.thing.should.eql(localeObj)
+    hx.consoleWarning.should.not.have.been.called()
 
-    hx.userFacingText('thing', trivialLocaleWithFrench)
+    hx.userFacingText('thing', localeObjWithFrench)
 
-    hx.userFacingText._.localisedText.thing.should.not.equal(trivialLocaleWithFrench)
-    hx.userFacingText._.localisedText.thing.should.eql(trivialLocaleWithFrench)
+    hx.userFacingText._.localisedText.thing.should.not.equal(localeObjWithFrench)
+    hx.userFacingText._.localisedText.thing.should.eql(localeObjWithFrench)
+    hx.consoleWarning.should.not.have.been.called()
 
   it 'should merge text for existing locales using an array path', ->
-    hx.userFacingText(['thing1', 'thing2', 'thing3'], trivialLocale)
+    hx.userFacingText(['thing1', 'thing2', 'thing3'], localeObj)
 
     should.exist(hx.userFacingText._.localisedText.thing1)
     should.exist(hx.userFacingText._.localisedText.thing1.thing2)
     should.exist(hx.userFacingText._.localisedText.thing1.thing2.thing3)
 
-    hx.userFacingText._.localisedText.thing1.thing2.thing3.should.not.equal(trivialLocale)
-    hx.userFacingText._.localisedText.thing1.thing2.thing3.should.eql(trivialLocale)
+    hx.userFacingText._.localisedText.thing1.thing2.thing3.should.not.equal(localeObj)
+    hx.userFacingText._.localisedText.thing1.thing2.thing3.should.eql(localeObj)
+    hx.consoleWarning.should.not.have.been.called()
 
-    hx.userFacingText(['thing1', 'thing2', 'thing3'], trivialLocaleWithFrench)
+    hx.userFacingText(['thing1', 'thing2', 'thing3'], localeObjWithFrench)
 
     should.exist(hx.userFacingText._.localisedText.thing1)
     should.exist(hx.userFacingText._.localisedText.thing1.thing2)
     should.exist(hx.userFacingText._.localisedText.thing1.thing2.thing3)
 
-    hx.userFacingText._.localisedText.thing1.thing2.thing3.should.not.equal(trivialLocaleWithFrench)
-    hx.userFacingText._.localisedText.thing1.thing2.thing3.should.eql(trivialLocaleWithFrench)
+    hx.userFacingText._.localisedText.thing1.thing2.thing3.should.not.equal(localeObjWithFrench)
+    hx.userFacingText._.localisedText.thing1.thing2.thing3.should.eql(localeObjWithFrench)
+    hx.consoleWarning.should.not.have.been.called()
 
-  it 'should return an object with all defined locale texts', ->
-    hx.userFacingText('thing1', trivialLocale)
-    hx.userFacingText('thing2', trivialLocaleWithFrench)
-    hx.userFacingText().should.eql({'thing1': trivialLocale, 'thing2': trivialLocaleWithFrench})
+  it 'should return an object with all defined locale texts ', ->
+    hx.userFacingText('thing1', localeObj)
+    hx.userFacingText('thing2', localeObjWithFrench)
+    hx.userFacingText().should.eql({'thing1': localeObj, 'thing2': localeObjWithFrench})
+    hx.consoleWarning.should.not.have.been.called()
 
-  it 'should return the text for the correct locale', ->
-    hx.userFacingText('thing1', trivialLocaleWithFrench)
+  it 'should return the text for the correct locale using a string path', ->
+    hx.userFacingText('thing1', localeObjWithFrench)
 
     hx.preferences.supportedLocales([
       {value: 'en', full: 'English'},
@@ -70,12 +81,14 @@ describe 'User Facing Text', ->
 
     hx.preferences.locale('en')
     hx.userFacingText('thing1').should.equal('English Thing')
+    hx.consoleWarning.should.not.have.been.called()
 
     hx.preferences.locale('fr')
     hx.userFacingText('thing1').should.equal('French Thing')
+    hx.consoleWarning.should.not.have.been.called()
 
-  it 'should fall back to english when text for a locale is not defined', ->
-    hx.userFacingText('thing', trivialLocale)
+  it 'should fall back to english when text for a locale is not defined using a string path', ->
+    hx.userFacingText('thing', localeObj)
 
     hx.preferences.supportedLocales([
       {value: 'en', full: 'English'},
@@ -84,7 +97,60 @@ describe 'User Facing Text', ->
 
     hx.preferences.locale('en')
     hx.userFacingText('thing').should.equal('Thing')
+    hx.consoleWarning.should.not.have.been.called()
 
     hx.preferences.locale('fr')
     hx.userFacingText('thing').should.equal('Thing')
+    hx.consoleWarning.should.not.have.been.called()
 
+  it 'should return the text for the correct locale using an array path', ->
+    hx.userFacingText(['thing1', 'thing2'], localeObjWithFrench)
+
+    hx.preferences.supportedLocales([
+      {value: 'en', full: 'English'},
+      {value: 'fr', full: 'French'}
+    ])
+
+    hx.preferences.locale('en')
+    hx.userFacingText(['thing1', 'thing2']).should.equal('English Thing')
+    hx.consoleWarning.should.not.have.been.called()
+
+    hx.preferences.locale('fr')
+    hx.userFacingText(['thing1', 'thing2']).should.equal('French Thing')
+    hx.consoleWarning.should.not.have.been.called()
+
+  it 'should fall back to english when text for a locale is not defined using an array path', ->
+    hx.userFacingText(['thing1', 'thing2'], localeObj)
+
+    hx.preferences.supportedLocales([
+      {value: 'en', full: 'English'},
+      {value: 'fr', full: 'French'}
+    ])
+
+    hx.preferences.locale('en')
+    hx.userFacingText(['thing1', 'thing2']).should.equal('Thing')
+    hx.consoleWarning.should.not.have.been.called()
+
+    hx.preferences.locale('fr')
+    hx.userFacingText(['thing1', 'thing2']).should.equal('Thing')
+    hx.consoleWarning.should.not.have.been.called()
+
+  it 'should show a console warning when a text object could not be found', ->
+    should.not.exist(hx.userFacingText('bob'))
+    hx.consoleWarning.should.have.been.called()
+
+  it 'should show a console warning when a text object could not be found in an array', ->
+    should.not.exist(hx.userFacingText(['bob', 'dave']))
+    hx.consoleWarning.should.have.been.called()
+
+  it 'should show a console warning when a text object could not be found in an array when part of the string path exists', ->
+    hx.userFacingText('thing', localeObj)
+    should.not.exist(hx.userFacingText(['thing', 'bob', 'dave']))
+    hx.consoleWarning.should.have.been.called()
+
+  it 'should emit an event when the text for a locale is changed', ->
+    fn = chai.spy()
+    hx.userFacingText.emitter.on 'change', fn
+    hx.userFacingText('thing', localeObj)
+    fn.should.have.been.called()
+    hx.consoleWarning.should.not.have.been.called()

--- a/modules/user-facing-text/test/spec.coffee
+++ b/modules/user-facing-text/test/spec.coffee
@@ -1,156 +1,83 @@
 describe 'User Facing Text', ->
-  origText = hx.merge hx.userFacingText._.localisedText
+  origText = hx.clone hx.userFacingText._.localisedText
+  origInitialText = hx.clone hx.userFacingText._.initialValues
   origConsoleWarning = hx.consoleWarning
-
-  localeObj = {'en': 'Thing'}
-  localeObjWithFrench = {'en': 'English Thing', 'fr': 'French Thing'}
 
   beforeEach ->
     hx.consoleWarning = chai.spy()
     hx.userFacingText._.localisedText = {}
+    hx.userFacingText._.initialValues = {}
 
   after ->
     hx.userFacingText._.localisedText = origText
+    hx.userFacingText._.initialValues = origInitialText
     hx.consoleWarning = origConsoleWarning
 
   it 'should register text using a string path', ->
-    hx.userFacingText('thing', localeObj)
-
-    # Must not be the same object but must have the same values
-    hx.userFacingText._.localisedText.thing.should.not.equal(localeObj)
-    hx.userFacingText._.localisedText.thing.should.eql(localeObj)
+    hx.userFacingText('module', 'key', 'text')
+    hx.userFacingText().module.key.should.equal('text')
     hx.consoleWarning.should.not.have.been.called()
 
-  it 'should register text using an array path', ->
-    hx.userFacingText(['thing1', 'thing2', 'thing3'], localeObj)
-    should.exist(hx.userFacingText._.localisedText.thing1)
-    should.exist(hx.userFacingText._.localisedText.thing1.thing2)
-    should.exist(hx.userFacingText._.localisedText.thing1.thing2.thing3)
-
-    hx.userFacingText._.localisedText.thing1.thing2.thing3.should.not.equal(localeObj)
-    hx.userFacingText._.localisedText.thing1.thing2.thing3.should.eql(localeObj)
+  it 'should return the correct value', ->
+    hx.userFacingText('module', 'key', 'text')
+    hx.userFacingText().module.key.should.equal('text')
+    hx.userFacingText('module', 'key').should.equal('text')
     hx.consoleWarning.should.not.have.been.called()
 
-  it 'should merge text for existing locales using a string path', ->
-    hx.userFacingText('thing', localeObj)
-
-    hx.userFacingText._.localisedText.thing.should.not.equal(localeObj)
-    hx.userFacingText._.localisedText.thing.should.eql(localeObj)
+  it 'should return the complete set of values when called with no arguments', ->
+    hx.userFacingText().should.eql({})
+    hx.userFacingText('module', 'key', 'text')
+    hx.userFacingText().should.eql({
+      module:
+        key: 'text'
+    })
     hx.consoleWarning.should.not.have.been.called()
 
-    hx.userFacingText('thing', localeObjWithFrench)
+  it 'should set multiple keys at once when calling with one argument', ->
+    textObj = {
+      module1:
+        key1: 'text1'
+        key2: 'text2'
+      module2:
+        key3: 'text3'
+    }
+    hx.userFacingText(textObj)
+    hx.consoleWarning.should.not.have.been.called()
+    hx.userFacingText().should.not.equal(textObj)
+    hx.userFacingText().should.eql(textObj)
 
-    hx.userFacingText._.localisedText.thing.should.not.equal(localeObjWithFrench)
-    hx.userFacingText._.localisedText.thing.should.eql(localeObjWithFrench)
+  it 'defaults: should return the first values that were set for a key/module', ->
+    hx.userFacingText('module', 'key', 'text1')
+    hx.userFacingText('module', 'key', 'text2')
+    hx.userFacingText.defaults().should.eql({
+      module:
+        key: 'text1'
+    })
     hx.consoleWarning.should.not.have.been.called()
 
-  it 'should merge text for existing locales using an array path', ->
-    hx.userFacingText(['thing1', 'thing2', 'thing3'], localeObj)
+  # "Bad" Path
+  it 'should throw an error when called with an invalid value', ->
+    hx.userFacingText('module', 'key', {})
+    hx.consoleWarning.should.have.been.called.once()
+    hx.consoleWarning.reset()
+    hx.userFacingText('module', 'key', 3.1415)
+    hx.consoleWarning.should.have.been.called.once()
+    hx.userFacingText().should.eql({})
 
-    should.exist(hx.userFacingText._.localisedText.thing1)
-    should.exist(hx.userFacingText._.localisedText.thing1.thing2)
-    should.exist(hx.userFacingText._.localisedText.thing1.thing2.thing3)
+  it 'should throw an error when called with a module / key that does not exist', ->
+    hx.userFacingText('module')
+    hx.consoleWarning.should.have.been.called.once()
+    hx.consoleWarning.reset()
+    hx.userFacingText('module', 'key')
+    hx.consoleWarning.should.have.been.called.once()
 
-    hx.userFacingText._.localisedText.thing1.thing2.thing3.should.not.equal(localeObj)
-    hx.userFacingText._.localisedText.thing1.thing2.thing3.should.eql(localeObj)
-    hx.consoleWarning.should.not.have.been.called()
-
-    hx.userFacingText(['thing1', 'thing2', 'thing3'], localeObjWithFrench)
-
-    should.exist(hx.userFacingText._.localisedText.thing1)
-    should.exist(hx.userFacingText._.localisedText.thing1.thing2)
-    should.exist(hx.userFacingText._.localisedText.thing1.thing2.thing3)
-
-    hx.userFacingText._.localisedText.thing1.thing2.thing3.should.not.equal(localeObjWithFrench)
-    hx.userFacingText._.localisedText.thing1.thing2.thing3.should.eql(localeObjWithFrench)
-    hx.consoleWarning.should.not.have.been.called()
-
-  it 'should return an object with all defined locale texts ', ->
-    hx.userFacingText('thing1', localeObj)
-    hx.userFacingText('thing2', localeObjWithFrench)
-    hx.userFacingText().should.eql({'thing1': localeObj, 'thing2': localeObjWithFrench})
-    hx.consoleWarning.should.not.have.been.called()
-
-  it 'should return the text for the correct locale using a string path', ->
-    hx.userFacingText('thing1', localeObjWithFrench)
-
-    hx.preferences.supportedLocales([
-      {value: 'en', full: 'English'},
-      {value: 'fr', full: 'French'}
-    ])
-
-    hx.preferences.locale('en')
-    hx.userFacingText('thing1').should.equal('English Thing')
-    hx.consoleWarning.should.not.have.been.called()
-
-    hx.preferences.locale('fr')
-    hx.userFacingText('thing1').should.equal('French Thing')
-    hx.consoleWarning.should.not.have.been.called()
-
-  it 'should fall back to english when text for a locale is not defined using a string path', ->
-    hx.userFacingText('thing', localeObj)
-
-    hx.preferences.supportedLocales([
-      {value: 'en', full: 'English'},
-      {value: 'fr', full: 'French'}
-    ])
-
-    hx.preferences.locale('en')
-    hx.userFacingText('thing').should.equal('Thing')
-    hx.consoleWarning.should.not.have.been.called()
-
-    hx.preferences.locale('fr')
-    hx.userFacingText('thing').should.equal('Thing')
-    hx.consoleWarning.should.not.have.been.called()
-
-  it 'should return the text for the correct locale using an array path', ->
-    hx.userFacingText(['thing1', 'thing2'], localeObjWithFrench)
-
-    hx.preferences.supportedLocales([
-      {value: 'en', full: 'English'},
-      {value: 'fr', full: 'French'}
-    ])
-
-    hx.preferences.locale('en')
-    hx.userFacingText(['thing1', 'thing2']).should.equal('English Thing')
-    hx.consoleWarning.should.not.have.been.called()
-
-    hx.preferences.locale('fr')
-    hx.userFacingText(['thing1', 'thing2']).should.equal('French Thing')
-    hx.consoleWarning.should.not.have.been.called()
-
-  it 'should fall back to english when text for a locale is not defined using an array path', ->
-    hx.userFacingText(['thing1', 'thing2'], localeObj)
-
-    hx.preferences.supportedLocales([
-      {value: 'en', full: 'English'},
-      {value: 'fr', full: 'French'}
-    ])
-
-    hx.preferences.locale('en')
-    hx.userFacingText(['thing1', 'thing2']).should.equal('Thing')
-    hx.consoleWarning.should.not.have.been.called()
-
-    hx.preferences.locale('fr')
-    hx.userFacingText(['thing1', 'thing2']).should.equal('Thing')
-    hx.consoleWarning.should.not.have.been.called()
-
-  it 'should show a console warning when a text object could not be found', ->
-    should.not.exist(hx.userFacingText('bob'))
-    hx.consoleWarning.should.have.been.called()
-
-  it 'should show a console warning when a text object could not be found in an array', ->
-    should.not.exist(hx.userFacingText(['bob', 'dave']))
-    hx.consoleWarning.should.have.been.called()
-
-  it 'should show a console warning when a text object could not be found in an array when part of the string path exists', ->
-    hx.userFacingText('thing', localeObj)
-    should.not.exist(hx.userFacingText(['thing', 'bob', 'dave']))
-    hx.consoleWarning.should.have.been.called()
-
-  it 'should emit an event when the text for a locale is changed', ->
-    fn = chai.spy()
-    hx.userFacingText.emitter.on 'change', fn
-    hx.userFacingText('thing', localeObj)
-    fn.should.have.been.called()
-    hx.consoleWarning.should.not.have.been.called()
+  it 'should throw an error when called with an invalid module or key', ->
+    hx.userFacingText('module')
+    hx.consoleWarning.should.have.been.called.once()
+    hx.consoleWarning.reset()
+    hx.userFacingText(3.1415, 'key')
+    hx.consoleWarning.should.have.been.called.once()
+    hx.consoleWarning.reset()
+    hx.userFacingText('module', undefined)
+    hx.consoleWarning.should.have.been.called.once()
+    hx.consoleWarning.reset()

--- a/modules/user-facing-text/test/spec.coffee
+++ b/modules/user-facing-text/test/spec.coffee
@@ -3,6 +3,8 @@ describe 'User Facing Text', ->
   origInitialText = hx.clone hx.userFacingText._.initialValues
   origConsoleWarning = hx.consoleWarning
 
+  objectWithLength = {length: 1}
+
   beforeEach ->
     hx.consoleWarning = chai.spy()
     hx.userFacingText._.localisedText = {}
@@ -56,28 +58,138 @@ describe 'User Facing Text', ->
     hx.consoleWarning.should.not.have.been.called()
 
   # "Bad" Path
-  it 'should throw an error when called with an invalid value', ->
-    hx.userFacingText('module', 'key', {})
-    hx.consoleWarning.should.have.been.called.once()
-    hx.consoleWarning.reset()
-    hx.userFacingText('module', 'key', 3.1415)
-    hx.consoleWarning.should.have.been.called.once()
-    hx.userFacingText().should.eql({})
+  describe 'Errors', ->
+    it 'when called with a module / key that does not exist', ->
+      hx.userFacingText('module')
+      hx.consoleWarning.should.have.been.called.once()
+      hx.consoleWarning.reset()
 
-  it 'should throw an error when called with a module / key that does not exist', ->
-    hx.userFacingText('module')
-    hx.consoleWarning.should.have.been.called.once()
-    hx.consoleWarning.reset()
-    hx.userFacingText('module', 'key')
-    hx.consoleWarning.should.have.been.called.once()
+      hx.userFacingText('module', 'key')
+      hx.consoleWarning.should.have.been.called.once()
+      hx.userFacingText().should.eql({})
 
-  it 'should throw an error when called with an invalid module or key', ->
-    hx.userFacingText('module')
-    hx.consoleWarning.should.have.been.called.once()
-    hx.consoleWarning.reset()
-    hx.userFacingText(3.1415, 'key')
-    hx.consoleWarning.should.have.been.called.once()
-    hx.consoleWarning.reset()
-    hx.userFacingText('module', undefined)
-    hx.consoleWarning.should.have.been.called.once()
-    hx.consoleWarning.reset()
+
+    it 'when called with an invalid module when getting', ->
+      hx.userFacingText(undefined)
+      hx.consoleWarning.should.have.been.called.once()
+      hx.consoleWarning.reset()
+
+      hx.userFacingText(undefined, 'key')
+      hx.consoleWarning.should.have.been.called.once()
+      hx.consoleWarning.reset()
+
+      hx.userFacingText(3.1415, 'key')
+      hx.consoleWarning.should.have.been.called.once()
+      hx.consoleWarning.reset()
+
+      hx.userFacingText(objectWithLength, 'key')
+      hx.consoleWarning.should.have.been.called.once()
+      hx.consoleWarning.reset()
+
+      hx.userFacingText().should.eql({})
+
+
+    it 'when called with an invalid module when setting', ->
+      hx.userFacingText(undefined, 'key', 'value')
+      hx.consoleWarning.should.have.been.called.once()
+      hx.consoleWarning.reset()
+      hx.userFacingText().should.eql({})
+
+      hx.userFacingText(3.1415, 'key', 'value')
+      hx.consoleWarning.should.have.been.called.once()
+      hx.consoleWarning.reset()
+
+      hx.userFacingText(objectWithLength, 'key', 'value')
+      hx.consoleWarning.should.have.been.called.once()
+      hx.consoleWarning.reset()
+
+      hx.userFacingText().should.eql({})
+
+
+    it 'when called with an invalid key when getting', ->
+      hx.userFacingText('module', undefined)
+      hx.consoleWarning.should.have.been.called.once()
+      hx.consoleWarning.reset()
+
+      hx.userFacingText('module', 3.1415)
+      hx.consoleWarning.should.have.been.called.once()
+      hx.consoleWarning.reset()
+
+      hx.userFacingText('module', objectWithLength)
+      hx.consoleWarning.should.have.been.called.once()
+      hx.consoleWarning.reset()
+
+      hx.userFacingText().should.eql({})
+
+
+    it 'when called with an invalid key when setting', ->
+      hx.userFacingText('module', undefined, 'value')
+      hx.consoleWarning.should.have.been.called.once()
+      hx.consoleWarning.reset()
+
+      hx.userFacingText('module', 3.1415, 'value')
+      hx.consoleWarning.should.have.been.called.once()
+      hx.consoleWarning.reset()
+
+      hx.userFacingText('module', objectWithLength, 'value')
+      hx.consoleWarning.should.have.been.called.once()
+      hx.consoleWarning.reset()
+
+      hx.userFacingText().should.eql({})
+
+
+    it 'when called with an invalid value', ->
+      hx.userFacingText('module', 'key', undefined)
+      hx.consoleWarning.should.have.been.called.once()
+      hx.consoleWarning.reset()
+
+      hx.userFacingText('module', 'key', 3.1415)
+      hx.consoleWarning.should.have.been.called.once()
+      hx.consoleWarning.reset()
+
+      hx.userFacingText('module', 'key', objectWithLength)
+      hx.consoleWarning.should.have.been.called.once()
+      hx.userFacingText().should.eql({})
+
+
+    it 'when calling the global setter with an object with invalid values', ->
+      hx.userFacingText({
+        'module1':
+          'key1': 'value1'
+        'module2':
+          'key2': undefined
+        'module3':
+          'key3': 3.1415
+        'module4':
+          'key4': objectWithLength
+      })
+      hx.consoleWarning.should.have.been.called.exactly(3)
+      hx.userFacingText().should.eql({
+        'module1':
+          'key1': 'value1'
+      })
+
+    it 'when calling the global setter with a non-plain object', ->
+      class Test
+        constructor: ->
+          @length = 1
+          @module1 =
+            key1: 'value'
+
+      testObj = new Test
+      hx.userFacingText(testObj)
+      hx.consoleWarning.should.have.been.called.once()
+      hx.userFacingText().should.eql({})
+
+    it 'when calling the global setter with an invalid value', ->
+      hx.userFacingText('module')
+      hx.consoleWarning.should.have.been.called.once()
+      hx.consoleWarning.reset()
+
+      hx.userFacingText(undefined)
+      hx.consoleWarning.should.have.been.called.once()
+      hx.consoleWarning.reset()
+
+      hx.userFacingText(3.1415)
+      hx.consoleWarning.should.have.been.called.once()
+      hx.consoleWarning.reset()


### PR DESCRIPTION
I've written a module for configuring the user facing text.

You can set up the text using:
```js
hx.userFacingText('noData', {'en': 'No Data'})
hx.userFacingText(['dataTable','noData'], {en: 'No Data'})
```

These can then be retrieved using the symmetrical getter:
```js
hx.userFacingText('noData')
hx.userFacingText(['dataTable','noData'])
```

You can also retrieve all the currently set strings using:
```js
hx.userFacingText()
```
Which is useful if you want to see what you need to localise.

The theory is that each module would set up it's own user facing text which would then be stored in the global `userFacingText` object then each module would internally use the function to retrieve the text.

The retrieval checks for text in the current `hx.preferences.locale()` and then falls back to `en` which _should_ always exist (as it will be set up in the module code).

