### PR TITLE
#236: properly hide sticky table cells so they don't show in ctrl+f results

### DIFF
--- a/modules/sticky-table-headers/main/index.coffee
+++ b/modules/sticky-table-headers/main/index.coffee
@@ -12,20 +12,19 @@ updateScrollIndicators = (wrapper, top, right, bottom, left) ->
   bottom.style('display', if canScrollDown then 'block' else '')
   left.style('display', if canScrollLeft then 'block' else '')
 
-updateHeaderPositions = (container) ->
+updateHeaderPositions = (container, wrapperNode) ->
   # Set the relative positions of the two headers.
   # This method reduces flickering when scrolling on mobile devices.
-  node = getChildren(container, '.hx-sticky-table-wrapper')[0]
-  leftOffset = - node.scrollLeft
-  topOffset = - node.scrollTop
+  leftOffset = - wrapperNode.scrollLeft
+  topOffset = - wrapperNode.scrollTop
 
-  topNode = getChildren(container, '.hx-sticky-table-header-top')[0]
+  topNode = container.shallowSelect('.hx-sticky-table-header-top')
   if topNode?
-    hx.select(topNode).select('.hx-table').style('left', leftOffset + 'px')
+    topNode.select('.hx-table').style('left', leftOffset + 'px')
 
-  leftNode = getChildren(container, '.hx-sticky-table-header-left')[0]
+  leftNode = container.shallowSelect('.hx-sticky-table-header-left')
   if leftNode?
-    hx.select(leftNode).select('.hx-table').style('top', topOffset + 'px')
+    leftNode.select('.hx-table').style('top', topOffset + 'px')
 
 
 cloneEvents = (elem, clone) ->
@@ -63,7 +62,18 @@ getChildren = (parent, selector, single) ->
 createStickyHeaderNodes = (real, cloned) ->
   for i in [0...real.length]
     cloneEvents(real[i], cloned[i])
+    # The real table shouldn't show the sticky header nodes
     hx.select(real[i]).classed('hx-sticky-table-invisible', true)
+    hx.select(cloned[i]).classed('hx-sticky-table-invisible', false)
+
+cloneTableAndNodeEvents = (selection, realTable, tableClone, body, single) ->
+  innerTableClone = selection.append tableClone.clone(true)
+  # We make all the cells invisible by default and then only make the ones we care about visible in `createStickyHeaderNodes`
+  innerTableClone.selectAll('th, td').classed('hx-sticky-table-invisible', true)
+  realNodes = getChildrenFromTable realTable, body, single
+  clonedNodes = getChildrenFromTable innerTableClone, body, single
+  createStickyHeaderNodes realNodes, clonedNodes
+  innerTableClone
 
 class StickyTableHeaders
   constructor: (selector, options) ->
@@ -132,7 +142,7 @@ class StickyTableHeaders
     wrapper.on 'scroll', 'hx.sticky-table-headers', ->
       if showScrollIndicators
         updateScrollIndicators(wrapper, topIndicator, rightIndicator, bottomIndicator, leftIndicator)
