### PR TITLE
Bugfix

### DIFF
--- a/build/main/util.js
+++ b/build/main/util.js
@@ -55,7 +55,7 @@ exports.iife = function (src) {
 }
 
 // compiles a scss string to css
-var prefixer = postcss([autoprefixer({ browsers: ['last 2 versions', 'iOS > 7'] })])
+var prefixer = postcss([autoprefixer({ browsers: ['last 2 versions', 'iOS >= 7'] })])
 exports.scss = function (src) {
   return sass.renderAsync({data: src})
     .then(function (res) {

--- a/build/main/util.js
+++ b/build/main/util.js
@@ -55,7 +55,7 @@ exports.iife = function (src) {
 }
 
 // compiles a scss string to css
-var prefixer = postcss([autoprefixer({ browsers: ['last 2 versions', 'iOS > 5'] })])
+var prefixer = postcss([autoprefixer({ browsers: ['last 2 versions', 'iOS > 7'] })])
 exports.scss = function (src) {
   return sass.renderAsync({data: src})
     .then(function (res) {

--- a/build/main/util.js
+++ b/build/main/util.js
@@ -55,7 +55,7 @@ exports.iife = function (src) {
 }
 
 // compiles a scss string to css
-var prefixer = postcss([autoprefixer({ browsers: ['last 2 version'] })])
+var prefixer = postcss([autoprefixer({ browsers: ['last 2 versions', 'iOS > 5'] })])
 exports.scss = function (src) {
   return sass.renderAsync({data: src})
     .then(function (res) {

--- a/modules/autocomplete/main/index.coffee
+++ b/modules/autocomplete/main/index.coffee
@@ -131,7 +131,7 @@ buildAutoComplete = (searchTerm, fromCallback, loading) ->
     if not filteredData?
       message.text = @options.loadingMessage
     else if searchTerm.length < @options.minLength
-      message.text = @options.minLengthMessage.replace('$minLength', @options.minLength)
+      message.text = @options.pleaseEnterMinCharactersMessage.replace('$minLength', @options.minLength)
     else if (searchTerm.length > 0 or @options.showAll) and filteredData.length is 0
       if @options.trimTrailingSpaces and _.input.value().lastIndexOf(' ') is _.input.value().length - 1
         trimAndReload = true

--- a/modules/preferences/main/index.coffee
+++ b/modules/preferences/main/index.coffee
@@ -2,7 +2,7 @@ hx.userFacingText({
   preferences: {
     locale: 'Locale',
     preferences: 'Preferences',
-    preferenesSaved: 'Preferences Saved',
+    preferencesSaved: 'Preferences Saved',
     save: 'Save',
     timezone: 'Timezone'
   }
@@ -195,7 +195,7 @@ class Preferences extends hx.EventEmitter
             if err
               hx.notify.negative(err)
             else
-              hx.notify.positive(hx.userFacingText('preferences','preferenesSaved'))
+              hx.notify.positive(hx.userFacingText('preferences','preferencesSaved'))
               modal.hide()
 
       hx.select(element)

--- a/modules/preferences/test/spec.coffee
+++ b/modules/preferences/test/spec.coffee
@@ -2,7 +2,7 @@ describe 'hx-preferences', ->
   it 'should have user facing text defined', ->
     hx.userFacingText('preferences', 'locale').should.equal('Locale')
     hx.userFacingText('preferences', 'preferences').should.equal('Preferences')
-    hx.userFacingText('preferences', 'preferenesSaved').should.equal('Preferences Saved')
+    hx.userFacingText('preferences', 'preferencesSaved').should.equal('Preferences Saved')
     hx.userFacingText('preferences', 'save').should.equal('Save')
     hx.userFacingText('preferences', 'timezone').should.equal('Timezone')
 


### PR DESCRIPTION
Following a bugfix in autocomplete, I checked over a few of the other files and found some issues.

I also found multiple issues in older versions of iOS Safari to do with flex styles that caused issues when rendering pages.

- Added support for older versions of iOS
- Fixed another misnamed variable in autocomplete
- Corrected the spelling of a variable in preferences