### PR TITLE
#313: update tag input to use more of the autocomplete internal

### DIFF
--- a/modules/tag-input/main/index.coffee
+++ b/modules/tag-input/main/index.coffee
@@ -72,10 +72,11 @@ class TagInput extends hx.EventEmitter
       if event.keyCode is 13
         if @form.node().checkValidity()
           event.preventDefault()
-          name = @input.value()
-          if name
-            _.userEvent = true
-            @add name
+          if not @_.autocomplete
+            name = @input.value()
+            if name
+              _.userEvent = true
+              @add name
 
     @input.on 'input', 'hx.tag-input', hasError
 
@@ -87,9 +88,11 @@ class TagInput extends hx.EventEmitter
         if @input.value() is ''
           selection = @tagContainer.selectAll('.hx-tag')
           if selection.size() > 0
+            @_.autocomplete?.hide()
             nodeSelection = hx.select(selection.node(selection.size()-1))
             value = nodeSelection.text()
             nodeSelection.remove()
+            @_.autocomplete?.show()
             @emit 'remove', {value: value, type: 'user'}
 
     @input.on 'keyup', 'hx.tag-input', (event) ->
@@ -97,9 +100,10 @@ class TagInput extends hx.EventEmitter
         backspacedown = false
         true
 
-    @input.on 'blur', 'hx.tag-input', (event) =>
-      if @input.value().length > 0 and not hasError()
-        @add(@input.value(), undefined)
+    if not @_.autocomplete
+      @input.on 'blur', 'hx.tag-input', (event) =>
+        if @input.value().length > 0 and not hasError()
+          @add(@input.value(), undefined)
 
     @input.on 'focus', 'hx.tag-input', (event) =>
       if hasError() then @form.node().checkValidity()

--- a/modules/tag-input/test/spec.coffee
+++ b/modules/tag-input/test/spec.coffee
@@ -253,5 +253,6 @@ describe 'tag-input', ->
       testHelpers.fakeNodeEvent(ti.input.node(), 'blur')({})
       testHelpers.fakeNodeEvent(dropdown.node(), 'click')({target: target})
       ti.items().should.eql(['bob'])
+      clock.uninstall()
 
 

--- a/modules/tag-input/test/spec.coffee
+++ b/modules/tag-input/test/spec.coffee
@@ -2,6 +2,8 @@ describe 'tag-input', ->
   origConsoleWarning = hx.consoleWarning
   hx.consoleWarning = chai.spy()
 
+  dropdownAnimateDuration = 200
+
   beforeEach ->
     hx.consoleWarning.reset()
 
@@ -184,8 +186,6 @@ describe 'tag-input', ->
         autocompleteData: ['a', 'b', 'c']
       })
 
-      dropdownAnimateDuration = 200
-
       chai.spy.on(ti._.autocomplete, 'show')
       testHelpers.fakeNodeEvent(ti.input.node(), 'focus')({})
       clock.tick(dropdownAnimateDuration)
@@ -236,3 +236,22 @@ describe 'tag-input', ->
         mustMatchAutocomplete: false
       })
       expect(ti._.autocomplete.options.mustMatch).to.be.false
+
+    it 'should not add a tag when selecting the item via the autocomplete', ->
+      ti = new hx.TagInput(hx.detached('div').node(), {
+        autocompleteData: ['bob']
+      })
+      clock = sinon.useFakeTimers()
+      testHelpers.fakeNodeEvent(ti.input.node(), 'focus')({})
+      ti.input.value('b')
+      testHelpers.fakeNodeEvent(ti.input.node(), 'input')({})
+      clock.tick(dropdownAnimateDuration)
+
+      dropdown = ti._.autocomplete._.menu.dropdown._.dropdown
+      target = dropdown.select('.hx-menu-item').node()
+
+      testHelpers.fakeNodeEvent(ti.input.node(), 'blur')({})
+      testHelpers.fakeNodeEvent(dropdown.node(), 'click')({target: target})
+      ti.items().should.eql(['bob'])
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above in the following format -->
<!--- #404: resolved issue with data table -->

## Description
<!--- Describe your changes in detail -->
Hand over the handling for blur/enter to autocomplete as it deals nicely with the `mustMatch` functionality by removing the `blur` event and only calling the `add` method inside the tag input when the autocomplete does not exist or has been updated.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Resolves #404) -->
Resolves #313 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a regression test and tested in browser using example in #313 

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.