### PR TITLE
#179: bugfix event emitter memory leak

### DIFF
--- a/modules/event-emitter/main/index.coffee
+++ b/modules/event-emitter/main/index.coffee
@@ -9,7 +9,7 @@ class BasicEventEmitter
     cb(name, data) for cb in @allCallbacks.entries()
     this
 
-  isEmpty: -> hx.sum(@callbacks.values().map((list) -> list.size)) is 0 and @allCallbacks.size is 0
+  isEmpty: -> @callbacks.values().every((list) -> list.size is 0) and @allCallbacks.size is 0
 
   # register a callback against the name given
   on: (name, callback) ->

--- a/modules/event-emitter/main/index.coffee
+++ b/modules/event-emitter/main/index.coffee
@@ -1,6 +1,4 @@
-
 class BasicEventEmitter
-
   constructor: ->
     @callbacks = new hx.Map
     @allCallbacks = new hx.List
@@ -10,6 +8,8 @@ class BasicEventEmitter
     if @callbacks.has(name) then cb(data) for cb in @callbacks.get(name).entries()
     cb(name, data) for cb in @allCallbacks.entries()
     this
+
+  isEmpty: -> hx.sum(@callbacks.values().map((list) -> list.size)) is 0 and @allCallbacks.size is 0
 
   # register a callback against the name given
   on: (name, callback) ->
@@ -74,19 +74,23 @@ class EventEmitter
     ee.emitters.add(be)
     be
 
-  removeEmitter = (ee, namespace) ->
-    if ee.emittersMap.has(namespace)
+  removeEmitter = (ee, be, namespace) ->
+    if namespace and ee.emittersMap.has(namespace)
       ee.emittersMap.delete(namespace)
-      ee.emitters.remove(ee)
-    ee
+    else
+      lookedUpNamespace = ee.emittersMap.entries().filter(([_, e]) -> e is be)[0]?[0]
+      if lookedUpNamespace
+        ee.emittersMap.delete(lookedUpNamespace)
+    ee.emitters.remove(be)
 
   # emit an object to all callbacks registered with the name given
   emit: (name, data) ->
     if not @suppressedMap.get(name)
-      if @deprecatedEvents?
-        for e of @deprecatedEvents
-          if @deprecatedEvents[e].event is name
-            @emit e, data
+      # XXX: Deprecated event check - This is useful to have if we need to deprecated events in the future
+      # if @deprecatedEvents?
+      #   for e of @deprecatedEvents
+      #     if @deprecatedEvents[e].event is name
+      #       @emit e, data
 
       for emitter in @emitters.entries()
         emitter.emit(name, data)
@@ -130,10 +134,22 @@ class EventEmitter
   # deregisters a callback
   off: (name, namespace, callback) ->
     if hx.isString(namespace)
-      @emittersMap.get(namespace)?.off(name, callback)
+      if @emittersMap.has(namespace)
+        be = @emittersMap.get(namespace)
+        be.off(name, callback)
+        if be.isEmpty()
+          removeEmitter(this, be, namespace)
     else
-      for emitter in @emitters.entries()
+      if not callback and not hx.isString(namespace)
+        callback = namespace
+
+      emitters = @emitters.entries()
+      emittersToRemove = []
+      emitters.forEach (emitter) =>
         emitter.off(name, callback)
+        if emitter isnt @global and emitter.isEmpty()
+          emittersToRemove.push(emitter)
+      emittersToRemove.map((e) => removeEmitter(this, e))
     this
 
   # lets you pipe events through to another event emitter

--- a/modules/event-emitter/test/spec.coffee
+++ b/modules/event-emitter/test/spec.coffee
@@ -1,4 +1,11 @@
 describe "EventEmitter", ->
+  origConsoleWarning = hx.consoleWarning
+
+  beforeEach ->
+    hx.consoleWarning = chai.spy()
+
+  afterEach ->
+    hx.consoleWarning = origConsoleWarning
 
   it "should work with a single callback registered", ->
     eventEmitter = new hx.EventEmitter
@@ -55,6 +62,26 @@ describe "EventEmitter", ->
     eventEmitter = new hx.EventEmitter
     eventEmitter.on(null, (data) -> received = data)
     eventEmitter.has('test-event').should.equal(true)
