### PR TITLE
Data table multi column filtering

### DIFF
--- a/modules/data-table/main/index.coffee
+++ b/modules/data-table/main/index.coffee
@@ -1075,7 +1075,7 @@ getAdvancedSearchFilter = (cellValueLookup = hx.identity, termLookup = defaultTe
     # If term is empty this will return false
     validFilters = hx.find filters, (groupedFilters) ->
       invalidFilter = hx.find groupedFilters, (filter) ->
-        searchTerm = if filter.column is 'any' then rowSearchTerm else cellValueLookup(row.cells[filter.column]).toLowerCase()
+        searchTerm = if filter.column is 'any' then rowSearchTerm else (cellValueLookup(row.cells[filter.column]) + '').toLowerCase()
         not termLookup filter.term.toLowerCase(), searchTerm
       not hx.defined invalidFilter
     hx.defined validFilters

--- a/modules/data-table/main/index.coffee
+++ b/modules/data-table/main/index.coffee
@@ -218,10 +218,12 @@ class DataTable extends hx.EventEmitter
       compact: 'auto'             # 'auto', true, false
       displayMode: 'paginate'     # 'paginate', 'all'
       feed: undefined
+      showSearchAboveTable: false
       filter: undefined
       filterEnabled: true
       showAdvancedSearch: false
       advancedSearchEnabled: false
+      advancedSearch: undefined
       pageSize: 15
       pageSizeOptions: undefined  # supply an array of numbers to show the user
       retainHorizontalScrollOnRender: true
@@ -230,7 +232,6 @@ class DataTable extends hx.EventEmitter
       singleSelection: false
       sort: undefined
       sortEnabled: true
-      showSearchAboveTable: false
 
       # functions used for getting row state
       rowIDLookup: (row) -> row.id
@@ -264,6 +265,7 @@ class DataTable extends hx.EventEmitter
     }, options)
 
     resolvedOptions.pageSize = Math.min resolvedOptions.pageSize, 1000
+    resolvedOptions.advancedSearchEnabled = true if resolvedOptions.advancedSearch
     resolvedOptions.showAdvancedSearch = true if resolvedOptions.advancedSearchEnabled
 
     selection = hx.select(selector).classed('hx-data-table', true)

--- a/modules/data-table/main/index.coffee
+++ b/modules/data-table/main/index.coffee
@@ -960,9 +960,6 @@ objectFeed = (data, options) ->
       validFilters = hx.find filters, (groupedFilters) ->
         invalidFilter = hx.find groupedFilters, (filter) ->
           searchTerm = if filter.column is 'any' then rowSearchTerm else row.cells[filter.column].toLowerCase()
-
-          console.log filter
-
           # This requires the cell value to be a string...
           not lookupTerm filter.term, searchTerm
         not hx.defined invalidFilter
@@ -990,11 +987,12 @@ objectFeed = (data, options) ->
       if range.sort?.column isnt sortCacheTerm.column
         filtered = undefined
 
-      if range.useAdvancedSearch and range.advancedSearch?.length
-        filtered = if filtered is undefined or filterCacheTerm isnt range.advancedSearch
+      if range.useAdvancedSearch
+        filtered = if range.advancedSearch?.length and (filtered is undefined or filterCacheTerm isnt range.advancedSearch)
           data.rows.filter((row) -> options.advancedSearch(range.advancedSearch, row))
         else
           data.rows.slice()
+
         filterCacheTerm = range.advancedSearch
         sorted = undefined
       else

--- a/modules/data-table/main/index.coffee
+++ b/modules/data-table/main/index.coffee
@@ -28,14 +28,8 @@ columnOptionLookup = (options, name, id) ->
     options[name]
 
 splitArray = (array, index) ->
-  left = if index is 0
-    []
-  else
-    array[0..index - 1]
-  right = if index is array.length - 1
-    []
-  else
-    array[index+1..array.length]
+  left = if index is 0 then [] else array[0...index]
+  right = if index is array.length - 1 then [] else array[index+1...array.length]
   [left, array[index], right]
 
 # pagination block (the page selector and the rows per page selector)

--- a/modules/data-table/main/index.coffee
+++ b/modules/data-table/main/index.coffee
@@ -1070,35 +1070,35 @@ stripLeadingAndTrailingWhitespaceRegex = /^\s+|\s+$/g
 getRowSearchTerm = (cellValueLookup, row) ->
   (v for k, v of row.cells).map(cellValueLookup).join(' ').toLowerCase()
 
-defaultTermFormatter = (term, rowSearchTerm) ->
+defaultTermLookup = (term, rowSearchTerm) ->
   arr = term?.toLowerCase()
     .replace(stripLeadingAndTrailingWhitespaceRegex,'')
     .split whitespaceSplitRegex
   validPart = hx.find arr, (part) -> ~rowSearchTerm.indexOf part
   hx.defined validPart
 
-getAdvancedSearchFilter = (cellValueLookup = hx.identity, termFormatter = defaultTermFormatter) ->
+getAdvancedSearchFilter = (cellValueLookup = hx.identity, termLookup = defaultTermLookup) ->
   (filters, row) ->
     rowSearchTerm = getRowSearchTerm(cellValueLookup, row)
     # If term is empty this will return false
     validFilters = hx.find filters, (groupedFilters) ->
       invalidFilter = hx.find groupedFilters, (filter) ->
         searchTerm = if filter.column is 'any' then rowSearchTerm else cellValueLookup(row.cells[filter.column]).toLowerCase()
-        not termFormatter filter.term, searchTerm
+        not termLookup filter.term, searchTerm
       not hx.defined invalidFilter
     hx.defined validFilters
 
 objectFeed = (data, options) ->
   options = hx.merge({
     cellValueLookup: hx.identity
-    termFormatter: defaultTermFormatter
+    termLookup: defaultTermLookup
 
     #XXX: should this provide more information - like the column id being sorted on?
     compare: hx.sort.compare
   }, options)
 
-  options.filter ?= (term, row) -> options.termFormatter(term, getRowSearchTerm(options.cellValueLookup, row))
-  options.advancedSearch ?= getAdvancedSearchFilter(options.cellValueLookup, options.termFormatter)
+  options.filter ?= (term, row) -> options.termLookup(term, getRowSearchTerm(options.cellValueLookup, row))
+  options.advancedSearch ?= getAdvancedSearchFilter(options.cellValueLookup, options.termLookup)
 
   # cached values
   filtered = undefined

--- a/modules/data-table/main/index.coffee
+++ b/modules/data-table/main/index.coffee
@@ -145,7 +145,7 @@ createAdvancedSearchView = (selection, dataTable, options) ->
         .attr('required', 'required')
         .on 'input', debouncedInput
 
-      removeBtn = hx.button({context: 'negative'}).classed('hx-btn-invert', true)
+      removeBtn = hx.button({context: 'negative'}).classed('hx-data-table-advanced-search-remove hx-btn-invert', true)
         .add(hx.icon({class: 'hx-icon hx-icon-close'}))
         .on 'click', ->
           prevFilters = dataTable.advancedSearch()
@@ -157,14 +157,9 @@ createAdvancedSearchView = (selection, dataTable, options) ->
           else if trueIndex is 0
             [leftFilterGroup..., leftFilterGroupLast] = leftFilterGroups
             [_, filters...] = filterGroup
-            newFilterGroup = [leftFilterGroupLast..., filters...]
-            [leftFilterGroup..., newFilterGroup, rightFilterGroups...]
+            [leftFilterGroup..., [leftFilterGroupLast..., filters...], rightFilterGroups...]
           else
-            newFilterGroup = [leftFilters..., rightFilters...]
-            if newFilterGroup.length
-              [leftFilterGroups..., newFilterGroup, rightFilterGroups...]
-            else
-              [leftFilterGroups..., rightFilterGroups...]
+            [leftFilterGroups..., [leftFilters..., rightFilters...], rightFilterGroups...]
 
           filterToUse = newFilters.filter((group) => group.length)
 
@@ -269,6 +264,7 @@ class DataTable extends hx.EventEmitter
     }, options)
 
     resolvedOptions.pageSize = Math.min resolvedOptions.pageSize, 1000
+    resolvedOptions.showAdvancedSearch = true if resolvedOptions.advancedSearchEnabled
 
     selection = hx.select(selector).classed('hx-data-table', true)
     content = hx.detached('div').class('hx-data-table-content')
@@ -359,7 +355,7 @@ class DataTable extends hx.EventEmitter
     clearFilters = => @advancedSearch(undefined)
 
     advancedSearchAddFilterButton = hx.button({context: 'positive'})
-      .classed('hx-data-table-advanced-search-button hx-btn-invert', true)
+      .classed('hx-data-table-advanced-search-add-filter hx-data-table-advanced-search-button hx-btn-invert', true)
       .add(hx.icon({class: 'hx-data-table-advanced-search-icon hx-icon hx-icon-plus hx-text-positive'}))
       .add(hx.detached('span').text(resolvedOptions.addFilterText))
       .on 'click', addFilter

--- a/modules/data-table/main/index.coffee
+++ b/modules/data-table/main/index.coffee
@@ -1027,9 +1027,8 @@ class DataTable extends hx.EventEmitter
           selection.select('.hx-data-table-content').insertAfter(container)
           selection.select('.hx-data-table-content').remove()
 
-          tableIsCompact = ((options.compact is 'auto') and (selection.width() < collapseBreakPoint)) or (options.compact is true)
-          selection.classed('hx-data-table-compact', tableIsCompact)
-            .classed('hx-data-table-show-search-above-table', options.showSearchAboveTable)
+          selection.classed('hx-data-table-compact', ((options.compact is 'auto') and (selection.width() < collapseBreakPoint)) or (options.compact is true))
+            .classed('hx-data-table-show-search-above-content', options.showSearchAboveTable)
 
           # set up the sticky headers
           stickFirstColumn = options.selectEnabled or options.collapsibleRenderer?
@@ -1071,8 +1070,7 @@ getRowSearchTerm = (cellValueLookup, row) ->
   (v for k, v of row.cells).map(cellValueLookup).join(' ').toLowerCase()
 
 defaultTermLookup = (term, rowSearchTerm) ->
-  arr = term?.toLowerCase()
-    .replace(stripLeadingAndTrailingWhitespaceRegex,'')
+  arr = term.replace(stripLeadingAndTrailingWhitespaceRegex,'')
     .split whitespaceSplitRegex
   validPart = hx.find arr, (part) -> ~rowSearchTerm.indexOf part
   hx.defined validPart
@@ -1084,7 +1082,7 @@ getAdvancedSearchFilter = (cellValueLookup = hx.identity, termLookup = defaultTe
     validFilters = hx.find filters, (groupedFilters) ->
       invalidFilter = hx.find groupedFilters, (filter) ->
         searchTerm = if filter.column is 'any' then rowSearchTerm else cellValueLookup(row.cells[filter.column]).toLowerCase()
-        not termLookup filter.term, searchTerm
+        not termLookup filter.term.toLowerCase(), searchTerm
       not hx.defined invalidFilter
     hx.defined validFilters
 
@@ -1097,7 +1095,7 @@ objectFeed = (data, options) ->
     compare: hx.sort.compare
   }, options)
 
-  options.filter ?= (term, row) -> options.termLookup(term, getRowSearchTerm(options.cellValueLookup, row))
+  options.filter ?= (term, row) -> options.termLookup(term.toLowerCase(), getRowSearchTerm(options.cellValueLookup, row))
   options.advancedSearch ?= getAdvancedSearchFilter(options.cellValueLookup, options.termLookup)
 
   # cached values
@@ -1136,7 +1134,6 @@ objectFeed = (data, options) ->
         sorted = if range.sort and range.sort.column
           direction = if range.sort.direction is 'asc' then 1 else -1
           column = range.sort.column
-          filtered.sort (r1, r2) -> direction * options.compare(r1.cells[column], r2.cells[column])
           filtered.sort (r1, r2) -> direction * options.compare(r1.cells[column], r2.cells[column])
           filtered
         else filtered

--- a/modules/data-table/main/index.scss
+++ b/modules/data-table/main/index.scss
@@ -365,7 +365,7 @@
 
 
   &.hx-data-table-compact,
-  &.hx-data-table-show-search-above-table {
+  &.hx-data-table-show-search-above-content {
     .hx-data-table-control-panel-bottom {
       order: 4;
     }
@@ -387,7 +387,7 @@
       }
     }
 
