### PR TITLE
Add an api method to Selection

### DIFF
--- a/modules/component/main/index.coffee
+++ b/modules/component/main/index.coffee
@@ -36,3 +36,16 @@ if hx.Selection
       if @nodes[0] then hx.components(@nodes[0])
     else
       @nodes.map(hx.components)
+
+  hx.Selection::api = (api) ->
+    if arguments.length > 0
+      if @singleSelection
+        hx.component.register(@nodes[0], api)
+      else
+        hx.consoleWarning('Selection::api', 'You cannot set an api for a multi-selection')
+      this
+    else
+      if @singleSelection
+        if @nodes[0] then hx.component(@nodes[0])
+      else
+        @nodes.map(hx.component)

--- a/modules/component/test/spec.coffee
+++ b/modules/component/test/spec.coffee
@@ -1,1 +1,31 @@
 describe 'hx-component', ->
+  describe 'Selection::api', ->
+    it 'should return undefined when no api is registered', ->
+      should.not.exist(hx.detached('div').api())
+
+    it 'should get and set an api object on a component', ->
+      api = {}
+      selection = hx.detached('div')
+      selection.api(api).should.equal(selection)
+      selection.api().should.equal(api)
+
+    it 'should not register an api object on a multi selection', ->
+      api = {}
+      selection = hx.detached('div')
+        .add('div')
+        .add('div')
+        .add('div')
+        .selectAll('div')
+      selection.api(api).should.equal(selection)
+      selection.api().should.eql([undefined, undefined, undefined])
+
+    it 'should return all apis from a multi-selection', ->
+      api1 = {}
+      api2 = {}
+      api3 = {}
+      selection = hx.detached('div')
+        .add(hx.detached('div').api(api1))
+        .add(hx.detached('div').api(api2))
+        .add(hx.detached('div').api(api3))
+        .selectAll('div')
+      selection.api().should.eql([api1, api2, api3])


### PR DESCRIPTION
Adds an api method to Selection for setting/getting components (in a nicer way that hx.component.register)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document.
- [x] All my changes are covered by tests.
- [x] This request is ready to merge

