### PR TITLE
add default value as true for sparkline 'redraw on resize'

### DIFF
--- a/modules/plot/main/coffee/Sparkline.coffee
+++ b/modules/plot/main/coffee/Sparkline.coffee
@@ -38,7 +38,7 @@ class Sparkline
     hx.components.clear(selector)
     hx.component.register(selector, this)
 
-    graph = new hx.Graph(selector, { redrawOnResize: options.redrawOnResize })
+    graph = new hx.Graph(selector, { redrawOnResize: opts.redrawOnResize })
 
     if opts.type isnt 'bar' and opts.type isnt 'line'
       hx.consoleWarning('options.type can only be "line" or "bar", you supplied "' + opts.type + '"')

--- a/modules/plot/main/coffee/Sparkline.coffee
+++ b/modules/plot/main/coffee/Sparkline.coffee
@@ -7,6 +7,7 @@ class Sparkline
       data: [],
       type: 'line',
       labelRenderer: (element, obj) -> hx.select(element).text(obj.y + ' (' + obj.x + ')')
+      redrawOnResize: true
     }, options)
 
     innerLabelRenderer = (element, meta) ->

--- a/modules/plot/test/spec.coffee
+++ b/modules/plot/test/spec.coffee
@@ -354,8 +354,13 @@ describe "plot", ->
       checkSetterGetterAndOption('startAngle', [0, 5, 10])
 
   describe 'hx.Sparkline', ->
+    it 'should use the correct default value for redrawOnResize', ->
+      sparkLine = new hx.Sparkline(hx.detached('div').node())
+      sparkLine._.graph.redrawOnResize().should.equal(true)
+      sparkLine.redrawOnResize().should.equal(true)
+
     it 'should pass the redrawOnResize option to its Graph', ->
-      sparkLine = new hx.Sparkline(hx.detached('div'), redrawOnResize: false)
+      sparkLine = new hx.Sparkline(hx.detached('div').node(), redrawOnResize: false)
       sparkLine._.graph.redrawOnResize().should.equal(false)
       sparkLine.redrawOnResize().should.equal(false)
       sparkLine.redrawOnResize(true)


### PR DESCRIPTION
When `redrawOnResize` was added, it was assumed that it would be defaulted to _true_ however as we pass it over in the options directly (`{ redrawOnResize: options.redrawOnResize }`) it was defaulting to `undefined`
Resolves #279