### PR TITLE
#203: update the tag input to deal with when it is inside a form

### DIFF
--- a/modules/form/main/index.coffee
+++ b/modules/form/main/index.coffee
@@ -30,6 +30,8 @@ validateForm = (form, options) ->
 
   errors = []
 
+  focusedElement = document.activeElement
+
   for i in [0...form.children.length]
     # Loop through all direct child divs of form element ()
     if form.children[i].nodeName.toLowerCase() is 'div'
@@ -43,6 +45,7 @@ validateForm = (form, options) ->
             message: getValidationMessage element.validationMessage, type
             node: element
             validity: element.validity
+            focused: focusedElement is element
           }
       else
         # Deal with radio groups and other similar structured elements
@@ -53,10 +56,13 @@ validateForm = (form, options) ->
             message: getValidationMessage input.validationMessage, type
             node: element
             validity: input.validity
+            focused: focusedElement is input
           }
 
   if options.showMessage and errors.length > 0
-    error = errors[0]
+    # Show the error for the focused element (if there is one) or the first error in the form
+    error = errors.filter((error) -> error.focused)[0] or errors[0]
+
     # XXX: This structure lets us jump out of the forced table layout. If we change
     # to match the full-width aeris forms, this will need changing.
     hx.select(error.node.parentNode)

--- a/modules/tag-input/main/index.scss
+++ b/modules/tag-input/main/index.scss
@@ -16,20 +16,20 @@
       display: none;
     }
   }
+}
 
-  form {
-    flex-flow: row wrap;
+.hx-tag-input-container {
+  flex-flow: row wrap;
+  flex-grow: 1;
+  display: flex;
+
+  input {
+    margin: 0;
+    margin: -1px;
     flex-grow: 1;
-    display: flex;
-
-    input {
-      margin: 0;
-      border-style: none;
-      flex-grow: 1;
-      padding-top: 0.55em;
-      padding-bottom: 0.55em;
-      min-width: 150px;
-    }
+    padding-top: 0.55em;
+    padding-bottom: 0.55em;
+    min-width: 150px;
   }
 }
 

--- a/modules/tag-input/module.json
+++ b/modules/tag-input/module.json
@@ -7,6 +7,7 @@
     "layout",
     "selection",
     "user-facing-text",
-    "util"
+    "util",
+    "form"
   ]
 }


### PR DESCRIPTION
Also update the styles so the focus/invalid borders show correctly and update the `validateForm` function so that it shows the error for the focused element if applicable.
Resolves #203

Example:
```js
const tagInput = hx.tagInput({
  validator: (term) => 'bob'
})

const formSel = hx.detached('form')

void new hx.Form(formSel.node())
  .addText('Text', {required: true})
  .addTagInput('Tag Input', {
    tagInputOptions: {
      validator: (term) => 'bob'
    }
  })
  .addSubmit('Submit')

const bodySel = hx.select('body')
bodySel.append(tagInput)
bodySel.append(formSel)
```

Notes:
- Entering a tag and pressing enter shows the inbuilt browser error when outside the form and the `validateForm` error when used inside a form
- Validation is now based on which element is focused (e.g. leave 'required' field empty and try to enter a tag)
- Other behaviour is as previous