### PR TITLE
Remove node 0.12 and add node 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: node_js
 node_js:
+- '7'
 - '6'
 - '5'
 - '4'
-- '0.12'
-- '0.11'
 script: npm test && npm run combine-coverage && npm run upload-coverage
 deploy:
   provider: npm


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above in the following format -->
<!--- #404: resolved issue with data table -->

## Description
Add node 7 to the list of supported platforms, and remove node 0.11/0.12

## Motivation and Context
https://github.com/nodejs/LTS

We no longer need to support the 0.x versions of node as they are about to drop out of maintenance

## How Has This Been Tested?
Travis will test that node 7 works (since it has just been released, the chances of it working are low)

## Checklist:
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document.
- [x] All my changes are covered by tests.
- [x] This request is ready to merge