+
+  it "should know which handlers are registered in namespaces", ->
+    ee = new hx.EventEmitter
+    ee.on('name', 'namespace', chai.spy())
+    ee.has('name').should.equal(true)
+
+  it "should know which handlers are registered in namespaces when no name is used", ->
+    ee = new hx.EventEmitter
+    ee.on(null, 'namespace', chai.spy())
+    ee.has('name').should.equal(true)
+
+  it "should know when handlers do not exist", ->
+    ee = new hx.EventEmitter
+    ee.on('name', chai.spy())
+    ee.has('test-event').should.equal(false)
+
+  it "should know when handlers do not exist in namespaces", ->
+    ee = new hx.EventEmitter
+    ee.on('name', 'namespace', chai.spy())
+    ee.has('test-event').should.equal(false)
 
   it "should allow listening to all events", ->
     eventEmitter = new hx.EventEmitter
@@ -158,7 +185,61 @@ describe "EventEmitter", ->
     received2.should.equal("some-data-1")
     received3.should.equal("some-data-10")
 
+  it "should be able to de-register handlers with no name", ->
+    ee = new hx.EventEmitter
+    spy = chai.spy()
+    ee.on(undefined, spy)
+    ee.emit('test', 'data')
+    spy.should.have.been.called.with('test','data')
+    spy.reset()
+    ee.off(undefined, spy)
+    ee.emit('test2', 'data2')
+    spy.should.not.have.been.called()
 
+  it "should clean-up correctly when de-registering handlers", ->
+    ee = new hx.EventEmitter
+    ee.emitters.size.should.equal(1)
+    ee.emittersMap.size.should.equal(1)
+    ee.emittersMap.entries().should.eql([['default', ee.global]])
+    ee.emittersMap.values()[0].should.equal(ee.global)
+    ee.global.callbacks.size.should.equal(0)
+
+    spy = chai.spy()
+
+    should.not.exist(ee.global.callbacks.get('name'))
+    ee.on('name', spy)
+    ee.global.callbacks.get('name').size.should.equal(1)
+
+    ee.off('name', spy)
+    ee.global.callbacks.get('name').size.should.equal(0)
+
+  it "should clean-up correctly when de-registering handlers with a namespace", ->
+    ee = new hx.EventEmitter
+    ee.emitters.size.should.equal(1)
+    ee.emittersMap.size.should.equal(1)
+    ee.emittersMap.entries().should.eql([['default', ee.global]])
+    ee.emittersMap.values()[0].should.equal(ee.global)
+    ee.global.callbacks.size.should.equal(0)
+
+    spy = chai.spy()
+
+    should.not.exist(ee.global.callbacks.get('name'))
+    ee.on('name', 'namespace', spy)
+    should.not.exist(ee.global.callbacks.get('name'))
+    ee.global.callbacks.size.should.equal(0)
+    ee.emitters.size.should.equal(2)
+    ee.emittersMap.size.should.equal(2)
+    ee.emittersMap.get('namespace').callbacks.get('name').size.should.equal(1)
+
+    ee.off('name', 'namespace', spy)
+    ee.emitters.size.should.equal(1)
+    ee.emittersMap.size.should.equal(1)
+    should.not.exist(ee.emittersMap.get('namespace'))
+
+  it "should be fine de-registering when a namespace doesn't exist", ->
+    ee = new hx.EventEmitter
+    spy = chai.spy()
+    ee.off('name', 'namespace', spy).should.equal(ee)
 
   it "should do standard piping correctly 1", ->
     ee1 = new hx.EventEmitter
@@ -421,3 +502,12 @@ describe "EventEmitter", ->
     ee.suppressed('test-event').should.equal(true)
     ee.suppressed('test-event', false).should.equal(ee)
     ee.suppressed('test-event').should.equal(false)
+
+  it 'should not let you assign "default" as a namespace', ->
+    ee = new hx.EventEmitter
+    spy = chai.spy()
+    hx.consoleWarning.should.not.have.been.called()
+    ee.on('name', 'default', spy)
+    hx.consoleWarning.should.have.been.called.with('"default" is a reserved namespace. It can not be used as a namespace name.')
+    ee.emit('name')
+    spy.should.not.have.been.called()

