### PR TITLE
#299: add a renderer option to notifications

### DIFF
--- a/modules/notify/main/index.coffee
+++ b/modules/notify/main/index.coffee
@@ -7,6 +7,7 @@ setupNotification = (notification, selection) ->
   content = hx.detached('div').class('hx-notification-content')
   msg = notification.message
 
+  # We check `isNumber` here as in some cases it might be sensible to pass a number as the message (e.g. hx.notify.error(404))
   msgIsString = hx.isString(msg) or hx.isNumber(msg)
 
   msgIsNode = not msgIsString and ((msg instanceof hx.Selection) or (msg instanceof HTMLElement))

--- a/modules/notify/main/index.coffee
+++ b/modules/notify/main/index.coffee
@@ -41,8 +41,10 @@ redraw = (manager) ->
   view = container.view('.hx-notification')
   view.enter (d) ->
     selection = @append('div')
+    optionalClass = if d.options.cssclass then " #{d.options.cssclass}" else ''
+
     selection
-      .class('hx-notification ' + d.options.cssclass)
+      .class("hx-notification#{optionalClass}")
       .forEach (node) ->
         setupNotification(d, selection)
         d.trueHeight = selection.style('height')
@@ -88,7 +90,7 @@ class Notification
   constructor: (@manager, @message, options) ->
     @options = hx.merge {
       icon: undefined
-      cssClass: undefined
+      cssclass: undefined
       timeout: @manager._.defaultTimeout
       pinnable: true
       renderer: (node, message) -> hx.select(node).text(message)
@@ -143,7 +145,8 @@ class NotificationManager
     mergedOptions = hx.merge({
       icon: 'hx-icon ' + iconClass
     }, options)
-    mergedOptions.cssclass = contextClass + ' ' + (options.cssclass or '')
+    optionalClass = if mergedOptions.cssclass then " #{mergedOptions.cssclass}" else ''
+    mergedOptions.cssclass = "#{contextClass}#{optionalClass}"
     manager.notify(message, mergedOptions)
 
   info: (message, options = {}) ->

--- a/modules/notify/main/index.coffee
+++ b/modules/notify/main/index.coffee
@@ -1,33 +1,32 @@
 # utility method for setting up notifications
 setupNotification = (notification, selection) ->
-  if notification.options.icon? and notification.options.icon.length > 0
-    selection.append('div')
-      .class('hx-notification-icon-container')
-      .append('i')
-        .class('hx-notification-icon ' + notification.options.icon)
+  icon = if notification.options.icon? and notification.options.icon.length > 0
+    hx.detached('div').class('hx-notification-icon-container')
+      .add(hx.detached('i').class('hx-notification-icon ' + notification.options.icon))
 
-  selection
-    .append('div')
-      .class('hx-notification-text')
-      .text(notification.message)
+  content = hx.detached('div').class('hx-notification-content')
+  notification.options.renderer(content.node(), notification.message)
 
   if notification.options.pinnable
-    notification.domPin = selection
-      .append('div')
-        .class('hx-notification-icon-container hx-notification-pin')
-        .on 'click', 'hx.notify', -> togglePin(notification)
+    pin = hx.detached('div')
+      .class('hx-notification-icon-container hx-notification-pin')
+      .on('click', 'hx.notify', -> togglePin(notification))
+      .add(hx.detached('i').attr('class', 'hx-icon hx-icon-thumb-tack'))
 
-    notification.domPin.append('i')
-      .attr('class', 'hx-icon hx-icon-thumb-tack')
-
+    notification.domPin = pin
     updatePinnedStatus(notification)
 
+  close = hx.detached('div')
+    .class('hx-notification-icon-container hx-notification-close')
+    .on('click', 'hx.notify', -> notification.close())
+    .add(hx.detached('i').class('hx-icon hx-icon-close'))
+
+
   selection
-    .append('div')
-      .class('hx-notification-icon-container hx-notification-close')
-      .on 'click', 'hx.notify', -> notification.close()
-      .append('i')
-        .class('hx-icon hx-icon-close')
+    .add(icon)
+    .add(content)
+    .add(pin)
+    .add(close)
 
 nextId = (manager) -> manager.currentId++
 
@@ -92,6 +91,7 @@ class Notification
       cssClass: undefined
       timeout: @manager._.defaultTimeout
       pinnable: true
+      renderer: (node, message) -> hx.select(node).text(message)
     }, options
 
     @id = nextId(@manager)

--- a/modules/notify/main/index.scss
+++ b/modules/notify/main/index.scss
@@ -72,9 +72,8 @@ body.hx-modal-open > {
     cursor: pointer;
   }
 
-  .hx-notification-text {
+  .hx-notification-content {
     word-wrap: break-word;
-    margin: 0;
     flex: 1 1 auto;
   }
 }


### PR DESCRIPTION
resolves #299

Example JS:
```js
const message = {
  header: 'Failed to do something',
  body: 'Something failed',
  url: 'somewhere/somewhere-else'
}

const options = {
  renderer: (node, message) => {
    const rows = [
      hx.detached('b').text(message.header),
      hx.detached('span').text(message.body),
      hx.detached('i').class('small').text(message.url)
    ].map((row) => hx.detached('div').add(row))

    hx.select(node).classed('customNotice', true).add(rows)
  }
}

hx.notify.warning(message, options)
hx.notify.warning('Regular Notice')
hx.notify('Regular Notice')
```

CSS:
```
.customNotice {
  font-size: 0.9em;
}

.small {
  opacity: 0.8;
  font-size: 0.9em;
}
```

Screenshot:
<img width="506" alt="screen shot 2016-10-04 at 11 03 55" src="https://cloud.githubusercontent.com/assets/3194349/19070268/54fd41aa-8a22-11e6-99b2-908e54774182.png">