### PR TITLE
Fix hx.minBy and hx.maxBy

### DIFF
--- a/modules/util/main/index.coffee
+++ b/modules/util/main/index.coffee
@@ -73,14 +73,13 @@ hx.minBy = (values, f) ->
 
   if f
     min = values[0]
-    minValue = f(min)
-    for i in [1...values.length-1] by 1
+    maxValue = f(min)
+    for i in [1...values.length] by 1
       v = values[i]
-      if v isnt undefined
-        fv = f(v)
-        if fv isnt undefined and fv < minValue
-          min = v
-          minValue = fv
+      fv = f(v)
+      if minValue is undefined or (fv isnt undefined and fv < minValue)
+        min = v
+        minValue = fv
     min
   else
     min = values[0]
@@ -97,13 +96,12 @@ hx.maxBy = (values, f) ->
   if f
     max = values[0]
     maxValue = f(max)
-    for i in [1...values.length-1] by 1
+    for i in [1...values.length] by 1
       v = values[i]
-      if v isnt undefined
-        fv = f(v)
-        if fv isnt undefined and fv > maxValue
-          max = v
-          maxValue = fv
+      fv = f(v)
+      if maxValue is undefined or (fv isnt undefined and fv > maxValue)
+        max = v
+        maxValue = fv
     max
   else
     max = values[0]

--- a/modules/util/main/index.coffee
+++ b/modules/util/main/index.coffee
@@ -73,7 +73,7 @@ hx.minBy = (values, f) ->
 
   if f
     min = values[0]
-    maxValue = f(min)
+    minValue = f(min)
     for i in [1...values.length] by 1
       v = values[i]
       fv = f(v)

--- a/modules/util/test/spec.coffee
+++ b/modules/util/test/spec.coffee
@@ -139,12 +139,13 @@ describe "Util", ->
   it 'minBy: should work', ->
     should.not.exist(hx.minBy())
     should.not.exist(hx.minBy([]))
+    should.not.exist(hx.minBy([undefined, undefined, undefined]))
     hx.minBy([1, 2, 3, 4]).should.equal(1)
     hx.minBy([1, undefined, 3, 4]).should.equal(1)
     hx.minBy([5, 2, 3, 4]).should.equal(2)
     hx.minBy([5, 2, 3, 4, 1], (d) -> d).should.equal(1)
-    hx.minBy([1, 5, undefined, 3, 4], (d) -> -d).should.equal(5)
-    hx.minBy([undefined, 1, 5, 3, 4], (d) -> -d).should.equal(5)
+    hx.minBy([1, 5, undefined, 3, 4], (d) -> if d is undefined then undefined else -d).should.equal(5)
+    hx.minBy([undefined, 1, 5, 3, 4], (d) -> if d is undefined then undefined else -d).should.equal(5)
 
   it 'max: should work', ->
     hx.max().should.equal(-Infinity)
@@ -156,12 +157,13 @@ describe "Util", ->
   it 'maxBy: should work', ->
     should.not.exist(hx.maxBy())
     should.not.exist(hx.maxBy([]))
+    should.not.exist(hx.maxBy([undefined, undefined, undefined]))
     hx.maxBy([1, 2, 3, 4]).should.equal(4)
     hx.maxBy([1, undefined, 3, 4]).should.equal(4)
     hx.maxBy([1, 5, 3, 4]).should.equal(5)
     hx.maxBy([5, 2, 3, 4, 1], (d) -> -d).should.equal(1)
-    hx.maxBy([5, 1, undefined, 5, 4], (d) -> -d).should.equal(1)
-    hx.maxBy([undefined, 5, 1, 5, 4], (d) -> -d).should.equal(1)
+    hx.maxBy([5, 1, undefined, 5, 4], (d) -> if d is undefined then undefined else -d).should.equal(1)
+    hx.maxBy([undefined, 5, 1, 5, 4], (d) -> if d is undefined then undefined else -d).should.equal(1)
 
   it 'range should work', ->
     hx.range(10).should.eql([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])

--- a/modules/util/test/spec.coffee
+++ b/modules/util/test/spec.coffee
@@ -134,6 +134,7 @@ describe "Util", ->
     hx.min([]).should.equal(Infinity)
     hx.min([1, 5, 2]).should.equal(1)
     hx.min([undefined, 5, 2]).should.equal(2)
+    hx.min([1, undefined, 5, 2]).should.equal(1)
 
   it 'minBy: should work', ->
     should.not.exist(hx.minBy())
@@ -141,13 +142,16 @@ describe "Util", ->
     hx.minBy([1, 2, 3, 4]).should.equal(1)
     hx.minBy([1, undefined, 3, 4]).should.equal(1)
     hx.minBy([5, 2, 3, 4]).should.equal(2)
+    hx.minBy([5, 2, 3, 4, 1], (d) -> d).should.equal(1)
     hx.minBy([1, 5, undefined, 3, 4], (d) -> -d).should.equal(5)
+    hx.minBy([undefined, 1, 5, 3, 4], (d) -> -d).should.equal(5)
 
   it 'max: should work', ->
     hx.max().should.equal(-Infinity)
     hx.max([]).should.equal(-Infinity)
     hx.max([1, 5, 2]).should.equal(5)
     hx.max([undefined, 5, 2]).should.equal(5)
+    hx.max([1, undefined, 5, 2]).should.equal(5)
 
   it 'maxBy: should work', ->
     should.not.exist(hx.maxBy())
@@ -155,7 +159,9 @@ describe "Util", ->
     hx.maxBy([1, 2, 3, 4]).should.equal(4)
     hx.maxBy([1, undefined, 3, 4]).should.equal(4)
     hx.maxBy([1, 5, 3, 4]).should.equal(5)
+    hx.maxBy([5, 2, 3, 4, 1], (d) -> -d).should.equal(1)
     hx.maxBy([5, 1, undefined, 5, 4], (d) -> -d).should.equal(1)
+    hx.maxBy([undefined, 5, 1, 5, 4], (d) -> -d).should.equal(1)
 
   it 'range should work', ->
     hx.range(10).should.eql([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])


### PR DESCRIPTION
`hx.minBy` and `hx.maxBy` have an off-by-one error meaning the last value in the array won't be checked. This change fixes that.

Also, the handling for undefined values has been tweaked. Before `undefined` values would be ignored, but now they are passed to the handler to be checked - it is feasible that you might want to include `undefined` values in a `hx.minBy` or `hx.maxBy` call.