### PR TITLE
Plot label fix #139

### DIFF
--- a/modules/plot/main/index.scss
+++ b/modules/plot/main/index.scss
@@ -69,7 +69,7 @@
 // XXXL theme variables
 .hx-plot-label-details {
   transform: translate(10px, -50%);
-  position: relative;
+  position: absolute;
   top: 0;
   left: 0;
   font-size: 10px;
@@ -77,7 +77,7 @@
 
 .hx-plot-label-details-basic {
   transform: translate(10px, -50%);
-  position: relative;
+  position: absolute;
   top: 0;
   left: 0;
   font-size: 10px;

--- a/modules/plot/main/index.scss
+++ b/modules/plot/main/index.scss
@@ -63,7 +63,7 @@
 }
 
 .hx-plot-label {
-  position: relative;
+  position: absolute;
 }
 
 // XXXL theme variables


### PR DESCRIPTION
The details section of the label is what was giving it 'size'
Giving the details section an absolute position allows us to continue using transforms to move the label whilst not affecting the page layout