-    &.hx-data-table-show-search-above-table {
+    &.hx-data-table-show-search-above-content {
       .hx-data-table-control-panel {
         order: 1;
         box-shadow: none;

--- a/modules/data-table/main/index.scss
+++ b/modules/data-table/main/index.scss
@@ -16,7 +16,7 @@
     left: 0;
     bottom: 0;
     right: 0;
-    z-index: 1;
+    z-index: 5;
   }
 
   .hx-data-table-loading-inner {
@@ -51,8 +51,35 @@
     }
   }
 
-  // Footer
+  // Control Panel
+  .hx-btn-invisible {
+    padding: 0.4em;
+    margin: 0 0.4em;
+    white-space: nowrap;
+
+    &:first-child {
+      margin-left: 0;
+    }
+
+    &:last-child:not(.hx-toggle) {
+      margin-right: 0;
+    }
+  }
+
+  .hx-data-table-btn-disabled {
+    cursor: not-allowed;
+    opacity: 0.7;
+  }
+
   .hx-data-table-control-panel {
+    display: none;
+  }
+
+  .hx-data-table-control-panel-visible {
+    display: block;
+  }
+
+  .hx-data-table-control-panel-inner {
     display: flex;
     flex-direction: row-reverse;
     flex-wrap: wrap;
@@ -69,36 +96,124 @@
     flex-grow: 1;
   }
 
-  .hx-data-table-pagination {
-    display: flex;
-    flex-wrap: nowrap;
-  }
-
-  .hx-data-table-sort-control,
+  .hx-data-table-sort,
   .hx-data-table-paginator,
   .hx-data-table-page-size {
-    padding: 0.4em;
+    padding: 0.2em 0.4em;
     display: none;
     flex-wrap: nowrap;
     align-items: center;
   }
 
-  .hx-data-table-filter-control {
+  .hx-data-table-filter {
     display: none;
-    margin: 0.25em 0.2em;
-    padding: 0.5em;
+    margin: 0.2em;
+    padding: 0.3em;
     flex: 1;
     min-width: 0;
   }
 
-  .hx-data-table-pagination-visible,
-  .hx-data-table-select-page-size,
-  .hx-data-table-multi-page {
+  .hx-data-table-page-size-visible,
+  .hx-data-table-paginator-visible {
     display: flex;
   }
 
   .hx-data-table-filter-visible {
     display: inline-block;
+  }
+
+
+  .hx-data-table-control-panel-compact-toggle {
+    opacity: 0.4;
+    display: none;
+    font-size: 1.5em;
+  }
+
+  .hx-data-table-control-panel-compact-toggle-visible {
+    display: initial;
+  }
+
+  .hx-data-table-control-panel-compact {
+    display: none;
+    margin-right: 2px;
+
+    &.hx-data-table-control-panel-compact-open {
+      .hx-data-table-control-panel-compact-toggle {
+        opacity: 0.75;
+      }
+    }
+  }
+
+  .hx-data-table-advanced-search-icon {
+    margin-right: 0.2em;
+  }
+
+  .hx-data-table-advanced-search-toggle,
+  .hx-data-table-advanced-search-container {
+    display: none;
+  }
+
+  .hx-data-table-advanced-search-visible {
+    display: block;
+  }
+
+  .hx-data-table-advanced-search-toggle:first-child {
+    // Lines it up with the search box properly
+    padding: 0.5em 0.2em;
+    margin: 0.25em 0.2em;
+  }
+
+  .hx-data-table-advanced-search-filter-group:first-child {
+    .hx-data-table-advanced-search-filter:first-child {
+      .hx-data-table-advanced-search-type {
+        display: none;
+      }
+      .hx-data-table-advanced-search-column {
+        border-radius: 0.2em 0 0 0.2em;
+      }
+    }
+  }
+
+  .hx-data-table-advanced-search:not(:empty) {
+    margin: 0.2em;
+    max-width: 25em;
+  }
+
+  .hx-data-table-advanced-search-filter-group + .hx-data-table-advanced-search-filter-group {
+    margin-top: 8px;
+  }
+
+  .hx-data-table-advanced-search-filter {
+    margin: 2px 0 0 0;
+  }
+
+  .hx-data-table-advanced-search-filter + .hx-data-table-advanced-search-filter {
+    margin-left: 8px;
+  }
+
+  .hx-data-table-advanced-search-column,
+  .hx-data-table-advanced-search-type {
+    flex-shrink: 0;
+  }
+
+  .hx-data-table-advanced-search-input {
+    min-width: 3em;
+  }
+
+  .hx-data-table-advanced-search-filter {
+    > *:not(:last-child) {
+      border-right-style: none;
+    }
+  }
+
+  .hx-data-table-advanced-search-button {
+    padding: 0.3em 0.4em;
+  }
+
+
+  .hx-data-table-control-panel-bottom {
+    display: none;
+    margin: 0.2em 2px 0 0;
   }
 
   // Cell Styles
@@ -243,160 +358,53 @@
   }
 
   &.hx-data-table-infinite {
-    .hx-data-table-pagination-picker {
+    .hx-data-table-paginator-picker {
       display: none;
     }
   }
 
-  .hx-btn-invisible {
-    padding: 0.4em;
-    margin: 0 0.4em;
-    white-space: nowrap;
-
-    &:first-child {
-      margin-left: 0;
-    }
-
-    &:last-child:not(.hx-toggle) {
-      margin-right: 0;
-    }
-  }
-
-  .hx-data-table-btn-disabled {
-    cursor: not-allowed;
-    opacity: 0.7;
-  }
-
-  .hx-data-table-bottom-control-panel {
-    display: none;
-    margin: 0.2em 2px 0 0;
-  }
 
   &.hx-data-table-compact,
   &.hx-data-table-show-search-above-table {
-    .hx-data-table-bottom-control-panel {
-      display: flex;
+    .hx-data-table-control-panel-bottom {
       order: 4;
+    }
+
+    .hx-data-table-control-panel-bottom-visible {
+      display: flex;
     }
   }
 
+  // Use 'not' so we don't have to override styles in compact mode
   &:not(.hx-data-table-compact) {
-    .hx-data-table-control-panel-container:not(.hx-data-table-filter-enabled) {
+    .hx-data-table-control-panel-visible:not(.hx-data-table-filter-enabled) {
       display: flex;
       flex-flow: row wrap-reverse;
       align-items: flex-end;
 
-      .hx-data-table-control-panel {
+      .hx-data-table-control-panel-inner {
         order: 2;
       }
     }
-  }
 
-  &.hx-data-table-show-search-above-table:not(.hx-data-table-compact) {
-    .hx-data-table-control-panel-container {
-      order: 1;
-      box-shadow: none;
+    &.hx-data-table-show-search-above-table {
+      .hx-data-table-control-panel {
+        order: 1;
+        box-shadow: none;
 
-      .hx-data-table-page-size,
-      .hx-data-table-pagination {
-        display: none;
+        .hx-data-table-page-size,
+        .hx-data-table-paginator {
+          display: none;
+        }
       }
-    }
-    .hx-data-table-status-bar {
-      order: 2;
-    }
-    .hx-data-table-content {
-      order: 3;
-    }
-  }
-
-  .hx-data-table-compact-control-panel-toggle {
-    opacity: 0.4;
-    display: none;
-  }
-
-  .hx-data-table-compact-control-panel-toggle-visible {
-    display: initial;
-  }
-
-  .hx-data-table-compact-control-panel {
-    display: none;
-    margin-right: 2px;
-
-    &.hx-data-table-compact-control-panel-open {
-      .hx-data-table-compact-control-panel-toggle {
-        opacity: 0.75;
+      .hx-data-table-status-bar {
+        order: 2;
+      }
+      .hx-data-table-content {
+        order: 3;
       }
     }
   }
-
-  .hx-data-table-advanced-search-icon {
-    margin-right: 0.2em;
-  }
-
-  .hx-data-table-advanced-search-toggle,
-  .hx-data-table-advanced-search {
-    display: none;
-  }
-
-  .hx-data-table-advanced-search-visible {
-    display: block;
-  }
-
-  .hx-data-table-advanced-search-toggle:first-child {
-    // Lines it up with the search box properly
-    padding: 0.5em 0.2em;
-    margin: 0.25em 0.2em;
-  }
-
-  .hx-data-table-advanced-search-filter-group:first-child {
-    .hx-data-table-advanced-search-filter:first-child {
-      .hx-data-table-advanced-search-type {
-        display: none;
-      }
-      .hx-data-table-advanced-search-column {
-        border-radius: 0.2em 0 0 0.2em;
-      }
-    }
-  }
-
-  .hx-data-table-advanced-search-container:not(:empty) {
-    margin: 0.2em;
-    max-width: 25em;
-  }
-
-  .hx-data-table-advanced-search-filter-group + .hx-data-table-advanced-search-filter-group {
-    margin-top: 8px;
-  }
-
-  .hx-data-table-advanced-search-filter {
-    margin: 2px 0 0 0;
-  }
-
-  .hx-data-table-advanced-search-filter + .hx-data-table-advanced-search-filter {
-    margin-left: 8px;
-  }
-
-  .hx-data-table-advanced-search-column,
-  .hx-data-table-advanced-search-type {
-    flex-shrink: 0;
-  }
-
-  .hx-data-table-advanced-search-input {
-    min-width: 3em;
-  }
-
-  .hx-data-table-advanced-search-filter {
-    > *:not(:last-child) {
-      border-right-style: none;
-    }
-  }
-
-  .hx-data-table-advanced-search-button {
-    padding: 0.5em 0.4em;
-    margin: 0.25em 0.2em;
-  }
-
 
   // Compact Mode
   &.hx-data-table-compact {
@@ -412,25 +420,15 @@
       border: none;
     }
 
-    .hx-data-table-bottom-control-panel {
+    .hx-data-table-control-panel-bottom {
       flex-direction: column;
-    }
-
-    .hx-data-table-compact-control-panel {
-      display: flex;
-      text-align: right;
-      justify-content: space-between;
-
-      > .hx-btn {
-        font-size: 1.5em;
-      }
     }
 
     .hx-data-table-compact-hide {
       display: none;
     }
 
-    .hx-data-table-pagination-picker {
+    .hx-data-table-paginator-picker {
       padding-left: 0;
     }
 
@@ -466,7 +464,11 @@
       visibility: visible;
     }
 
-    .hx-data-table-control-panel {
+    .hx-data-table-control-panel-compact-visible {
+      display: flex;
+    }
+
+    .hx-data-table-control-panel-inner {
       flex-direction: column-reverse;
     }
 
@@ -482,11 +484,7 @@
       text-align: left;
     }
 
-    .hx-data-table-spacer {
-      display: none;
-    }
-
-    .hx-data-table-sort-control {
+    .hx-data-table-sort {
       display: none;
     }
 
@@ -494,12 +492,11 @@
       display: flex;
     }
 
-    // Order reversed because structure is backwards (column-reverse)
     .hx-data-table-page-size {
       order: 3;
     }
 
-    .hx-data-table-sort-control {
+    .hx-data-table-sort {
       order: 2;
     }
 
@@ -508,10 +505,13 @@
       flex-direction: column;
     }
 
-
-    .hx-data-table-control-panel-container {
+    .hx-data-table-control-panel {
       order: 1;
       margin-right: 2px;
+
+      .hx-data-table-spacer {
+        display: none;
+      }
     }
 
     .hx-data-table-status-bar {

--- a/modules/data-table/main/index.scss
+++ b/modules/data-table/main/index.scss
@@ -52,19 +52,24 @@
   }
 
   // Footer
-  .hx-data-table-footer {
+  .hx-data-table-control-panel {
     display: flex;
-    flex-direction: row;
+    flex-direction: row-reverse;
     flex-wrap: wrap;
     flex-grow: 1;
     flex-shrink: 0;
+    justify-content: flex-end;
   }
 
-  .hx-data-table-footer-spacer {
+  .hx-data-table-filter-container {
+    display: flex;
+  }
+
+  .hx-data-table-spacer {
     flex-grow: 1;
   }
 
-  .hx-data-table-pagination-block {
+  .hx-data-table-pagination {
     display: flex;
     flex-wrap: nowrap;
   }
@@ -80,11 +85,13 @@
 
   .hx-data-table-filter-control {
     display: none;
-    margin: 0.25em;
-    padding: 0.25em;
+    margin: 0.25em 0.2em;
+    padding: 0.5em;
+    flex: 1;
+    min-width: 0;
   }
 
-  .hx-data-table-pagination-block-visible,
+  .hx-data-table-pagination-visible,
   .hx-data-table-select-page-size,
   .hx-data-table-multi-page {
     display: flex;
@@ -250,7 +257,7 @@
       margin-left: 0;
     }
 
-    &:last-child {
+    &:last-child:not(.hx-toggle) {
       margin-right: 0;
     }
   }
@@ -259,6 +266,137 @@
     cursor: not-allowed;
     opacity: 0.7;
   }
+
+  .hx-data-table-bottom-control-panel {
+    display: none;
+    margin: 0.2em 2px 0 0;
+  }
+
+  &.hx-data-table-compact,
+  &.hx-data-table-show-search-above-table {
+    .hx-data-table-bottom-control-panel {
+      display: flex;
+      order: 4;
+    }
+  }
+
+  &:not(.hx-data-table-compact) {
+    .hx-data-table-control-panel-container:not(.hx-data-table-filter-enabled) {
+      display: flex;
+      flex-flow: row wrap-reverse;
+      align-items: flex-end;
+
+      .hx-data-table-control-panel {
+        order: 2;
+      }
+    }
+  }
+
+  &.hx-data-table-show-search-above-table:not(.hx-data-table-compact) {
+    .hx-data-table-control-panel-container {
+      order: 1;
+      box-shadow: none;
+
+      .hx-data-table-page-size,
+      .hx-data-table-pagination {
+        display: none;
+      }
+    }
+    .hx-data-table-status-bar {
+      order: 2;
+    }
+    .hx-data-table-content {
+      order: 3;
+    }
+  }
+
+  .hx-data-table-compact-control-panel-toggle {
+    opacity: 0.4;
+    display: none;
+  }
+
+  .hx-data-table-compact-control-panel-toggle-visible {
+    display: initial;
+  }
+
+  .hx-data-table-compact-control-panel {
+    display: none;
+    margin-right: 2px;
+
+    &.hx-data-table-compact-control-panel-open {
+      .hx-data-table-compact-control-panel-toggle {
+        opacity: 0.75;
+      }
+    }
+  }
+
+  .hx-data-table-advanced-search-icon {
+    margin-right: 0.2em;
+  }
+
+  .hx-data-table-advanced-search-toggle,
+  .hx-data-table-advanced-search {
+    display: none;
+  }
+
+  .hx-data-table-advanced-search-visible {
+    display: block;
+  }
+
+  .hx-data-table-advanced-search-toggle:first-child {
+    // Lines it up with the search box properly
+    padding: 0.5em 0.2em;
+    margin: 0.25em 0.2em;
+  }
+
+  .hx-data-table-advanced-search-filter-group:first-child {
+    .hx-data-table-advanced-search-filter:first-child {
+      .hx-data-table-advanced-search-type {
+        display: none;
+      }
+      .hx-data-table-advanced-search-column {
+        border-radius: 0.2em 0 0 0.2em;
+      }
+    }
+  }
+
+  .hx-data-table-advanced-search-container:not(:empty) {
+    margin: 0.2em;
+    max-width: 25em;
+  }
+
+  .hx-data-table-advanced-search-filter-group + .hx-data-table-advanced-search-filter-group {
+    margin-top: 8px;
+  }
+
+  .hx-data-table-advanced-search-filter {
+    margin: 2px 0 0 0;
+  }
+
+  .hx-data-table-advanced-search-filter + .hx-data-table-advanced-search-filter {
+    margin-left: 8px;
+  }
+
+  .hx-data-table-advanced-search-column,
+  .hx-data-table-advanced-search-type {
+    flex-shrink: 0;
+  }
+
+  .hx-data-table-advanced-search-input {
+    min-width: 3em;
+  }
+
+  .hx-data-table-advanced-search-filter {
+    > *:not(:last-child) {
+      border-right-style: none;
+    }
+  }
+
+  .hx-data-table-advanced-search-button {
+    padding: 0.5em 0.4em;
+    margin: 0.25em 0.2em;
+  }
+
 
   // Compact Mode
   &.hx-data-table-compact {
@@ -274,9 +412,26 @@
       border: none;
     }
 
-    .hx-data-table-filter-control {
-      margin: 0.5em;
-      padding: 0.5em;
+    .hx-data-table-bottom-control-panel {
+      flex-direction: column;
+    }
+
+    .hx-data-table-compact-control-panel {
+      display: flex;
+      text-align: right;
+      justify-content: space-between;
+
+      > .hx-btn {
+        font-size: 1.5em;
+      }
+    }
+
+    .hx-data-table-compact-hide {
+      display: none;
+    }
+
+    .hx-data-table-pagination-picker {
+      padding-left: 0;
     }
 
     .hx-sticky-table-headers {
@@ -311,14 +466,23 @@
       visibility: visible;
     }
 
-    .hx-data-table-footer {
-      order: 1;
-      // flex: 1 1 auto;
-      flex-direction: column;
-      margin-right: 2px;
+    .hx-data-table-control-panel {
+      flex-direction: column-reverse;
     }
 
-    .hx-data-table-footer-spacer {
+    .hx-data-table-advanced-search-buttons {
+      display: flex;
+
+      button {
+        flex: 1 0 auto;
+      }
+    }
+
+    .hx-data-table-advanced-search-toggle {
+      text-align: left;
+    }
+
+    .hx-data-table-spacer {
       display: none;
     }
 
@@ -330,17 +494,24 @@
       display: flex;
     }
 
-    .hx-data-table-pagination-block {
+    // Order reversed because structure is backwards (column-reverse)
+    .hx-data-table-page-size {
+      order: 3;
+    }
+
+    .hx-data-table-sort-control {
+      order: 2;
+    }
+
+    .hx-data-table-filter-container {
       order: 1;
       flex-direction: column;
     }
 
-    .hx-data-table-page-size {
-      order: 1;
-    }
 
-    .hx-data-table-paginator {
-      order: 2;
+    .hx-data-table-control-panel-container {
+      order: 1;
+      margin-right: 2px;
     }
 
     .hx-data-table-status-bar {

--- a/modules/data-table/main/theme.scss
+++ b/modules/data-table/main/theme.scss
@@ -51,11 +51,11 @@
     }
   }
 
-  .hx-data-table-bottom-control-panel,
-  .hx-data-table-compact-control-panel,
-  .hx-data-table-control-panel-container {
+  .hx-data-table-control-panel-bottom,
+  .hx-data-table-control-panel-compact,
+  .hx-data-table-control-panel {
     background: $footer-background-col;
-    box-shadow: 1px 1px 1px 1px $footer-shadow-col;
+    box-shadow: 1px 1px 1px $footer-shadow-col;
   }
 
   .hx-data-table-status-bar {

--- a/modules/data-table/main/theme.scss
+++ b/modules/data-table/main/theme.scss
@@ -51,7 +51,9 @@
     }
   }
 
-  .hx-data-table-footer {
+  .hx-data-table-bottom-control-panel,
+  .hx-data-table-compact-control-panel,
+  .hx-data-table-control-panel-container {
     background: $footer-background-col;
     box-shadow: 1px 1px 1px 1px $footer-shadow-col;
   }

--- a/modules/data-table/module.json
+++ b/modules/data-table/module.json
@@ -15,6 +15,7 @@
     "sort",
     "sticky-table-headers",
     "table",
+    "toggle",
     "user-facing-text",
     "util"
   ]

--- a/modules/data-table/module.json
+++ b/modules/data-table/module.json
@@ -2,8 +2,10 @@
   "dependencies": [
     "button",
     "button-group",
+    "component",
     "event-emitter",
     "filter",
+    "fluid",
     "icon",
     "picker",
     "request",

--- a/modules/data-table/test/spec.coffee
+++ b/modules/data-table/test/spec.coffee
@@ -219,6 +219,7 @@ describe 'data-table', ->
     checkOption('displayMode', ['paginate', 'all'])
     checkOption('feed', [hx.dataTable.objectFeed(noData), hx.dataTable.objectFeed(threeRowsData)])
     checkOption('filter', ['bob', 'aaaa', undefined])
+    checkOption('advancedSearch', [[[{column: 'any', term: 'a'}]], [[{column: 'any', term: 'a'}, {column: 'any', term: 'b'}]], undefined])
     checkOption('filterEnabled', [true, false])
     checkOption('showAdvancedSearch', [true, false])
     checkOption('advancedSearchEnabled', [true, false])
@@ -275,6 +276,15 @@ describe 'data-table', ->
           hx.select(rows[2]).selectAll('td').selectAll('.hx-data-table-cell-key').text().should.eql(headers)
           hx.select(rows[2]).selectAll('td').selectAll('.hx-data-table-cell-value').text().should.eql(['Dan', '41', 'Builder'])
 
+        it 'should not show the search above the table', ->
+          container.classed('hx-data-table-show-search-above-content').should.equal(false)
+
+        it 'should not show the bottom control panel', ->
+          container.select('.hx-data-table-control-panel-bottom-visible').empty().should.equal(true)
+
+        it 'should show the control panel', ->
+          container.select('.hx-data-table-control-panel-visible').empty().should.equal(false)
+
         it 'should not show the paginator', ->
           container.selectAll('.hx-data-table-paginator-visible').size().should.equal(0)
 
@@ -301,7 +311,7 @@ describe 'data-table', ->
       it 'should add the allowHeaderWrap class to all columns when enabled by default', (done) ->
         tableOptions =
           allowHeaderWrap: true
-        testTable {tableOptions: tableOptions}, done, (container, dt, options, data) ->
+        testTable {tableOptions}, done, (container, dt, options, data) ->
           container.select('.hx-sticky-table-header-top').selectAll('.hx-table-header-allow-wrap').size().should.equal(3)
 
       it 'should allow allowHeaderWrap for individual columns', (done) ->
@@ -314,7 +324,7 @@ describe 'data-table', ->
             profession:
               allowHeaderWrap: false
 
-        testTable {tableOptions: tableOptions}, done, (container, dt, options, data) ->
+        testTable {tableOptions}, done, (container, dt, options, data) ->
           container.select('.hx-sticky-table-header-top').selectAll('.hx-table-header-allow-wrap').size().should.equal(1)
 
       it 'should override default allowHeaderWrap when defined for a column', (done) ->
@@ -324,7 +334,7 @@ describe 'data-table', ->
             name:
               allowHeaderWrap: false
 
-        testTable {tableOptions: tableOptions}, done, (container, dt, options, data) ->
+        testTable {tableOptions}, done, (container, dt, options, data) ->
           container.select('.hx-sticky-table-header-top').selectAll('.hx-table-header-allow-wrap').size().should.equal(2)
 
 
@@ -333,7 +343,7 @@ describe 'data-table', ->
       it 'should call the cellRenderer', (done) ->
         tableOptions =
           cellRenderer: (elem) -> hx.select(elem).classed('bob', true)
-        testTable {tableOptions: tableOptions}, done, (container, dt, options, data) ->
+        testTable {tableOptions}, done, (container, dt, options, data) ->
           container.select('.hx-sticky-table-wrapper').select('tbody').select('.hx-data-table-row').selectAll('.bob').size().should.equal(3)
 
       it 'should call the cellRenderer for individual columns', (done) ->
@@ -346,7 +356,7 @@ describe 'data-table', ->
             profession:
               cellRenderer: (elem) -> hx.select(elem).classed('steve', true)
 
-        testTable {tableOptions: tableOptions}, done, (container, dt, options, data) ->
+        testTable {tableOptions}, done, (container, dt, options, data) ->
           container.select('.hx-sticky-table-wrapper').select('tbody').select('.hx-data-table-row').selectAll('.bob').size().should.equal(1)
           container.select('.hx-sticky-table-wrapper').select('tbody').select('.hx-data-table-row').selectAll('.dave').size().should.equal(1)
           container.select('.hx-sticky-table-wrapper').select('tbody').select('.hx-data-table-row').selectAll('.steve').size().should.equal(1)
@@ -358,7 +368,7 @@ describe 'data-table', ->
             name:
               cellRenderer: (elem) -> hx.select(elem).classed('bob', true)
 
-        testTable {tableOptions: tableOptions}, done, (container, dt, options, data) ->
+        testTable {tableOptions}, done, (container, dt, options, data) ->
           container.select('.hx-sticky-table-wrapper').select('tbody').select('.hx-data-table-row').selectAll('.bob').size().should.equal(1)
           container.select('.hx-sticky-table-wrapper').select('tbody').select('.hx-data-table-row').selectAll('.kate').size().should.equal(2)
 
@@ -370,7 +380,7 @@ describe 'data-table', ->
         rowCollapsibleLookup: (row) -> true
       }
 
-      testTable {tableOptions: tableOptions}, undefined, (container, dt, options, data) ->
+      testTable {tableOptions}, undefined, (container, dt, options, data) ->
         it 'should show collapsible expand icons', ->
           container.select('.hx-sticky-table-header-left').select('tbody').selectAll('.hx-data-table-collapsible-toggle').size().should.equal(data.rows.length)
 
@@ -396,7 +406,7 @@ describe 'data-table', ->
           collapsibleRenderer: (element, d) -> hx.select(element).class('bob')
           rowCollapsibleLookup: (row) -> !!row.collapsible
         }
-        testTable {tableOptions: tableOptions}, done, (container, dt, options, data) ->
+        testTable {tableOptions}, done, (container, dt, options, data) ->
           dt.expandedRows ['0', '1'], ->
             container.select('.hx-sticky-table-wrapper').select('tbody').selectAll('.hx-data-table-collapsible-content-row').size().should.equal(1)
             container.select('.hx-sticky-table-header-left').select('tbody').selectAll('.hx-data-table-collapsible-content-row').size().should.equal(1)
@@ -407,7 +417,7 @@ describe 'data-table', ->
           collapsibleRenderer: (element, d) -> hx.select(element).class('bob')
           rowCollapsibleLookup: (row) -> !!row.collapsible
         }
-        testTable {tableOptions: tableOptions}, done, (container, dt, options, data) ->
+        testTable {tableOptions}, done, (container, dt, options, data) ->
           dt.expandedRows().should.eql([])
 
           clickHandlers = container.select('.hx-sticky-table-header-left').select('tbody').selectAll('.hx-data-table-collapsible-toggle')
@@ -537,7 +547,7 @@ describe 'data-table', ->
       it 'should call the headerCellRenderer', (done) ->
         tableOptions =
           headerCellRenderer: (elem) -> hx.select(elem).classed('bob', true)
-        testTable {tableOptions: tableOptions}, done, (container, dt, options, data) ->
+        testTable {tableOptions}, done, (container, dt, options, data) ->
           container.select('.hx-sticky-table-header-top').select('thead').selectAll('.bob').size().should.equal(3)
 
       it 'should call the headerCellRenderer for individual columns', (done) ->
@@ -550,7 +560,7 @@ describe 'data-table', ->
             profession:
               headerCellRenderer: (elem) -> hx.select(elem).classed('steve', true)
 
-        testTable {tableOptions: tableOptions}, done, (container, dt, options, data) ->
+        testTable {tableOptions}, done, (container, dt, options, data) ->
           container.select('.hx-sticky-table-header-top').select('thead').selectAll('.bob').size().should.equal(1)
           container.select('.hx-sticky-table-header-top').select('thead').selectAll('.dave').size().should.equal(1)
           container.select('.hx-sticky-table-header-top').select('thead').selectAll('.steve').size().should.equal(1)
@@ -562,7 +572,7 @@ describe 'data-table', ->
             name:
               headerCellRenderer: (elem) -> hx.select(elem).classed('bob', true)
 
-        testTable {tableOptions: tableOptions}, done, (container, dt, options, data) ->
+        testTable {tableOptions}, done, (container, dt, options, data) ->
           container.select('.hx-sticky-table-header-top').select('thead').selectAll('.bob').size().should.equal(1)
           container.select('.hx-sticky-table-header-top').select('thead').selectAll('.kate').size().should.equal(2)
 
@@ -1058,7 +1068,7 @@ describe 'data-table', ->
             profession:
               sortEnabled: false
 
-        testTable {tableOptions: tableOptions}, done, (container, dt, options, data) ->
+        testTable {tableOptions}, done, (container, dt, options, data) ->
           container.select('.hx-sticky-table-header-top').selectAll('.hx-data-table-sort-icon').size().should.equal(1)
 
       it 'should use a column sortEnabled instead of the default sortEnabled if one is defined', (done) ->
@@ -1068,7 +1078,7 @@ describe 'data-table', ->
             name:
               sortEnabled: true
 
-        testTable {tableOptions: tableOptions}, done, (container, dt, options, data) ->
+        testTable {tableOptions}, done, (container, dt, options, data) ->
           container.select('.hx-sticky-table-header-top').selectAll('.hx-data-table-sort-icon').size().should.equal(1)
 
       it 'should change the sort when clicking a sort icon', (done) ->
@@ -1094,6 +1104,10 @@ describe 'data-table', ->
           dt.sort().should.eql({column: 'age', direction: 'asc'})
 
       describe 'compact mode', ->
+        it 'should show the compact control panel for default options', ->
+          testTable {tableOptions: {compact: true}}, undefined, (container, dt, options, data) ->
+            container.select('.hx-data-table-control-panel-compact-visible').empty().should.equal(false)
+
         it 'should not show the sort control if there are no sorts', ->
           testTable {tableOptions: {compact: true, sortEnabled: false}}, undefined, (container, dt, options, data) ->
             container.select('.hx-data-table-sort').classed('hx-data-table-sort-visible').should.equal(false)
@@ -1140,7 +1154,7 @@ describe 'data-table', ->
             name:
               maxWidth: 10
 
-        testTable {tableOptions: tableOptions}, done, (container, dt, options, data) ->
+        testTable {tableOptions}, done, (container, dt, options, data) ->
           container.select('.hx-sticky-table-wrapper').select('tbody').select('tr').selectAll('td').forEach (cell, index) ->
             if index is 0
               cell.attr('style').should.equal('max-width: 10px; width: 10px; min-width: 10px; ')
@@ -1198,6 +1212,41 @@ describe 'data-table', ->
           filterSpy.should.have.been.called.with('a', undefined, 'user')
           clock.uninstall()
           done()
+
+
+
+    describe 'showSearchAboveTable', ->
+      it 'should add the correct class to the table', (done) ->
+        # The re-ordering is done by CSS
+        tableOptions =
+          showSearchAboveTable: true
+
+        testTable {tableOptions}, done, (container, dt, options, data) ->
+          container.classed('hx-data-table-show-search-above-content').should.equal(true)
+          container.select('.hx-data-table-control-panel-bottom-visible').size().should.equal(0)
+          container.select('.hx-data-table-control-panel-visible').size().should.equal(1)
+
+      it 'should show the bottom control panel if there are page size options', (done) ->
+        # The re-ordering is done by CSS
+        tableOptions =
+          showSearchAboveTable: true
+          pageSizeOptions: [1,2,3,4,5]
+
+        testTable {tableOptions}, done, (container, dt, options, data) ->
+          container.classed('hx-data-table-show-search-above-content').should.equal(true)
+          container.select('.hx-data-table-control-panel-bottom-visible').size().should.equal(1)
+          container.select('.hx-data-table-control-panel-visible').size().should.equal(1)
+
+      it 'should show the bottom control panel if there are multiple pages', (done) ->
+        # The re-ordering is done by CSS
+        tableOptions =
+          showSearchAboveTable: true
+          pageSize: 1
+
+        testTable {tableOptions}, done, (container, dt, options, data) ->
+          container.classed('hx-data-table-show-search-above-content').should.equal(true)
+          container.select('.hx-data-table-control-panel-bottom-visible').size().should.equal(1)
+          container.select('.hx-data-table-control-panel-visible').size().should.equal(1)
 
 
 
@@ -1317,6 +1366,62 @@ describe 'data-table', ->
 
 
 
+    describe 'advanced search', ->
+      describe 'showAdvancedSearch', ->
+        it 'should show the advanced search toggle when filters are enabled', -> # TODO
+
+        it 'should not show the advanced search toggle when filters are disabled', -> # TODO
+
+        it 'should toggle the advanced and regular filters correctly', -> # TODO
+
+
+      describe 'advancedSearchEnabled', ->
+        it 'should not be enabled by default', -> # TODO
+
+        it 'should hide the filter input when enabled', -> # TODO
+
+      describe 'hx.dataTable.getAdvancedSearchFilter', ->
+        it 'should use the defaults if provided', ->
+          advancedSearchFilter = hx.dataTable.getAdvancedSearchFilter()
+
+          filter = [[{column: 'name', term: 'Bob'}]]
+
+          advancedSearchFilter(filter, {cells: {name: 'Bob'}}).should.equal(true)
+          advancedSearchFilter(filter, {cells: {name: 'Steve'}}).should.equal(false)
+          advancedSearchFilter(filter, {cells: {name: 'Bobby'}}).should.equal(true)
+
+          filter = [[{column: 'any', term: 'Bob'}, {column: 'any', term: 'Steve'}]]
+
+          advancedSearchFilter(filter, {cells: {name: 'Bob', surname: 'Steve'}}).should.equal(true)
+          advancedSearchFilter(filter, {cells: {name: 'steve', surname: 'bob'}}).should.equal(true)
+
+        it 'should use the provided cellValueLookup', ->
+          cellValueLookup = (cell) -> cell.value
+
+          advancedSearchFilter = hx.dataTable.getAdvancedSearchFilter(cellValueLookup)
+
+          filter = [[{column: 'name', term: 'Bob'}]]
+
+          advancedSearchFilter(filter, {cells: {name: {text: 'a', value: 'Bob'}}}).should.equal(true)
+          advancedSearchFilter(filter, {cells: {name: {text: 'b', value: 'Steve'}}}).should.equal(false)
+          advancedSearchFilter(filter, {cells: {name: {text: 'c', value: 'Bobby'}}}).should.equal(true)
+
+        it 'should use the provided termLookup', ->
+          termLookup = (term, rowSearchTerm) -> rowSearchTerm.indexOf(term) > -1
+
+          filter = [[{column: 'name', term: 'Bob Steve'}]]
+
+          advancedSearchFilter = hx.dataTable.getAdvancedSearchFilter(undefined, termLookup)
+
+          advancedSearchFilter(filter, {cells: {name: 'Bob Steve'}}).should.equal(true)
+          advancedSearchFilter(filter, {cells: {name: 'bob a steve'}}).should.equal(false)
+
+          filter = [[{column: 'any', term: 'Bob'}, {column: 'any', term: 'Steve'}]]
+
+          advancedSearchFilter(filter, {cells: {name: 'Bob', surname: 'Steve'}}).should.equal(true)
+          advancedSearchFilter(filter, {cells: {name: 'steve', surname: 'bob'}}).should.equal(true)
+
+
 
   describe 'rowsForIds', ->
     it 'should return the correct values', (done) ->
@@ -1358,6 +1463,238 @@ describe 'data-table', ->
       f.should.not.have.been.called()
       container.select('.hx-data-table-content').node().childNodes.length.should.equal(0)
       container.selectAll('.hx-data-table-table').size().should.equal(0)
+
+
+
+
+
+
+
+  describe 'events', ->
+
+    describe 'sortchange', ->
+      it 'should emit an event when sort clicked with cause: user', (done) ->
+        selection = hx.detached('div')
+        dt = new hx.DataTable(selection.node())
+
+        dt.on 'sortchange', (d) ->
+          d.value.column.should.equal('name')
+          d.value.direction.should.equal('asc')
+          d.cause.should.equal('user')
+          done()
+
+        dt.feed hx.dataTable.objectFeed(threeRowsData), ->
+          fakeNodeEvent(selection.select('.hx-sticky-table-header-top').select('.hx-data-table-cell').node(), 'click')()
+
+    describe 'filterchange', ->
+      it 'should emit an event when filter clicked with cause: user', (done) ->
+        selection = hx.detached('div')
+        dt = new hx.DataTable(selection.node())
+
+        dt.on 'filterchange', (d) ->
+          d.value.should.equal('test')
+          d.cause.should.equal('user')
+          done()
+
+        dt.feed hx.dataTable.objectFeed(threeRowsData), ->
+          selection.select('.hx-data-table-filter').value('test')
+          fakeNodeEvent(selection.select('.hx-data-table-filter').node(), 'input')()
+
+    describe 'selectedrowschange', ->
+      it 'should emit an event when rows are selected/deselected', (done) ->
+        selection = hx.detached('div')
+        dt = new hx.DataTable(selection.node(), {
+          selectEnabled: true,
+          rowSelectableLookup: (row) -> true
+        })
+
+        n = 0
+        dt.on 'selectedrowschange', (d) ->
+
+          if n is 0
+            d.row.should.eql(threeRowsData.rows[0])
+            d.rowValue.should.equal(true)
+            d.value.should.eql([threeRowsData.rows[0].id])
+            d.cause.should.equal('user')
+            n++
+          else if n is 1
+            d.row.should.eql(threeRowsData.rows[2])
+            d.rowValue.should.equal(true)
+            d.value.should.eql([threeRowsData.rows[0].id, threeRowsData.rows[2].id])
+            d.cause.should.equal('user')
+            n++
+          else if n is 2
+            d.row.should.eql(threeRowsData.rows[0])
+            d.rowValue.should.equal(false)
+            d.value.should.eql([threeRowsData.rows[2].id])
+            d.cause.should.equal('user')
+            done()
+
+        dt.feed hx.dataTable.objectFeed(threeRowsData), ->
+          fakeNodeEvent(selection.select('.hx-sticky-table-header-left').select('tbody').selectAll('.hx-data-table-checkbox').node(0), 'click')(fakeEvent)
+          fakeNodeEvent(selection.select('.hx-sticky-table-header-left').select('tbody').selectAll('.hx-data-table-checkbox').node(2), 'click')(fakeEvent)
+          fakeNodeEvent(selection.select('.hx-sticky-table-header-left').select('tbody').selectAll('.hx-data-table-checkbox').node(0), 'click')(fakeEvent)
+
+    describe 'selectedrowsclear', ->
+      it 'should emit an event when the selected rows is cleared', (done) ->
+        selection = hx.detached('div')
+        dt = new hx.DataTable(selection.node(), {
+          selectEnabled: true,
+          rowSelectableLookup: (row) -> true
+        })
+
+        n = 0
+        dt.on 'selectedrowschange', (d) ->
+          if n is 1
+            fakeNodeEvent(selection.select('.hx-data-table-status-bar-clear').node(0), 'click')(fakeEvent)
+          n++
+
+        dt.on 'selectedrowsclear', (d) ->
+          done()
+
+        dt.feed hx.dataTable.objectFeed(threeRowsData), ->
+          fakeNodeEvent(selection.select('.hx-sticky-table-header-left').select('tbody').selectAll('.hx-data-table-checkbox').node(0), 'click')(fakeEvent)
+          fakeNodeEvent(selection.select('.hx-sticky-table-header-left').select('tbody').selectAll('.hx-data-table-checkbox').node(2), 'click')(fakeEvent)
+
+    describe 'expandedrowschange', ->
+      it 'should emit an event when row is collapsed/expanded', (done) ->
+
+        selection = hx.detached('div')
+        dt = new hx.DataTable(selection.node(), {
+          collapsibleRenderer: ->
+          rowCollapsibleLookup: (row) -> true
+        })
+
+        first = true
+        dt.on 'expandedrowschange', (d) ->
+          d.row.should.eql(threeRowsData.rows[0])
+          if first
+            d.rowValue.should.equal(true)
+            d.value.should.eql([threeRowsData.rows[0].id])
+            d.cause.should.equal('user')
+            first = false
+          else
+            d.rowValue.should.equal(false)
+            d.value.should.eql([])
+            d.cause.should.equal('user')
+            done()
+
+        dt.feed hx.dataTable.objectFeed(threeRowsData), ->
+          fakeNodeEvent(selection.select('.hx-sticky-table-header-left').select('.hx-data-table-collapsible-toggle').node(), 'click')()
+          fakeNodeEvent(selection.select('.hx-sticky-table-header-left').select('.hx-data-table-collapsible-toggle').node(), 'click')()
+
+    describe 'rowclick', ->
+      it 'should emit an event when the row is clicked', (done) ->
+        selection = hx.detached('div')
+        dt = new hx.DataTable(selection.node(), {pageSizeOptions: [5, 10, 15]})
+
+        dt.on 'rowclick', (d) ->
+          d.data.should.eql(threeRowsData.rows[0])
+          d.node.should.be.an.instanceof(Element)
+          done()
+
+        dt.feed hx.dataTable.objectFeed(threeRowsData), ->
+          fakeNodeEvent(selection.select('.hx-sticky-table-wrapper').select('.hx-data-table-body').select('.hx-data-table-row').node(), 'click')()
+
+    describe 'render', ->
+      it 'should emit an event when the row is clicked', (done) ->
+        selection = hx.detached('div')
+        dt = new hx.DataTable(selection.node(), {pageSizeOptions: [5, 10, 15]})
+
+        dt.on 'render', -> done()
+
+        dt.feed hx.dataTable.objectFeed(threeRowsData)
+
+    describe 'pagesizechange', ->
+      it 'should emit an event when the page size is changed with cause: user', (done) ->
+        selection = hx.detached('div')
+        dt = new hx.DataTable(selection.node(), {pageSizeOptions: [5, 10, 15]})
+
+        dt.on 'pagesizechange', (d) ->
+          d.value.should.equal(10)
+          d.cause.should.equal('user')
+          done()
+
+        dt.feed hx.dataTable.objectFeed(threeRowsData), ->
+          selection
+            .select('.hx-data-table-page-size-picker')
+            .component()
+            .emit('change', {value: {value: 10, text: '10'}, cause: 'user'})
+
+    describe 'pagechange', ->
+
+      describe 'should emit an event when the page changes', ->
+
+        it 'should work when setting the page to 2', (done) ->
+          selection = hx.detached('div')
+          dt = new hx.DataTable(selection.node(), {pageSize: 2, pageSizeOptions: [5, 10, 15]})
+          dt.on 'pagechange', (d) ->
+            d.value.should.eql(2)
+            d.cause.should.equal('user')
+            done()
+          dt.feed hx.dataTable.objectFeed(threeRowsData), ->
+            selection.select('.hx-data-table-paginator-picker').component().emit('change', {value: {value: 2}, cause: 'user'})
+
+        it 'should work when setting the page to 1', (done) ->
+          selection = hx.detached('div')
+          dt = new hx.DataTable(selection.node(), {pageSize: 2, pageSizeOptions: [5, 10, 15]})
+          dt.on 'pagechange', (d) ->
+            d.value.should.equal(1)
+            d.cause.should.equal('user')
+            done()
+          dt.feed hx.dataTable.objectFeed(threeRowsData), ->
+            selection.select('.hx-data-table-paginator-picker').component().emit('change', {value: {value: 1}, cause: 'user'})
+
+    describe 'compactchange', ->
+      it 'should emit an event when changing from full to compact', (done) ->
+
+        container = hx.select('body').append('div').style('width', '1000px')
+
+        dt = new hx.DataTable(container.node())
+
+        dt.on 'compactchange', (d) ->
+          d.value.should.equal('auto')
+          d.state.should.equal(true)
+          d.cause.should.equal('user')
+          hx.select('body').clear()
+          done()
+
+        dt.feed hx.dataTable.objectFeed(threeRowsData), ->
+          container.style('width', '100px')
+
+      it 'should emit an event when changing from compact to full', (done) ->
+        container = hx.select('body').append('div').style('width', '100px')
+
+        dt = new hx.DataTable(container.node())
+
+        dt.on 'compactchange', (d) ->
+          d.value.should.equal('auto')
+          d.state.should.equal(false)
+          d.cause.should.equal('user')
+          dt.off('compactchange')
+          hx.select('body').clear()
+          done()
+
+        dt.feed hx.dataTable.objectFeed(threeRowsData), ->
+          container.style('width', '1000px')
+
+       it 'should not emit an event if it doesnt change mode', (done) ->
+
+        container = hx.select('body').append('div').style('width', '1000px')
+
+        dt = new hx.DataTable(container.node())
+
+        called = false
+        dt.on 'compactchange', (d) ->
+          called = true
+
+        dt.feed hx.dataTable.objectFeed(threeRowsData), ->
+          container.style('width', '900px')
+
+          f = ->
+            called.should.equal(false)
+            done()
+          setTimeout(f, 50)
 
 
 
@@ -1582,6 +1919,27 @@ describe 'data-table', ->
           ]
         }
 
+        it 'should return the complete dataset when the filter is not defined', (done) ->
+          filter = undefined
+          hx.dataTable.objectFeed(advancedSearchData).rows {start: 0, end: 5, useAdvancedSearch: true, advancedSearch: filter}, (data) ->
+            data.rows.should.eql(advancedSearchData.rows)
+            data.filteredCount.should.equal(6)
+            done()
+
+        it 'should return the complete dataset when the filter is empty', (done) ->
+          filter = []
+          hx.dataTable.objectFeed(advancedSearchData).rows {start: 0, end: 5, useAdvancedSearch: true, advancedSearch: filter}, (data) ->
+            data.rows.should.eql(advancedSearchData.rows)
+            data.filteredCount.should.equal(6)
+            done()
+
+        it 'should return the complete dataset when the filter is empty', (done) ->
+          filter = [[]]
+          hx.dataTable.objectFeed(advancedSearchData).rows {start: 0, end: 5, useAdvancedSearch: true, advancedSearch: filter}, (data) ->
+            data.rows.should.eql(advancedSearchData.rows)
+            data.filteredCount.should.equal(6)
+            done()
+
         it 'should get the rows from the data set with filtering on multiple columns', (done) ->
           filter = [
             [{
@@ -1598,6 +1956,46 @@ describe 'data-table', ->
             ])
             data.filteredCount.should.equal(1)
             done()
+
+        it 'should filter multiple times on the same data', (done) ->
+          filter = [
+            [{
+              column: 'any'
+              term: 'a'
+            }]
+          ]
+          feed = hx.dataTable.objectFeed(advancedSearchData)
+
+          firstData = undefined
+
+          feed.rows {start: 0, end: 5, useAdvancedSearch: true, advancedSearch: filter}, (data) ->
+            firstData = data.rows
+            data.rows.should.eql([
+              { cells: { name: "Wing Simon", phone: "(0151) 610 0311", email: "Curabitur.vel.lectus@nibhdolor.com", company: "Fringilla Corp.", city: "Frignano", keywords: "Morbi sit amet", salary: "£235.59" } }
+              { cells: { name: "Simon Olsen", phone: "056 1366 7271", email: "mauris.sapien.cursus@Proinultrices.com", company: "Aenean Foundation", city: "Istanbul", keywords: "non magna. Nam", salary: "£337.53" } }
+              { cells: { name: "Juliet Ruiz", phone: "0800 692945", email: "vel@Aliquam.ca", company: "Auctor Velit Aliquam Corp.", city: "Kungälv", keywords: "consequat nec, mollis", salary: "£463.76" } }
+              { cells: { name: "Olivia Caldwell", phone: "(01370) 43740", email: "Aenean.massa@condimentum.co.uk", company: "Fringilla Porttitor Vulputate Inc.", city: "Birmingham", keywords: "Donec fringilla. Donec", salary: "£257.33" } }
+              { cells: { name: "Odette Ferrell", phone: "(011495) 29835", email: "dolor@aliquetPhasellus.co.uk", company: "Tincidunt Company", city: "Quedlinburg", keywords: "ac, eleifend vitae,", salary: "£353.87" } }
+              { cells: { name: "Lilah Lamb", phone: "07624 294538", email: "gravida@nonmassa.com", company: "Tellus Justo Sit LLP", city: "Vagli Sotto", keywords: "commodo auctor velit.", salary: "£292.15" } }
+            ])
+            data.filteredCount.should.equal(6)
+
+            filter = [
+              [{
+                column: 'name',
+                term: 'a',
+              }, {
+                column: 'phone',
+                term: '1',
+              }]
+            ]
+
+            feed.rows {start: 0, end: 5, useAdvancedSearch: true, advancedSearch: filter}, (data) ->
+              data.rows.should.eql([
+                { cells: { name: "Olivia Caldwell", phone: "(01370) 43740", email: "Aenean.massa@condimentum.co.uk", company: "Fringilla Porttitor Vulputate Inc.", city: "Birmingham", keywords: "Donec fringilla. Donec", salary: "£257.33" } }
+              ])
+              data.filteredCount.should.equal(1)
+              done()
 
         it 'should filter on "any" column', (done) ->
           filter = [
@@ -1834,233 +2232,6 @@ describe 'data-table', ->
       describe 'with extra object passed in should make the correct requests for', ->
         testFeedWithOptions({extra: 'some-value'})
 
-
-
-  describe 'events', ->
-
-    describe 'sortchange', ->
-      it 'should emit an event when sort clicked with cause: user', (done) ->
-        selection = hx.detached('div')
-        dt = new hx.DataTable(selection.node())
-
-        dt.on 'sortchange', (d) ->
-          d.value.column.should.equal('name')
-          d.value.direction.should.equal('asc')
-          d.cause.should.equal('user')
-          done()
-
-        dt.feed hx.dataTable.objectFeed(threeRowsData), ->
-          fakeNodeEvent(selection.select('.hx-sticky-table-header-top').select('.hx-data-table-cell').node(), 'click')()
-
-    describe 'filterchange', ->
-      it 'should emit an event when filter clicked with cause: user', (done) ->
-        selection = hx.detached('div')
-        dt = new hx.DataTable(selection.node())
-
-        dt.on 'filterchange', (d) ->
-          d.value.should.equal('test')
-          d.cause.should.equal('user')
-          done()
-
-        dt.feed hx.dataTable.objectFeed(threeRowsData), ->
-          selection.select('.hx-data-table-filter').value('test')
-          fakeNodeEvent(selection.select('.hx-data-table-filter').node(), 'input')()
-
-    describe 'selectedrowschange', ->
-      it 'should emit an event when rows are selected/deselected', (done) ->
-        selection = hx.detached('div')
-        dt = new hx.DataTable(selection.node(), {
-          selectEnabled: true,
-          rowSelectableLookup: (row) -> true
-        })
-
-        n = 0
-        dt.on 'selectedrowschange', (d) ->
-
-          if n is 0
-            d.row.should.eql(threeRowsData.rows[0])
-            d.rowValue.should.equal(true)
-            d.value.should.eql([threeRowsData.rows[0].id])
-            d.cause.should.equal('user')
-            n++
-          else if n is 1
-            d.row.should.eql(threeRowsData.rows[2])
-            d.rowValue.should.equal(true)
-            d.value.should.eql([threeRowsData.rows[0].id, threeRowsData.rows[2].id])
-            d.cause.should.equal('user')
-            n++
-          else if n is 2
-            d.row.should.eql(threeRowsData.rows[0])
-            d.rowValue.should.equal(false)
-            d.value.should.eql([threeRowsData.rows[2].id])
-            d.cause.should.equal('user')
-            done()
-
-        dt.feed hx.dataTable.objectFeed(threeRowsData), ->
-          fakeNodeEvent(selection.select('.hx-sticky-table-header-left').select('tbody').selectAll('.hx-data-table-checkbox').node(0), 'click')(fakeEvent)
-          fakeNodeEvent(selection.select('.hx-sticky-table-header-left').select('tbody').selectAll('.hx-data-table-checkbox').node(2), 'click')(fakeEvent)
-          fakeNodeEvent(selection.select('.hx-sticky-table-header-left').select('tbody').selectAll('.hx-data-table-checkbox').node(0), 'click')(fakeEvent)
-
-    describe 'selectedrowsclear', ->
-      it 'should emit an event when the selected rows is cleared', (done) ->
-        selection = hx.detached('div')
-        dt = new hx.DataTable(selection.node(), {
-          selectEnabled: true,
-          rowSelectableLookup: (row) -> true
-        })
-
-        n = 0
-        dt.on 'selectedrowschange', (d) ->
-          if n is 1
-            fakeNodeEvent(selection.select('.hx-data-table-status-bar-clear').node(0), 'click')(fakeEvent)
-          n++
-
-        dt.on 'selectedrowsclear', (d) ->
-          done()
-
-        dt.feed hx.dataTable.objectFeed(threeRowsData), ->
-          fakeNodeEvent(selection.select('.hx-sticky-table-header-left').select('tbody').selectAll('.hx-data-table-checkbox').node(0), 'click')(fakeEvent)
-          fakeNodeEvent(selection.select('.hx-sticky-table-header-left').select('tbody').selectAll('.hx-data-table-checkbox').node(2), 'click')(fakeEvent)
-
-    describe 'expandedrowschange', ->
-      it 'should emit an event when row is collapsed/expanded', (done) ->
-
-        selection = hx.detached('div')
-        dt = new hx.DataTable(selection.node(), {
-          collapsibleRenderer: ->
-          rowCollapsibleLookup: (row) -> true
-        })
-
-        first = true
-        dt.on 'expandedrowschange', (d) ->
-          d.row.should.eql(threeRowsData.rows[0])
-          if first
-            d.rowValue.should.equal(true)
-            d.value.should.eql([threeRowsData.rows[0].id])
-            d.cause.should.equal('user')
-            first = false
-          else
-            d.rowValue.should.equal(false)
-            d.value.should.eql([])
-            d.cause.should.equal('user')
-            done()
-
-        dt.feed hx.dataTable.objectFeed(threeRowsData), ->
-          fakeNodeEvent(selection.select('.hx-sticky-table-header-left').select('.hx-data-table-collapsible-toggle').node(), 'click')()
-          fakeNodeEvent(selection.select('.hx-sticky-table-header-left').select('.hx-data-table-collapsible-toggle').node(), 'click')()
-
-    describe 'rowclick', ->
-      it 'should emit an event when the row is clicked', (done) ->
-        selection = hx.detached('div')
-        dt = new hx.DataTable(selection.node(), {pageSizeOptions: [5, 10, 15]})
-
-        dt.on 'rowclick', (d) ->
-          d.data.should.eql(threeRowsData.rows[0])
-          d.node.should.be.an.instanceof(Element)
-          done()
-
-        dt.feed hx.dataTable.objectFeed(threeRowsData), ->
-          fakeNodeEvent(selection.select('.hx-sticky-table-wrapper').select('.hx-data-table-body').select('.hx-data-table-row').node(), 'click')()
-
-    describe 'render', ->
-      it 'should emit an event when the row is clicked', (done) ->
-        selection = hx.detached('div')
-        dt = new hx.DataTable(selection.node(), {pageSizeOptions: [5, 10, 15]})
-
-        dt.on 'render', -> done()
-
-        dt.feed hx.dataTable.objectFeed(threeRowsData)
-
-    describe 'pagesizechange', ->
-      it 'should emit an event when the page size is changed with cause: user', (done) ->
-        selection = hx.detached('div')
-        dt = new hx.DataTable(selection.node(), {pageSizeOptions: [5, 10, 15]})
-
-        dt.on 'pagesizechange', (d) ->
-          d.value.should.equal(10)
-          d.cause.should.equal('user')
-          done()
-
-        dt.feed hx.dataTable.objectFeed(threeRowsData), ->
-          selection
-            .select('.hx-data-table-page-size-picker')
-            .component()
-            .emit('change', {value: {value: 10, text: '10'}, cause: 'user'})
-
-    describe 'pagechange', ->
-
-      describe 'should emit an event when the page changes', ->
-
-        it 'should work when setting the page to 2', (done) ->
-          selection = hx.detached('div')
-          dt = new hx.DataTable(selection.node(), {pageSize: 2, pageSizeOptions: [5, 10, 15]})
-          dt.on 'pagechange', (d) ->
-            d.value.should.eql(2)
-            d.cause.should.equal('user')
-            done()
-          dt.feed hx.dataTable.objectFeed(threeRowsData), ->
-            selection.select('.hx-data-table-paginator-picker').component().emit('change', {value: {value: 2}, cause: 'user'})
-
-        it 'should work when setting the page to 1', (done) ->
-          selection = hx.detached('div')
-          dt = new hx.DataTable(selection.node(), {pageSize: 2, pageSizeOptions: [5, 10, 15]})
-          dt.on 'pagechange', (d) ->
-            d.value.should.equal(1)
-            d.cause.should.equal('user')
-            done()
-          dt.feed hx.dataTable.objectFeed(threeRowsData), ->
-            selection.select('.hx-data-table-paginator-picker').component().emit('change', {value: {value: 1}, cause: 'user'})
-
-    describe 'compactchange', ->
-      it 'should emit an event when changing from full to compact', (done) ->
-
-        container = hx.select('body').append('div').style('width', '1000px')
-
-        dt = new hx.DataTable(container.node())
-
-        dt.on 'compactchange', (d) ->
-          d.value.should.equal('auto')
-          d.state.should.equal(true)
-          d.cause.should.equal('user')
-          hx.select('body').clear()
-          done()
-
-        dt.feed hx.dataTable.objectFeed(threeRowsData), ->
-          container.style('width', '100px')
-
-      it 'should emit an event when changing from compact to full', (done) ->
-        container = hx.select('body').append('div').style('width', '100px')
-
-        dt = new hx.DataTable(container.node())
-
-        dt.on 'compactchange', (d) ->
-          d.value.should.equal('auto')
-          d.state.should.equal(false)
-          d.cause.should.equal('user')
-          dt.off('compactchange')
-          hx.select('body').clear()
-          done()
-
-        dt.feed hx.dataTable.objectFeed(threeRowsData), ->
-          container.style('width', '1000px')
-
-       it 'should not emit an event if it doesnt change mode', (done) ->
-
-        container = hx.select('body').append('div').style('width', '1000px')
-
-        dt = new hx.DataTable(container.node())
-
-        called = false
-        dt.on 'compactchange', (d) ->
-          called = true
-
-        dt.feed hx.dataTable.objectFeed(threeRowsData), ->
-          container.style('width', '900px')
-
-          f = ->
-            called.should.equal(false)
-            done()
-          setTimeout(f, 50)
 
 
   describe 'fluid api', ->

--- a/modules/data-table/test/spec.coffee
+++ b/modules/data-table/test/spec.coffee
@@ -198,10 +198,16 @@ describe 'data-table', ->
       done?()
 
   it 'should have user facing text defined', ->
+    hx.userFacingText('dataTable', 'addFilter').should.equal('Add Filter')
+    hx.userFacingText('dataTable', 'advancedSearch').should.equal('Advanced Search')
+    hx.userFacingText('dataTable', 'and').should.equal('and')
+    hx.userFacingText('dataTable', 'anyColumn').should.equal('Any column')
+    hx.userFacingText('dataTable', 'clearFilters').should.equal('Clear Filters')
     hx.userFacingText('dataTable', 'clearSelection').should.equal('clear selection')
     hx.userFacingText('dataTable', 'loading').should.equal('Loading')
     hx.userFacingText('dataTable', 'noData').should.equal('No Data')
     hx.userFacingText('dataTable', 'noSort').should.equal('No Sort')
+    hx.userFacingText('dataTable', 'or').should.equal('or')
     hx.userFacingText('dataTable', 'rowsPerPage').should.equal('Rows Per Page')
     hx.userFacingText('dataTable', 'search').should.equal('Search')
     hx.userFacingText('dataTable', 'selectedRows').should.equal('$selected of $total selected.')
@@ -214,6 +220,9 @@ describe 'data-table', ->
     checkOption('feed', [hx.dataTable.objectFeed(noData), hx.dataTable.objectFeed(threeRowsData)])
     checkOption('filter', ['bob', 'aaaa', undefined])
     checkOption('filterEnabled', [true, false])
+    checkOption('showAdvancedSearch', [true, false])
+    checkOption('advancedSearchEnabled', [true, false])
+    checkOption('showSearchAboveTable', [true, false])
     checkOption('noDataMessage', ['No Data', 'Wahooo! You successfully deleted everything.'])
     checkOption('pageSize', [10, 20, 666])
     checkOption('pageSizeOptions', [undefined, [5, 10, 20], [100, 200, 500]])
@@ -266,19 +275,16 @@ describe 'data-table', ->
           hx.select(rows[2]).selectAll('td').selectAll('.hx-data-table-cell-key').text().should.eql(headers)
           hx.select(rows[2]).selectAll('td').selectAll('.hx-data-table-cell-value').text().should.eql(['Dan', '41', 'Builder'])
 
-        it 'should show the paginator block', ->
-          container.select('.hx-data-table-pagination-visible').size().should.equal(1)
-
         it 'should not show the paginator', ->
-          container.select('.hx-data-table-multi-page').size().should.equal(0)
+          container.selectAll('.hx-data-table-paginator-visible').size().should.equal(0)
 
         it 'should not show the row per page picker', ->
-          container.select('.hx-data-table-page-size').size().should.equal(1)
-          container.select('.hx-data-table-page-size').classed('hx-data-table-select-page-size').should.equal(false)
+          container.selectAll('.hx-data-table-page-size').size().should.equal(2)
+          container.selectAll('.hx-data-table-page-size-visible').size().should.equal(0)
 
         it 'should show the filter box', ->
-          container.select('.hx-data-table-filter-control').size().should.equal(1)
-          container.select('.hx-data-table-filter-control').classed('hx-data-table-filter-visible').should.equal(true)
+          container.select('.hx-data-table-filter').size().should.equal(1)
+          container.select('.hx-data-table-filter').classed('hx-data-table-filter-visible').should.equal(true)
 
         it 'should not show collapsible expand icons', ->
           container.select('.hx-sticky-table-header-left').selectAll('.hx-data-table-collapsible-toggle').size().should.equal(0)
@@ -444,17 +450,13 @@ describe 'data-table', ->
     describe 'displayMode', ->
       describe 'paginate', ->
         testTable {tableOptions: {displayMode: 'paginate'}}, undefined, (container, dt, options, data) ->
-          it 'should show the paginator block', ->
-            container.select('.hx-data-table-pagination-visible').size().should.equal(1)
-
           it 'should not show the paginator when there is one page', ->
             dt._.numPages.should.equal(1)
-            container.select('.hx-data-table-multi-page').size().should.equal(0)
+            container.selectAll('.hx-data-table-paginator-visible').size().should.equal(0)
 
         it 'should show the paginator when there is more than one page', (done) ->
           testTable {tableOptions: {displayMode: 'paginate', pageSize: 1}}, done, (container, dt, options, data) ->
-            container.select('.hx-data-table-pagination-visible').size().should.equal(1)
-            container.select('.hx-data-table-multi-page').size().should.equal(1)
+            container.selectAll('.hx-data-table-paginator-visible').size().should.equal(3)
             dt._.numPages.should.equal(3)
 
         it 'should change the page when the picker is changed', (done) ->
@@ -465,7 +467,7 @@ describe 'data-table', ->
               done()
 
             container
-              .select('.hx-data-table-pagination-picker')
+              .select('.hx-data-table-paginator-picker')
               .component()
               .emit('change', {value: {value: 2}, cause: 'user'})
 
@@ -511,7 +513,7 @@ describe 'data-table', ->
         it 'should hide the paginator block', (done) ->
           testTable {tableOptions: {displayMode: 'all', pageSize: 1}}, done, (container, dt, options, data) ->
             should.not.exist(dt._.numPages)
-            container.select('.hx-data-table-pagination-block-visible').size().should.equal(0)
+            container.selectAll('.hx-data-table-paginator-visible').size().should.equal(0)
             container.select('.hx-sticky-table-wrapper').select('tbody').selectAll('tr').size().should.equal(3)
 
 
@@ -520,14 +522,14 @@ describe 'data-table', ->
       describe 'true', ->
         it 'should show the filter box', (done) ->
           testTable {tableOptions: {filterEnabled: true}}, done, (container, dt, options, data) ->
-            container.select('.hx-data-table-filter-control').size().should.equal(1)
-            container.select('.hx-data-table-filter-control').classed('hx-data-table-filter-visible').should.equal(true)
+            container.select('.hx-data-table-filter').size().should.equal(1)
+            container.select('.hx-data-table-filter').classed('hx-data-table-filter-visible').should.equal(true)
 
       describe 'false', ->
         it 'should not show the filter box', (done) ->
           testTable {tableOptions: {filterEnabled: false}}, done, (container, dt, options, data) ->
-            container.select('.hx-data-table-filter-control').size().should.equal(1)
-            container.select('.hx-data-table-filter-control').classed('hx-data-table-filter-visible').should.equal(false)
+            container.select('.hx-data-table-filter').size().should.equal(1)
+            container.select('.hx-data-table-filter').classed('hx-data-table-filter-visible').should.equal(false)
 
 
 
@@ -623,13 +625,13 @@ describe 'data-table', ->
     describe 'pageSizeOptions', ->
       it 'should not show the row per page picker by default', (done) ->
         testTable {tableOptions: {pageSizeOptions: undefined}}, done, (container, dt, options, data) ->
-          container.select('.hx-data-table-page-size').size().should.equal(1)
-          container.select('.hx-data-table-page-size').classed('hx-data-table-select-page-size').should.equal(false)
+          container.selectAll('.hx-data-table-page-size').size().should.equal(2)
+          container.selectAll('.hx-data-table-page-size-visible').size().should.equal(0)
 
       testTable {tableOptions: {pageSizeOptions: [4, 1, 3, 2]}}, undefined, (container, dt, options, data) ->
         it 'should show the rows per page picker', ->
-          container.select('.hx-data-table-page-size').size().should.equal(1)
-          container.select('.hx-data-table-page-size').classed('hx-data-table-select-page-size').should.equal(true)
+          container.selectAll('.hx-data-table-page-size').size().should.equal(2)
+          container.selectAll('.hx-data-table-page-size-visible').size().should.equal(2)
 
         it 'should sort the options in numeric order', ->
           dt.pageSizeOptions().should.eql([1, 2, 3, 4, 15])
@@ -1094,11 +1096,11 @@ describe 'data-table', ->
       describe 'compact mode', ->
         it 'should not show the sort control if there are no sorts', ->
           testTable {tableOptions: {compact: true, sortEnabled: false}}, undefined, (container, dt, options, data) ->
-            container.select('.hx-data-table-sort-control').classed('hx-data-table-sort-visible').should.equal(false)
+            container.select('.hx-data-table-sort').classed('hx-data-table-sort-visible').should.equal(false)
 
         it 'should show the sort control if sort is only enabled for one column ', ->
           testTable {tableOptions: {compact: true, sortEnabled: false, columns: {name: {sortEnabled: true}}}}, undefined, (container, dt, options, data) ->
-            container.select('.hx-data-table-sort-control').classed('hx-data-table-sort-visible').should.equal(true)
+            container.select('.hx-data-table-sort').classed('hx-data-table-sort-visible').should.equal(true)
 
         it 'should change the sort column when changing the sort picker', (done) ->
           testTable {tableOptions: {compact: true}}, undefined, (container, dt, options, data) ->
@@ -1108,7 +1110,7 @@ describe 'data-table', ->
               done()
 
             picker = container
-              .select('.hx-data-table-sort-control').select('.hx-picker')
+              .select('.hx-data-table-sort').select('.hx-picker')
               .component()
 
             picker.value({value: 'nameasc'})
@@ -1123,7 +1125,7 @@ describe 'data-table', ->
               done()
 
             picker = container
-              .select('.hx-data-table-sort-control').select('.hx-picker')
+              .select('.hx-data-table-sort').select('.hx-picker')
               .component()
 
             picker.value(undefined)
@@ -1187,7 +1189,7 @@ describe 'data-table', ->
         filterSpy.should.not.have.been.called()
         dt.feed hx.dataTable.objectFeed(threeRowsData), ->
           filterSpy.should.have.been.called.with()
-          filterInput = container.select('.hx-data-table-filter-control')
+          filterInput = container.select('.hx-data-table-filter')
           filterEvent = fakeNodeEvent filterInput.node(), 'input'
           filterInput.value('a')
           filterEvent(fakeEvent)
@@ -1861,8 +1863,8 @@ describe 'data-table', ->
           done()
 
         dt.feed hx.dataTable.objectFeed(threeRowsData), ->
-          selection.select('.hx-data-table-filter-control').value('test')
-          fakeNodeEvent(selection.select('.hx-data-table-filter-control').node(), 'input')()
+          selection.select('.hx-data-table-filter').value('test')
+          fakeNodeEvent(selection.select('.hx-data-table-filter').node(), 'input')()
 
     describe 'selectedrowschange', ->
       it 'should emit an event when rows are selected/deselected', (done) ->
@@ -1997,7 +1999,7 @@ describe 'data-table', ->
             d.cause.should.equal('user')
             done()
           dt.feed hx.dataTable.objectFeed(threeRowsData), ->
-            selection.select('.hx-data-table-pagination-picker').component().emit('change', {value: {value: 2}, cause: 'user'})
+            selection.select('.hx-data-table-paginator-picker').component().emit('change', {value: {value: 2}, cause: 'user'})
 
         it 'should work when setting the page to 1', (done) ->
           selection = hx.detached('div')
@@ -2007,7 +2009,7 @@ describe 'data-table', ->
             d.cause.should.equal('user')
             done()
           dt.feed hx.dataTable.objectFeed(threeRowsData), ->
-            selection.select('.hx-data-table-pagination-picker').component().emit('change', {value: {value: 1}, cause: 'user'})
+            selection.select('.hx-data-table-paginator-picker').component().emit('change', {value: {value: 1}, cause: 'user'})
 
     describe 'compactchange', ->
       it 'should emit an event when changing from full to compact', (done) ->

--- a/modules/data-table/test/spec.coffee
+++ b/modules/data-table/test/spec.coffee
@@ -267,7 +267,7 @@ describe 'data-table', ->
           hx.select(rows[2]).selectAll('td').selectAll('.hx-data-table-cell-value').text().should.eql(['Dan', '41', 'Builder'])
 
         it 'should show the paginator block', ->
-          container.select('.hx-data-table-pagination-block-hidden').size().should.equal(0)
+          container.select('.hx-data-table-pagination-visible').size().should.equal(1)
 
         it 'should not show the paginator', ->
           container.select('.hx-data-table-multi-page').size().should.equal(0)
@@ -445,7 +445,7 @@ describe 'data-table', ->
       describe 'paginate', ->
         testTable {tableOptions: {displayMode: 'paginate'}}, undefined, (container, dt, options, data) ->
           it 'should show the paginator block', ->
-            container.select('.hx-data-table-pagination-block-visible').size().should.equal(1)
+            container.select('.hx-data-table-pagination-visible').size().should.equal(1)
 
           it 'should not show the paginator when there is one page', ->
             dt._.numPages.should.equal(1)
@@ -453,7 +453,7 @@ describe 'data-table', ->
 
         it 'should show the paginator when there is more than one page', (done) ->
           testTable {tableOptions: {displayMode: 'paginate', pageSize: 1}}, done, (container, dt, options, data) ->
-            container.select('.hx-data-table-pagination-block-visible').size().should.equal(1)
+            container.select('.hx-data-table-pagination-visible').size().should.equal(1)
             container.select('.hx-data-table-multi-page').size().should.equal(1)
             dt._.numPages.should.equal(3)
 
@@ -1558,6 +1558,114 @@ describe 'data-table', ->
           ])
           done()
 
+
+      describe 'advanced search', ->
+        advancedSearchData = {
+          headers: [
+            { id: 'name', name: "Name" }
+            { id: 'phone', name: "Phone" }
+            { id: 'email', name: "Email" }
+            { id: 'company', name: "Company" }
+            { id: 'city', name: "City" }
+            { id: 'keywords', name: "Keywords" }
+            { id: 'salary', name: "Salary" }
+          ]
+          rows: [
+            { cells: { name: "Wing Simon", phone: "(0151) 610 0311", email: "Curabitur.vel.lectus@nibhdolor.com", company: "Fringilla Corp.", city: "Frignano", keywords: "Morbi sit amet", salary: "£235.59" } }
+            { cells: { name: "Simon Olsen", phone: "056 1366 7271", email: "mauris.sapien.cursus@Proinultrices.com", company: "Aenean Foundation", city: "Istanbul", keywords: "non magna. Nam", salary: "£337.53" } }
+            { cells: { name: "Juliet Ruiz", phone: "0800 692945", email: "vel@Aliquam.ca", company: "Auctor Velit Aliquam Corp.", city: "Kungälv", keywords: "consequat nec, mollis", salary: "£463.76" } }
+            { cells: { name: "Olivia Caldwell", phone: "(01370) 43740", email: "Aenean.massa@condimentum.co.uk", company: "Fringilla Porttitor Vulputate Inc.", city: "Birmingham", keywords: "Donec fringilla. Donec", salary: "£257.33" } }
+            { cells: { name: "Odette Ferrell", phone: "(011495) 29835", email: "dolor@aliquetPhasellus.co.uk", company: "Tincidunt Company", city: "Quedlinburg", keywords: "ac, eleifend vitae,", salary: "£353.87" } }
+            { cells: { name: "Lilah Lamb", phone: "07624 294538", email: "gravida@nonmassa.com", company: "Tellus Justo Sit LLP", city: "Vagli Sotto", keywords: "commodo auctor velit.", salary: "£292.15" } }
+          ]
+        }
+
+        it 'should get the rows from the data set with filtering on multiple columns', (done) ->
+          filter = [
+            [{
+              column: 'name',
+              term: 'a',
+            }, {
+              column: 'phone',
+              term: '1',
+            }]
+          ]
+          hx.dataTable.objectFeed(advancedSearchData).rows {start: 0, end: 5, useAdvancedSearch: true, advancedSearch: filter}, (data) ->
+            data.rows.should.eql([
+              { cells: { name: "Olivia Caldwell", phone: "(01370) 43740", email: "Aenean.massa@condimentum.co.uk", company: "Fringilla Porttitor Vulputate Inc.", city: "Birmingham", keywords: "Donec fringilla. Donec", salary: "£257.33" } }
+            ])
+            data.filteredCount.should.equal(1)
+            done()
+
+        it 'should filter on "any" column', (done) ->
+          filter = [
+            [{
+              column: 'any'
+              term: 'a'
+            }]
+          ]
+          hx.dataTable.objectFeed(advancedSearchData).rows {start: 0, end: 5, useAdvancedSearch: true, advancedSearch: filter}, (data) ->
+            data.rows.should.eql([
+              { cells: { name: "Wing Simon", phone: "(0151) 610 0311", email: "Curabitur.vel.lectus@nibhdolor.com", company: "Fringilla Corp.", city: "Frignano", keywords: "Morbi sit amet", salary: "£235.59" } }
+              { cells: { name: "Simon Olsen", phone: "056 1366 7271", email: "mauris.sapien.cursus@Proinultrices.com", company: "Aenean Foundation", city: "Istanbul", keywords: "non magna. Nam", salary: "£337.53" } }
+              { cells: { name: "Juliet Ruiz", phone: "0800 692945", email: "vel@Aliquam.ca", company: "Auctor Velit Aliquam Corp.", city: "Kungälv", keywords: "consequat nec, mollis", salary: "£463.76" } }
+              { cells: { name: "Olivia Caldwell", phone: "(01370) 43740", email: "Aenean.massa@condimentum.co.uk", company: "Fringilla Porttitor Vulputate Inc.", city: "Birmingham", keywords: "Donec fringilla. Donec", salary: "£257.33" } }
+              { cells: { name: "Odette Ferrell", phone: "(011495) 29835", email: "dolor@aliquetPhasellus.co.uk", company: "Tincidunt Company", city: "Quedlinburg", keywords: "ac, eleifend vitae,", salary: "£353.87" } }
+              { cells: { name: "Lilah Lamb", phone: "07624 294538", email: "gravida@nonmassa.com", company: "Tellus Justo Sit LLP", city: "Vagli Sotto", keywords: "commodo auctor velit.", salary: "£292.15" } }
+            ])
+            data.filteredCount.should.equal(6)
+            done()
+
+        it 'should get the rows from the data set with filtering on multiple columns using "or"', (done) ->
+          filter = [
+            [{
+              column: 'name',
+              term: 'a',
+            }], [{
+              column: 'phone',
+              term: '1',
+            }]
+          ]
+          hx.dataTable.objectFeed(advancedSearchData).rows {start: 0, end: 5, useAdvancedSearch: true, advancedSearch: filter}, (data) ->
+            data.rows.should.eql([
+              { cells: { name: "Wing Simon", phone: "(0151) 610 0311", email: "Curabitur.vel.lectus@nibhdolor.com", company: "Fringilla Corp.", city: "Frignano", keywords: "Morbi sit amet", salary: "£235.59" } }
+              { cells: { name: "Simon Olsen", phone: "056 1366 7271", email: "mauris.sapien.cursus@Proinultrices.com", company: "Aenean Foundation", city: "Istanbul", keywords: "non magna. Nam", salary: "£337.53" } }
+              { cells: { name: "Olivia Caldwell", phone: "(01370) 43740", email: "Aenean.massa@condimentum.co.uk", company: "Fringilla Porttitor Vulputate Inc.", city: "Birmingham", keywords: "Donec fringilla. Donec", salary: "£257.33" } }
+              { cells: { name: "Odette Ferrell", phone: "(011495) 29835", email: "dolor@aliquetPhasellus.co.uk", company: "Tincidunt Company", city: "Quedlinburg", keywords: "ac, eleifend vitae,", salary: "£353.87" } }
+              { cells: { name: "Lilah Lamb", phone: "07624 294538", email: "gravida@nonmassa.com", company: "Tellus Justo Sit LLP", city: "Vagli Sotto", keywords: "commodo auctor velit.", salary: "£292.15" } }
+            ])
+            data.filteredCount.should.equal(5)
+            done()
+
+        it 'should perform a complex filter', (done) ->
+          filter = [
+            [{
+              column: 'name',
+              term: 'a',
+            }, {
+              column: 'email',
+              term: '.com',
+            }], [{
+              column: 'company',
+              term: 'corp.',
+            }, {
+              column: 'phone',
+              term: '1',
+            }], [{
+              column: 'keywords',
+              term: 'nam',
+            }]
+          ]
+          hx.dataTable.objectFeed(advancedSearchData).rows {start: 0, end: 5, useAdvancedSearch: true, advancedSearch: filter}, (data) ->
+            data.rows.should.eql([
+              { cells: { name: "Wing Simon", phone: "(0151) 610 0311", email: "Curabitur.vel.lectus@nibhdolor.com", company: "Fringilla Corp.", city: "Frignano", keywords: "Morbi sit amet", salary: "£235.59" } }
+              { cells: { name: "Simon Olsen", phone: "056 1366 7271", email: "mauris.sapien.cursus@Proinultrices.com", company: "Aenean Foundation", city: "Istanbul", keywords: "non magna. Nam", salary: "£337.53" } }
+              { cells: { name: "Lilah Lamb", phone: "07624 294538", email: "gravida@nonmassa.com", company: "Tellus Justo Sit LLP", city: "Vagli Sotto", keywords: "commodo auctor velit.", salary: "£292.15" } }
+            ])
+            data.filteredCount.should.equal(3)
+            done()
+
+
     describe 'infinite data', ->
 
       # feed for use when testing the infinite data
@@ -1629,6 +1737,101 @@ describe 'data-table', ->
             dt.page 2, ->
               container.select('.hx-data-table-paginator-back').classed('hx-data-table-btn-disabled').should.equal(false)
               done()
+
+
+    describe 'url feed', ->
+      json = undefined
+      setupFakeHxJson = (response, expectedUrl, expectedPostData) ->
+        json = hx.json
+        hx.json = (url, data, cb) ->
+          if expectedUrl isnt undefined
+            url.should.eql(expectedUrl)
+          else
+            should.not.exist(data)
+
+          if expectedPostData isnt undefined
+            data.should.eql(expectedPostData)
+          else
+            should.not.exist(data)
+
+          cb(undefined, response)
+
+      tearDownFakeHxJson = -> hx.json = json
+
+
+      testFeedWithOptions = (options) ->
+        it 'headers', (done) ->
+          setupFakeHxJson(['header1', 'header2', 'header3'], 'some-url', {type: 'headers', extra: options?.extra})
+          hx.dataTable.urlFeed('some-url', options).headers (headers) ->
+            headers.should.eql(['header1', 'header2', 'header3'])
+            tearDownFakeHxJson()
+            done()
+
+        it 'totalCount', (done) ->
+          setupFakeHxJson({count: 3}, 'some-url', {type: 'totalCount', extra: options?.extra})
+          hx.dataTable.urlFeed('some-url', options).totalCount (count) ->
+            count.should.equal(3)
+            tearDownFakeHxJson()
+            done()
+
+        it 'rows', (done) ->
+          result = {
+            rows: [
+              {'id': 0, 'cells': {'whatever': 1}},
+              {'id': 1, 'cells': {'whatever': 2}}
+            ],
+            filteredCount: 5
+          }
+          setupFakeHxJson(result, 'some-url', {type: 'rows', range: {start: 0, end: 5, filter: 'something'}, extra: options?.extra})
+          hx.dataTable.urlFeed('some-url', options).rows {start: 0, end: 5, filter: 'something'}, (res) ->
+            res.should.eql(result)
+            tearDownFakeHxJson()
+            done()
+
+        it 'rowsForIds', (done) ->
+          result = [
+            {'id': 0, 'cells': {'whatever': 1}},
+            {'id': 1, 'cells': {'whatever': 2}}
+          ]
+          setupFakeHxJson(result, 'some-url', {type: 'rowsForIds', ids: [0, 1], extra: options?.extra})
+          hx.dataTable.urlFeed('some-url', options).rowsForIds [0, 1], undefined, (res) ->
+            res.should.eql(result)
+            tearDownFakeHxJson()
+            done()
+
+      describe 'with default options should make the correct requests for', ->
+        testFeedWithOptions(undefined)
+
+      describe 'with cached: true should make the correct requests for', ->
+        testFeedWithOptions({cache: true})
+
+        it 'should cache the headers', (done) ->
+          setupFakeHxJson(['header1', 'header2', 'header3'], 'some-url', {type: 'headers', extra: undefined})
+          jsonSpy = chai.spy.on(hx, 'json')
+          feed = hx.dataTable.urlFeed('some-url', {cache: true})
+          feed.headers (headers) ->
+            headers.should.eql(['header1', 'header2', 'header3'])
+            feed.headers (headers) ->
+              headers.should.eql(['header1', 'header2', 'header3'])
+              jsonSpy.should.have.been.called.once
+              tearDownFakeHxJson()
+              done()
+
+        it 'should cache the totalCount', (done) ->
+          setupFakeHxJson({count: 5}, 'some-url', {type: 'totalCount', extra: undefined})
+          jsonSpy = chai.spy.on(hx, 'json')
+          feed = hx.dataTable.urlFeed('some-url', {cache: true})
+          feed.totalCount (totalCount) ->
+            totalCount.should.equal(5)
+            feed.totalCount (totalCount) ->
+              totalCount.should.equal(5)
+              jsonSpy.should.have.been.called.once
+              tearDownFakeHxJson()
+              done()
+
+      describe 'with extra object passed in should make the correct requests for', ->
+        testFeedWithOptions({extra: 'some-value'})
+
 
 
   describe 'events', ->
@@ -1858,101 +2061,6 @@ describe 'data-table', ->
           setTimeout(f, 50)
 
 
-  describe 'url feed', ->
-
-    json = undefined
-    setupFakeHxJson = (response, expectedUrl, expectedPostData) ->
-      json = hx.json
-      hx.json = (url, data, cb) ->
-        if expectedUrl isnt undefined
-          url.should.eql(expectedUrl)
-        else
-          should.not.exist(data)
-
-        if expectedPostData isnt undefined
-          data.should.eql(expectedPostData)
-        else
-          should.not.exist(data)
-
-        cb(undefined, response)
-
-    tearDownFakeHxJson = -> hx.json = json
-
-
-    testFeedWithOptions = (options) ->
-      it 'headers', (done) ->
-        setupFakeHxJson(['header1', 'header2', 'header3'], 'some-url', {type: 'headers', extra: options?.extra})
-        hx.dataTable.urlFeed('some-url', options).headers (headers) ->
-          headers.should.eql(['header1', 'header2', 'header3'])
-          tearDownFakeHxJson()
-          done()
-
-      it 'totalCount', (done) ->
-        setupFakeHxJson({count: 3}, 'some-url', {type: 'totalCount', extra: options?.extra})
-        hx.dataTable.urlFeed('some-url', options).totalCount (count) ->
-          count.should.equal(3)
-          tearDownFakeHxJson()
-          done()
-
-      it 'rows', (done) ->
-        result = {
-          rows: [
-            {'id': 0, 'cells': {'whatever': 1}},
-            {'id': 1, 'cells': {'whatever': 2}}
-          ],
-          filteredCount: 5
-        }
-        setupFakeHxJson(result, 'some-url', {type: 'rows', range: {start: 0, end: 5, filter: 'something'}, extra: options?.extra})
-        hx.dataTable.urlFeed('some-url', options).rows {start: 0, end: 5, filter: 'something'}, (res) ->
-          res.should.eql(result)
-          tearDownFakeHxJson()
-          done()
-
-      it 'rowsForIds', (done) ->
-        result = [
-          {'id': 0, 'cells': {'whatever': 1}},
-          {'id': 1, 'cells': {'whatever': 2}}
-        ]
-        setupFakeHxJson(result, 'some-url', {type: 'rowsForIds', ids: [0, 1], extra: options?.extra})
-        hx.dataTable.urlFeed('some-url', options).rowsForIds [0, 1], undefined, (res) ->
-          res.should.eql(result)
-          tearDownFakeHxJson()
-          done()
-
-    describe 'with default options should make the correct requests for', ->
-      testFeedWithOptions(undefined)
-
-    describe 'with cached: true should make the correct requests for', ->
-      testFeedWithOptions({cache: true})
-
-      it 'should cache the headers', (done) ->
-        setupFakeHxJson(['header1', 'header2', 'header3'], 'some-url', {type: 'headers', extra: undefined})
-        jsonSpy = chai.spy.on(hx, 'json')
-        feed = hx.dataTable.urlFeed('some-url', {cache: true})
-        feed.headers (headers) ->
-          headers.should.eql(['header1', 'header2', 'header3'])
-          feed.headers (headers) ->
-            headers.should.eql(['header1', 'header2', 'header3'])
-            jsonSpy.should.have.been.called.once
-            tearDownFakeHxJson()
-            done()
-
-      it 'should cache the totalCount', (done) ->
-        setupFakeHxJson({count: 5}, 'some-url', {type: 'totalCount', extra: undefined})
-        jsonSpy = chai.spy.on(hx, 'json')
-        feed = hx.dataTable.urlFeed('some-url', {cache: true})
-        feed.totalCount (totalCount) ->
-          totalCount.should.equal(5)
-          feed.totalCount (totalCount) ->
-            totalCount.should.equal(5)
-            jsonSpy.should.have.been.called.once
-            tearDownFakeHxJson()
-            done()
-
-    describe 'with extra object passed in should make the correct requests for', ->
-      testFeedWithOptions({extra: 'some-value'})
-
-
   describe 'fluid api', ->
     it 'should return a selection', ->
       hx.dataTable().should.be.an.instanceof(hx.Selection)
@@ -1962,110 +2070,3 @@ describe 'data-table', ->
 
     it 'should render if a feed is defined', ->
       hx.dataTable({feed: hx.dataTable.objectFeed(threeRowsData)}).select('.hx-data-table-content').selectAll('td').empty().should.equal(false)
-
-  describe 'advanced search', ->
-    data = {
-      headers: [
-        { id: 'name', name: "Name" }
-        { id: 'phone', name: "Phone" }
-        { id: 'email', name: "Email" }
-        { id: 'company', name: "Company" }
-        { id: 'city', name: "City" }
-        { id: 'keywords', name: "Keywords" }
-        { id: 'salary', name: "Salary" }
-      ]
-      rows: [
-        { cells: { name: "Wing Simon", phone: "(0151) 610 0311", email: "Curabitur.vel.lectus@nibhdolor.com", company: "Fringilla Corp.", city: "Frignano", keywords: "Morbi sit amet", salary: "£235.59" } }
-        { cells: { name: "Simon Olsen", phone: "056 1366 7271", email: "mauris.sapien.cursus@Proinultrices.com", company: "Aenean Foundation", city: "Istanbul", keywords: "non magna. Nam", salary: "£337.53" } }
-        { cells: { name: "Juliet Ruiz", phone: "0800 692945", email: "vel@Aliquam.ca", company: "Auctor Velit Aliquam Corp.", city: "Kungälv", keywords: "consequat nec, mollis", salary: "£463.76" } }
-        { cells: { name: "Olivia Caldwell", phone: "(01370) 43740", email: "Aenean.massa@condimentum.co.uk", company: "Fringilla Porttitor Vulputate Inc.", city: "Birmingham", keywords: "Donec fringilla. Donec", salary: "£257.33" } }
-        { cells: { name: "Odette Ferrell", phone: "(011495) 29835", email: "dolor@aliquetPhasellus.co.uk", company: "Tincidunt Company", city: "Quedlinburg", keywords: "ac, eleifend vitae,", salary: "£353.87" } }
-        { cells: { name: "Lilah Lamb", phone: "07624 294538", email: "gravida@nonmassa.com", company: "Tellus Justo Sit LLP", city: "Vagli Sotto", keywords: "commodo auctor velit.", salary: "£292.15" } }
-      ]
-    }
-
-    it 'should get the rows from the data set with filtering on multiple columns', (done) ->
-      filter = [
-        [{
-          column: 'name',
-          term: 'a',
-        }, {
-          column: 'phone',
-          term: '1',
-        }]
-      ]
-      hx.dataTable.objectFeed(data).rows {start: 0, end: 5, useAdvancedSearch: true, advancedSearch: filter}, (data) ->
-        data.rows.should.eql([
-          { cells: { name: "Olivia Caldwell", phone: "(01370) 43740", email: "Aenean.massa@condimentum.co.uk", company: "Fringilla Porttitor Vulputate Inc.", city: "Birmingham", keywords: "Donec fringilla. Donec", salary: "£257.33" } }
-        ])
-        data.filteredCount.should.equal(1)
-        done()
-
-    it 'should filter on "any" column', (done) ->
-      filter = [
-        [{
-          column: 'any'
-          term: 'a'
-        }]
-      ]
-      hx.dataTable.objectFeed(data).rows {start: 0, end: 5, useAdvancedSearch: true, advancedSearch: filter}, (data) ->
-        data.rows.should.eql([
-          { cells: { name: "Wing Simon", phone: "(0151) 610 0311", email: "Curabitur.vel.lectus@nibhdolor.com", company: "Fringilla Corp.", city: "Frignano", keywords: "Morbi sit amet", salary: "£235.59" } }
-          { cells: { name: "Simon Olsen", phone: "056 1366 7271", email: "mauris.sapien.cursus@Proinultrices.com", company: "Aenean Foundation", city: "Istanbul", keywords: "non magna. Nam", salary: "£337.53" } }
-          { cells: { name: "Juliet Ruiz", phone: "0800 692945", email: "vel@Aliquam.ca", company: "Auctor Velit Aliquam Corp.", city: "Kungälv", keywords: "consequat nec, mollis", salary: "£463.76" } }
-          { cells: { name: "Olivia Caldwell", phone: "(01370) 43740", email: "Aenean.massa@condimentum.co.uk", company: "Fringilla Porttitor Vulputate Inc.", city: "Birmingham", keywords: "Donec fringilla. Donec", salary: "£257.33" } }
-          { cells: { name: "Odette Ferrell", phone: "(011495) 29835", email: "dolor@aliquetPhasellus.co.uk", company: "Tincidunt Company", city: "Quedlinburg", keywords: "ac, eleifend vitae,", salary: "£353.87" } }
-          { cells: { name: "Lilah Lamb", phone: "07624 294538", email: "gravida@nonmassa.com", company: "Tellus Justo Sit LLP", city: "Vagli Sotto", keywords: "commodo auctor velit.", salary: "£292.15" } }
-        ])
-        data.filteredCount.should.equal(6)
-        done()
-
-    it 'should get the rows from the data set with filtering on multiple columns using "or"', (done) ->
-      filter = [
-        [{
-          column: 'name',
-          term: 'a',
-        }], [{
-          column: 'phone',
-          term: '1',
-        }]
-      ]
-      hx.dataTable.objectFeed(data).rows {start: 0, end: 5, useAdvancedSearch: true, advancedSearch: filter}, (data) ->
-        data.rows.should.eql([
-          { cells: { name: "Wing Simon", phone: "(0151) 610 0311", email: "Curabitur.vel.lectus@nibhdolor.com", company: "Fringilla Corp.", city: "Frignano", keywords: "Morbi sit amet", salary: "£235.59" } }
-          { cells: { name: "Simon Olsen", phone: "056 1366 7271", email: "mauris.sapien.cursus@Proinultrices.com", company: "Aenean Foundation", city: "Istanbul", keywords: "non magna. Nam", salary: "£337.53" } }
-          { cells: { name: "Olivia Caldwell", phone: "(01370) 43740", email: "Aenean.massa@condimentum.co.uk", company: "Fringilla Porttitor Vulputate Inc.", city: "Birmingham", keywords: "Donec fringilla. Donec", salary: "£257.33" } }
-          { cells: { name: "Odette Ferrell", phone: "(011495) 29835", email: "dolor@aliquetPhasellus.co.uk", company: "Tincidunt Company", city: "Quedlinburg", keywords: "ac, eleifend vitae,", salary: "£353.87" } }
-          { cells: { name: "Lilah Lamb", phone: "07624 294538", email: "gravida@nonmassa.com", company: "Tellus Justo Sit LLP", city: "Vagli Sotto", keywords: "commodo auctor velit.", salary: "£292.15" } }
-        ])
-        data.filteredCount.should.equal(5)
-        done()
-
-    it 'should perform a complex filter', (done) ->
-      filter = [
-        [{
-          column: 'name',
-          term: 'a',
-        }, {
-          column: 'email',
-          term: '.com',
-        }], [{
-          column: 'company',
-          term: 'corp.',
-        }, {
-          column: 'phone',
-          term: '1',
-        }], [{
-          column: 'keywords',
-          term: 'nam',
-        }]
-      ]
-      hx.dataTable.objectFeed(data).rows {start: 0, end: 5, useAdvancedSearch: true, advancedSearch: filter}, (data) ->
-        data.rows.should.eql([
-          { cells: { name: "Wing Simon", phone: "(0151) 610 0311", email: "Curabitur.vel.lectus@nibhdolor.com", company: "Fringilla Corp.", city: "Frignano", keywords: "Morbi sit amet", salary: "£235.59" } }
-          { cells: { name: "Simon Olsen", phone: "056 1366 7271", email: "mauris.sapien.cursus@Proinultrices.com", company: "Aenean Foundation", city: "Istanbul", keywords: "non magna. Nam", salary: "£337.53" } }
-          { cells: { name: "Lilah Lamb", phone: "07624 294538", email: "gravida@nonmassa.com", company: "Tellus Justo Sit LLP", city: "Vagli Sotto", keywords: "commodo auctor velit.", salary: "£292.15" } }
-        ])
-        data.filteredCount.should.equal(3)
-        done()
-

--- a/modules/data-table/test/spec.coffee
+++ b/modules/data-table/test/spec.coffee
@@ -1,18 +1,14 @@
 describe 'data-table', ->
   origConsoleWarning = hx.consoleWarning
-
   clockTime = (new Date(2013, 0, 1)).getTime()
   dropdownAnimationTime = 150
   inputDebounceDelay = 200
   animationCompletedDelay = 500
 
-  before ->
+  beforeEach ->
     hx.consoleWarning = chai.spy()
 
-  beforeEach ->
-    hx.consoleWarning.reset()
-
-  after ->
+  afterEach ->
     hx.consoleWarning = origConsoleWarning
 
   # Used to mimic an event call for a node
@@ -1389,6 +1385,18 @@ describe 'data-table', ->
 
 
     describe 'advanced search', ->
+      describe 'advancedSearch', ->
+        it 'should enable the advanced search filtering if passed in the options', (done) ->
+          tableOptions =
+            advancedSearch: [[{column: 'any', term: ''}]]
+
+          testTable {tableOptions}, done, (container, dt, options, data) ->
+            container.classed('hx-data-table-show-search-above-content').should.equal(false)
+            container.selectAll('.hx-data-table-control-panel-bottom-visible').size().should.equal(0)
+            container.selectAll('.hx-data-table-control-panel-visible').size().should.equal(1)
+            container.selectAll('.hx-data-table-advanced-search-visible').size().should.equal(2)
+            container.selectAll('.hx-data-table-filter-visible').size().should.equal(0)
+
       describe 'showAdvancedSearch', ->
         it 'should show the advanced search toggle when filters are enabled', (done) ->
           tableOptions =
@@ -1399,6 +1407,7 @@ describe 'data-table', ->
             container.selectAll('.hx-data-table-control-panel-bottom-visible').size().should.equal(0)
             container.selectAll('.hx-data-table-control-panel-visible').size().should.equal(1)
             container.selectAll('.hx-data-table-advanced-search-visible').size().should.equal(1)
+
 
         it 'should not show the advanced search toggle when filters are disabled', (done) ->
           tableOptions =

--- a/modules/toggle/main/index.scss
+++ b/modules/toggle/main/index.scss
@@ -6,8 +6,8 @@
     position: relative;
     margin: 2px 8px;
     padding: 0;
-    width: 26px;
-    height: 16px;
+    width: 20px;
+    height: 10px;
     color: #555;
     line-height: 0;
     text-align: center;
@@ -22,11 +22,11 @@
       content: ' ';
       position: absolute;
       display: block;
-      left: -10px;
+      left: -5px;
       top: -5px;
       margin: 3px;
-      height: 20px;
-      width: 20px;
+      height: 14px;
+      width: 14px;
       border-radius: 50%;
       border: none;
       transform: scale(1);
@@ -43,7 +43,7 @@
   }
 
   &.hx-btn > .hx-toggle-box {
-    margin-left: 1em;
+    margin-left: 0.5em;
     margin-right: 0;
   }
 }

--- a/modules/view/main/index.coffee
+++ b/modules/view/main/index.coffee
@@ -77,7 +77,7 @@ class View
 
       newNodeSet = enterSet.map (d, i) =>
         datum = d.datum
-        element = @new.call @rootSelection, d.datum, i
+        element = @new.call @rootSelection, datum, i, data.indexOf(datum)
 
         # Checks isChild first as it's the quickest operation
         isChild = @rootSelection.node().contains(element)


### PR DESCRIPTION
Closes #49 

### Screenshots

#### Table with advanced search enabled
<img width="908" alt="screen shot 2016-07-20 at 15 18 25" src="https://cloud.githubusercontent.com/assets/3194349/16989880/c2aac69e-4e8d-11e6-9e4f-a30a04700d95.png">

#### Table with only advanced search
<img width="904" alt="screen shot 2016-07-20 at 15 19 57" src="https://cloud.githubusercontent.com/assets/3194349/16989875/c27bb584-4e8d-11e6-858f-5c387138a914.png">

#### Advanced Search filter grouping
<img width="363" alt="screen shot 2016-07-20 at 15 19 35" src="https://cloud.githubusercontent.com/assets/3194349/16989878/c2a43efa-4e8d-11e6-96eb-efa28f541095.png">

#### Advanced Search 'off' state 
<img width="316" alt="screen shot 2016-07-20 at 15 19 41" src="https://cloud.githubusercontent.com/assets/3194349/16989876/c290ab6a-4e8d-11e6-802c-f4689f6c43e0.png">

#### Table with search above content
<img width="907" alt="screen shot 2016-07-20 at 15 19 20" src="https://cloud.githubusercontent.com/assets/3194349/16989877/c2a10dac-4e8d-11e6-954a-7cf727747b4d.png">


#### Compact table with top/bottom control panel
<img width="330" alt="screen shot 2016-07-20 at 15 18 58" src="https://cloud.githubusercontent.com/assets/3194349/16989879/c2a64970-4e8d-11e6-9f86-ee68c9ba60eb.png">

#### Compact table with top/bottom control panel
<img width="330" alt="screen shot 2016-07-20 at 15 18 58" src="https://cloud.githubusercontent.com/assets/3194349/16989879/c2a64970-4e8d-11e6-9f86-ee68c9ba60eb.png">

#### Compact table with top control panel open
<img width="327" alt="screen shot 2016-07-20 at 15 19 12" src="https://cloud.githubusercontent.com/assets/3194349/16989881/c2ab7486-4e8d-11e6-88c2-a18c31d130ae.png">