--- a/modules/selection/test/spec.coffee
+++ b/modules/selection/test/spec.coffee
@@ -1078,7 +1078,7 @@ describe 'Selection Api', ->
     div = hx.detached('div')
     called = false
     div.on 'click', (e) -> called = true
-    div.node().__hx__.eventEmitter.emit('click', {})
+    testHelpers.fakeNodeEvent(div.node(), 'click')({})
     called.should.equal(true)
 
   it 'basic event emitter replacement should work', ->
@@ -1086,7 +1086,7 @@ describe 'Selection Api', ->
     called = false
     div.on('click', (e) -> called = 1)
     div.on('click', (e) -> called = 2)
-    div.node().__hx__.eventEmitter.emit('click', {})
+    testHelpers.fakeNodeEvent(div.node(), 'click')({})
     called.should.equal(2)
 
   it 'basic event emitter removal should work', ->
@@ -1096,14 +1096,14 @@ describe 'Selection Api', ->
     div.on('click', (e) -> called = 2)
     div.on('click', f)
     div.off('click', f)
-    div.node().__hx__.eventEmitter.emit('click', {})
+    testHelpers.fakeNodeEvent(div.node(), 'click')({})
     called.should.equal(false)
 
   it 'namespaced event emitter addition should work', ->
     div = hx.detached('div')
     result1 = false
     div.on('click', 'my-namespace', (e) -> result1 = true)
-    div.node().__hx__.eventEmitter.emit('click', {})
+    testHelpers.fakeNodeEvent(div.node(), 'click')({})
     result1.should.equal(true)
 
   it 'namespaced event emitter addition should not affect other namespaces', ->
@@ -1112,7 +1112,7 @@ describe 'Selection Api', ->
     result2 = false
     div.on('click', 'my-namespace-1', (e) -> result1 = true)
     div.on('click', 'my-namespace-2', (e) -> result2 = true)
-    div.node().__hx__.eventEmitter.emit('click', {})
+    testHelpers.fakeNodeEvent(div.node(), 'click')({})
     result1.should.equal(true)
     result2.should.equal(true)
 
@@ -1123,7 +1123,7 @@ describe 'Selection Api', ->
     div.on('click', 'my-namespace-1', (e) -> result1 = true)
     div.on('click', 'my-namespace-2', (e) -> result2 = true)
     div.off('click', 'my-namespace-1')
-    div.node().__hx__.eventEmitter.emit('click', {})
+    testHelpers.fakeNodeEvent(div.node(), 'click')({})
     result1.should.equal(false)
     result2.should.equal(true)
 
@@ -1135,7 +1135,7 @@ describe 'Selection Api', ->
     div.on('click', 'my-namespace-1', f)
     div.on('click', 'my-namespace-2', (e) -> result2 = true)
     div.off('click', 'my-namespace-1', f)
-    div.node().__hx__.eventEmitter.emit('click', {})
+    testHelpers.fakeNodeEvent(div.node(), 'click')({})
     result1.should.equal(false)
     result2.should.equal(true)
 
@@ -1147,7 +1147,7 @@ describe 'Selection Api', ->
     div.on('click', 'my-namespace-1', f)
     div.on('click', 'my-namespace-2', (e) -> result2 = true)
     div.off('click', f)
-    div.node().__hx__.eventEmitter.emit('click', {})
+    testHelpers.fakeNodeEvent(div.node(), 'click')({})
     result1.should.equal(false)
     result2.should.equal(true)
 
@@ -1159,7 +1159,7 @@ describe 'Selection Api', ->
     div.on('click', 'my-namespace-1', (e) -> result1 = true)
     div.on('click', 'my-namespace-2', (e) -> result2 = true)
     div.on('click', 'my-namespace-1', (e) -> result3 = true)
-    div.node().__hx__.eventEmitter.emit('click', {})
+    testHelpers.fakeNodeEvent(div.node(), 'click')({})
     result1.should.equal(false)
     result2.should.equal(true)
     result3.should.equal(true)
