### PR TITLE
Preferences: prefer navigator.languages over navigator.language

### DIFF
--- a/modules/preferences/main/index.coffee
+++ b/modules/preferences/main/index.coffee
@@ -207,7 +207,7 @@ class Preferences extends hx.EventEmitter
       modal: modal
     }
 
-    defaultLocaleId = moment?.locale() or navigator.language
+    defaultLocaleId = moment?.locale() or navigator.languages?[0] or navigator.language
     if not (hx.isString(defaultLocaleId) and lookupLocale(defaultLocaleId))
       defaultLocaleId = 'en'
     @locale defaultLocaleId


### PR DESCRIPTION
On Chrome, navigator.language is determined at the point chrome is downloaded and is unaffected by re-ordering the languages in the chrome settings.

`navigator.languages`, however, are.

See [here](https://alicoding.com/detect-browser-language-preference-in-firefox-and-chrome-using-javascript/) for more details.