-      updateHeaderPositions(container)
+      updateHeaderPositions(container, wrapper.node())
 
     @_ = {
       options: resolvedOptions,
@@ -240,15 +250,8 @@ class StickyTableHeaders
           background = table.select('th').style('background-color')
           topHead.style('background-color', background)
 
-
       topHead.clear()
-
-      topTable = topHead.append tableClone.clone(true)
-
-      realNodes = getChildrenFromTable table
-      clonedNodes = getChildrenFromTable topTable
-
-      createStickyHeaderNodes realNodes, clonedNodes
+      topTable = cloneTableAndNodeEvents topHead, table, tableClone
 
     if options.stickFirstColumn
       # Append left
@@ -260,72 +263,52 @@ class StickyTableHeaders
           background = table.select('th').style('background-color')
           leftHead.style('background-color', background)
 
-
       leftHead.clear()
-
-      leftTable = leftHead.append tableClone.clone(true)
-
-      realNodes = getChildrenFromTable table, true, true
-      clonedNodes = getChildrenFromTable leftTable, true, true
-
-      createStickyHeaderNodes realNodes, clonedNodes
+      leftTable = cloneTableAndNodeEvents leftHead, table, tableClone, true, true
 
     if options.stickTableHead and options.stickFirstColumn
       # Append top left
       topLeftHead = container.shallowSelect('.hx-sticky-table-header-top-left')
       if topLeftHead.empty()
         topLeftHead = container.prepend('div').class('hx-sticky-table-header-top-left')
+
       topLeftHead.clear()
-
-      topLeftTable = topLeftHead.append tableClone.clone(true)
-
-      realNodes = getChildrenFromTable table, false, true
-      clonedNodes = getChildrenFromTable topLeftTable, false, true
-
-      createStickyHeaderNodes realNodes, clonedNodes
+      topLeftTable = cloneTableAndNodeEvents topLeftHead, table, tableClone, false, true
 
     topHead?.style('height', offsetHeight + 'px')
       .style('width', wrapperBox.width + 'px')
       .style('left', offsetWidth + 'px')
-      .selectAll('.hx-sticky-table-invisible')
-        .classed('hx-sticky-table-invisible', false)
 
     topTable?.style('margin-left', - offsetWidth + 'px')
-      .selectAll('.hx-sticky-table-invisible')
-        .classed('hx-sticky-table-invisible', false)
 
     leftHead?.style('height', wrapperBox.height + 'px')
       .style('width', offsetWidth + 'px')
       .style('top', offsetHeight + 'px')
-      .selectAll('.hx-sticky-table-invisible')
-        .classed('hx-sticky-table-invisible', false)
 
     leftTable?.style('margin-top', - offsetHeight + 'px')
 
     topLeftHead?.style('width', leftHead?.style('width') || offsetWidth + 'px')
       .style('height', topHead?.style('height') || offsetHeight + 'px')
-      .selectAll('.hx-sticky-table-invisible')
-        .classed('hx-sticky-table-invisible', false)
 
     wrapperNode.scrollTop = origScroll
     if _.showScrollIndicators
       scrollOffsetWidth = offsetWidth - 1
       scrollOffsetHeight = offsetHeight - 1
 
-      topIndicator = container.select('.hx-sticky-table-scroll-top')
+      topIndicator = container.shallowSelect('.hx-sticky-table-scroll-top')
         .style('top', scrollOffsetHeight + 'px')
         .style('left', scrollOffsetWidth + 'px')
         .style('width', wrapperBox.width + 'px')
 
-      rightIndicator = container.select('.hx-sticky-table-scroll-right')
+      rightIndicator = container.shallowSelect('.hx-sticky-table-scroll-right')
         .style('top', scrollOffsetHeight + 'px')
         .style('height', wrapperBox.height + 'px')
 
-      bottomIndicator = container.select('.hx-sticky-table-scroll-bottom')
+      bottomIndicator = container.shallowSelect('.hx-sticky-table-scroll-bottom')
         .style('left', scrollOffsetWidth + 'px')
         .style('width', wrapperBox.width + 'px')
 
-      leftIndicator = container.select('.hx-sticky-table-scroll-left')
+      leftIndicator = container.shallowSelect('.hx-sticky-table-scroll-left')
         .style('top', scrollOffsetHeight + 'px')
         .style('left', scrollOffsetWidth + 'px')
         .style('height', wrapperBox.height + 'px')
@@ -333,7 +316,7 @@ class StickyTableHeaders
       updateScrollIndicators(wrapper, topIndicator, rightIndicator, bottomIndicator, leftIndicator)
 
 
-    updateHeaderPositions(container)
+    updateHeaderPositions(container, wrapper.node())
 
 
 hx.StickyTableHeaders = StickyTableHeaders

--- a/modules/sticky-table-headers/main/index.scss
+++ b/modules/sticky-table-headers/main/index.scss
@@ -19,6 +19,10 @@
     z-index: 2;
   }
 
+  .hx-sticky-table-invisible {
+    visibility: hidden;
+  }
+
   .hx-sticky-table-header-top {
     top: 0;
 
@@ -53,10 +57,6 @@
 
     .hx-table {
       overflow: visible;
-    }
-
-    .hx-sticky-table-invisible {
-      visibility: hidden;
     }
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above in the following format -->
<!--- #404: resolved issue with data table -->

## Description
<!--- Describe your changes in detail -->
Updated the internals to be more deliberate when hiding/showing cells. This involved making all the cells (`td, th`) in cloned tables invisible (using `hx-sticky-table-invisible`) by default and then only making them visible when we create the sticky headers.

This update means that all cells that cannot be seen when scrolling are given the `visibility: hidden` style which prevents them showing in `ctrl+f` results.

I did this in a common way and removed some duplicate code by pulling it out into a function.

I also updated a few places  internally to use `shallowSelect`/`shallowSelectAll` as it is more efficient and removed the need for some code.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Resolves #404) -->
Resolves #236 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in-browser using the code from https://www.hexagonjs.io/examples/sticky-table-headers/ and making sure that there are only `567` search results for `Cell Text` and `61` search results for `Head Text` to match the HTML.
Also made sure `dataTable` tests still pass as they use the sticky table headers.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.