@@ -1171,10 +1171,10 @@ describe 'Selection Api', ->
     result3 = false
     div.on('click', 'my-namespace-1', (e) -> result1 = true)
     div.on('click', 'my-namespace-2', (e) -> result2 = true)
-    div.on('clack', 'my-namespace-1', ((e) -> result3 = true))
+    div.on('clack', 'my-namespace-1', (e) -> result3 = true)
     div.off()
-    div.node().__hx__.eventEmitter.emit('click', {})
-    div.node().__hx__.eventEmitter.emit('clack', {})
+    testHelpers.fakeNodeEvent(div.node(), 'click')({})
+    testHelpers.fakeNodeEvent(div.node(), 'clack')({})
     result1.should.equal(false)
     result2.should.equal(false)
     result3.should.equal(false)
@@ -1188,8 +1188,8 @@ describe 'Selection Api', ->
     div.on('click', 'my-namespace-2', (e) -> result2 = true)
     div.on('clack', 'my-namespace-1', ((e) -> result3 = true))
     div.off('click')
-    div.node().__hx__.eventEmitter.emit('click', {})
-    div.node().__hx__.eventEmitter.emit('clack', {})
+    testHelpers.fakeNodeEvent(div.node(), 'click')({})
+    testHelpers.fakeNodeEvent(div.node(), 'clack')({})
     result1.should.equal(false)
     result2.should.equal(false)
     result3.should.equal(true)
@@ -1203,8 +1203,8 @@ describe 'Selection Api', ->
     div.on('click', 'my-namespace-2', (e) -> result2 = true)
     div.on('clack', 'my-namespace-1', ((e) -> result3 = true))
     div.off(undefined, 'my-namespace-1')
-    div.node().__hx__.eventEmitter.emit('click', {})
-    div.node().__hx__.eventEmitter.emit('clack', {})
+    testHelpers.fakeNodeEvent(div.node(), 'click')({})
+    testHelpers.fakeNodeEvent(div.node(), 'clack')({})
     result1.should.equal(false)
     result2.should.equal(true)
     result3.should.equal(false)
@@ -1218,8 +1218,8 @@ describe 'Selection Api', ->
     div.on('click', 'my-namespace-2', (e) -> result2 = true)
     div.on('clack', 'my-namespace-1', ((e) -> result3 = true))
     div.off('click', 'my-namespace-1')
-    div.node().__hx__.eventEmitter.emit('click', {})
-    div.node().__hx__.eventEmitter.emit('clack', {})
+    testHelpers.fakeNodeEvent(div.node(), 'click')({})
+    testHelpers.fakeNodeEvent(div.node(), 'clack')({})
     result1.should.equal(false)
     result2.should.equal(true)
     result3.should.equal(true)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above in the following format -->
<!--- #404: resolved issue with data table -->

## Description
<!--- Describe your changes in detail -->
Updated the `off` method of `EventEmitter` to check if a `BasicEventEmitter` is empty after the callback/listeners have been removed and remove it from the `EventEmitter` if it has no listeners left.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Resolves #404) -->
Resolves #179 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In addition to adding tests, I used the following to test in the browser:
```js
hx.range(500).map(() => setInterval(addTest, 1))
function addTest () {
  const cd = new hx.ClickDetector()
  cd.cleanUp()
}
```
This rapidly creates name-spaced event emitters on the `document` (for `pointer-up`/`pointer-down`) and then calls the cleanup on the click detector to remove them straight away.
I then used the chrome developer tools to look a the JS Heap over 6 seconds (that's all the buffer can store in this example):

Before Change (bottom of graph is 240mb, top is 366mb):
![screen shot 2016-10-12 at 11 36 38](https://cloud.githubusercontent.com/assets/3194349/19306993/2cac4e9a-9070-11e6-942b-e2bd5eb168c9.png)
After Change (bottom of graph is 11mb, top is 33mb)
![screen shot 2016-10-12 at 11 35 41](https://cloud.githubusercontent.com/assets/3194349/19306994/2cb2b758-9070-11e6-8d16-21217614b9bc.png)

Before the change, the memory use increased rapidly at a constant rate until the browser tab crashed.
After the change, the memory usage stays consistently low and does not crash the browser tab.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
