### PR TITLE
add some issue templates to .github directory

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -36,27 +36,3 @@ To test just the library process:
 To test a single module:
 
     npm run test-library <name-of-module>
-
-
-Template for issue creation
----------------------------
-
-When submitting a bug report please provide an example that reproduces the bug, and specify which version of hexagon you are using. The following template can be used:
-
-    Title: Module Name: short description
-
-    Hexagon version: x.x.x
-    Theme: theme-name    // if relevant
-    Build Config: {...}  // if using the npm builder
-
-    Expected
-    --------
-    What you expected to happen
-
-    Actual
-    ------
-    What actually happens
-
-    Example
-    -------
-    A short example that reproduces the problem

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,31 @@
+<!--- Provide a general summary of the issue in the Title above in the following format: -->
+<!--- DataTable: error rendering when setting feed -->
+
+## Context
+<!--- Provide a more detailed introduction to the issue itself, and why you consider it to be a bug -->
+
+## Expected Behavior
+<!--- Tell us what should happen -->
+
+## Actual Behavior
+<!--- Tell us what happens instead -->
+
+## Possible Fix
+<!--- Not obligatory, but suggest a fix or reason for the bug -->
+
+## Steps to Reproduce
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug include code to reproduce, if relevant -->
+1.
+2.
+3.
+4.
+
+## Context
+<!--- How has this bug affected you? What were you trying to accomplish? -->
+
+## Your Environment
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+* Hexagon Version:
+* Browser Name and version:
+* Operating System and version (desktop or mobile):

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+<!--- Provide a general summary of your changes in the Title above in the following format -->
+<!--- #404: resolved issue with data table -->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here (e.g. Resolves #404) -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Screenshots (if appropriate):
+
+## Types of changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+## Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have read the **CONTRIBUTING** document.
+- [ ] I have added tests to cover my changes.
+- [ ] All new and existing tests passed.


### PR DESCRIPTION
I realised that we could have templates for PRs and Issue creation so I added some templates based on a 'generator':

https://www.talater.com/open-source-templates/ - It's built like a text-based adventure which is fun :) 

I'm not 100% sure on what _should_ go in these files so feel free to make suggestions