### PR TITLE
#29: add lazy loading to trees

### DIFF
--- a/modules/tree/main/index.coffee
+++ b/modules/tree/main/index.coffee
@@ -125,6 +125,7 @@ class Tree
       animate: true
       renderer: (elem, data) -> hx.select(elem).html(data.name || data)
       items: []
+      lazy: false
     }, options
 
     @selection = hx.select(@selector).classed('hx-tree hx-openable', true)

--- a/modules/tree/main/index.coffee
+++ b/modules/tree/main/index.coffee
@@ -62,7 +62,7 @@ format = (tree, element, animate) ->
     renderLazyChildren(treeNode, true)
     treeNode.selectAll('.hx-tree-node-children').style('display', 'block')
 
-    if treeNode.style('display') is 'block'
+    if treeNode.shallowSelect('.hx-tree-node-children').style('display') is 'block'
       formatChildren(tree, treeNode.selectAll('.hx-tree-node'), animate)
     else
       toggle(iconElement)


### PR DESCRIPTION
resolves #29 

I used this for benchmarking:
```js
let count = 0
const createItemTree = (levels, level = 0) => {
  return hx.range(10).map(int => {
    let children
    if (level < levels) {
      children = createItemTree(levels, level + 1)
    }
    count += 1
    return {
      name: 'Node',
      children: children || []
    }
  })
}
const itemTree = createItemTree(4)
console.log('countNodes', count)

start = new Date()
hx.select('body')
.add(hx.tree({
  lazy: true,
  items: itemTree
}))

hx.select('body')
  .add('br')

console.log('first', Date.now() - start.getTime())
start = new Date()
hx.select('body')
.add(hx.tree({
  lazy: false,
  items: itemTree
}))
console.log('second', Date.now() - start.getTime())
```

It's not the cleanest way of doing it but it detects the time it blocks execution of other JS.
```
countNodes 111110
first 312
second 22350
```

Double click is still enabled for lazy loading trees so if you have a lot of nested content in one node you can still 'hang' the UI - I'm looking at optimising the rendering so it only updates the DOM at the last step but in it's current state this resolves the issue :)