### PR TITLE
#290: prevent text wrapping for basic labels

### DIFF
--- a/modules/plot/main/index.scss
+++ b/modules/plot/main/index.scss
@@ -66,7 +66,7 @@
   position: absolute;
 }
 
-// XXXL theme variables
+// XXX: theme variables
 .hx-plot-label-details {
   transform: translate(10px, -50%);
   position: absolute;
@@ -84,6 +84,7 @@
   font-weight: bold;
   margin-left: 0.5em;
   padding: 0.5em;
+  white-space: nowrap;
 }
 
 .hx-plot-label-details-header {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above in the following format -->
<!--- #404: resolved issue with data table -->

## Description
<!--- Describe your changes in detail -->
Prevent text wrapping for basic labels on graphs to make them display correctly using `white-space: nowrap`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Resolves #404) -->
The basic plot labels (e.g. those used in sparklines) allow text wrapping which can be problematic when showing more complex values with spaces in.
Resolves #290 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested visually (see screenshots)

## Screenshots (if appropriate):
Before:
<img width="375" alt="screen shot 2016-10-10 at 14 48 10" src="https://cloud.githubusercontent.com/assets/3194349/19238259/a4d1e548-8ef8-11e6-8ee7-ffb6015f0ef0.png">

After:
<img width="370" alt="screen shot 2016-10-10 at 14 47 50" src="https://cloud.githubusercontent.com/assets/3194349/19238260/a4d45382-8ef8-11e6-99d6-d127d66fad6b.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

