### PR TITLE
#370: Resolves y bounds calculation

### DIFF
--- a/modules/plot/main/coffee/Axis.coffee
+++ b/modules/plot/main/coffee/Axis.coffee
@@ -323,7 +323,7 @@ class Axis
       ymin = undefined
       ymax = undefined
 
-      { ymin, ymax } = calculateYBounds(@series(), @yScale.domainMin, @x.scaleType)
+      { ymin, ymax } = @calculateYBounds()
 
 
       ymin = if @y.min() is 'auto' then ymin else @y.min()
@@ -522,6 +522,73 @@ class Axis
             xStack += xs
       xStack
     else Math.max(start, 0)
-  getYStack: (type, group, x, seriesId, start = 0) ->
-    getYStack(type, group, x, seriesId, start, @yScale.domainMin, @series(), @x.scaleType)
 
+  getYStack: (type, group, x, seriesId, start = 0) ->
+    allSeries = @series()
+    xscaletype = @x.scaleType()
+    yscaledomainmin = @yScale.domainMin
+
+    if group
+      yStack = Math.max(yscaledomainmin, 0)
+      maybeys = allSeries.map (series) ->
+        if series._.seriesId < seriesId and series.group() == group and series._.type == type
+          series.getY(x, xscaletype is 'discrete')
+      yStack + hx.sum maybeys.filter hx.identity
+    else
+      Math.max(start, 0)
+
+  calculateYBounds: ->
+    allSeries = @series()
+    xscaletype = @x.scaleType()
+    yscaledomainmin = @yScale.domainMin
+
+    initValue = { ymin: 0, ymax: 0 }
+    types = hx.groupBy(allSeries, (d) -> d._.type)
+    stackGroups = types.map ([type, series]) ->
+      type: type
+      group: hx.groupBy series, (s) -> if supportsGroup(s) then s.group() else undefined
+  
+  
+    typeGroupReductor = ({ ymin, ymax }, [seriesGroup, series]) =>
+      { yymin, yymax } = if seriesGroup == undefined
+        maybeys = allSeries.map (s) ->
+          data = s.data()
+          if s instanceof StraightLineSeries
+            if not data.dx and not data.dy and data.y
+              [data.y, data.y]
+            else
+              undefined
+          else if s instanceof BandSeries
+            extent2(data, ((d) -> d.y1), (d) -> d.y2)
+          else
+            extent(data, (d) -> d.y)
+        ys = maybeys.filter((d) -> d?)
+  
+        yymin = hx.min(ys.map((d) -> d[0]))
+        yymax = hx.max(ys.map((d) -> d[1]))
+      else
+        topSeries = series[series.length-1]
+        if ymin == undefined
+          ymin = 0
+        else
+          ymin = Math.min(ymin, 0)
+        if ymax == undefined
+          ymax = 0
+        else
+          ymax = Math.max(ymax, 0)
+        stackHeights = topSeries.data().map (d) =>
+          console.log topSeries._
+          @getYStack(topSeries._.type, topSeries.group(), d.x, topSeries._.seriesId+1, yscaledomainmin)
+        console.log stackHeights
+        {
+          yymin: hx.min stackHeights
+          yymax: hx.max stackHeights
+        }
+      {
+        ymin: if (ymin == undefined or yymin < ymin) then yymin else ymin
+        ymax: if (ymax == undefined or yymax > ymax) then yymax else ymax
+      }
+  
+    stackGroupReductor = (prev, type) ->
+      type.group.reduce typeGroupReductor, prev
+    stackGroups.reduce stackGroupReductor, initValue

--- a/modules/plot/main/coffee/Axis.coffee
+++ b/modules/plot/main/coffee/Axis.coffee
@@ -570,15 +570,16 @@ class Axis
         }
       else
         topSeries = series[series.length-1]
-        stackHeights = topSeries.data().map (d) ->
-          @getYStack(topSeries._.type, topSeries.group(), d.x, topSeries._.seriesId+1, yscaledomainmin)
+        allX = hx.unique hx.flatten series.map (s) -> s.data().map ({ x }) -> x
+        stackHeights = allX.map (x) =>
+          @getYStack(topSeries._.type, topSeries.group(), x, topSeries._.seriesId+1, yscaledomainmin)
         {
           yymin: hx.min stackHeights
           yymax: hx.max stackHeights
         }
       {
         ymin: Math.min(ymin, yymin)
-        ymax: Math.max(yMax, yymax)
+        ymax: Math.max(ymax, yymax)
       }
   
     stackGroupReductor = (prev, type) ->

--- a/modules/plot/main/coffee/Axis.coffee
+++ b/modules/plot/main/coffee/Axis.coffee
@@ -317,21 +317,20 @@ class Axis
       @yScale.domain(domain)
     else
 
-      # OPTIM: this expensive calculation is not needed if the scales are non auto
-      # XXX: band series?
-
-      ymin = undefined
-      ymax = undefined
-
-      { ymin, ymax } = @calculateYBounds()
+      { yMinMightBeAuto, yMaxMightBeAuto } = { yMaxMightBeAuto: @y.max(), yMinMightBeAuto: @y.min() }
+      { ymin, ymax } = if 'auto' in [yMaxMightBeAuto, yMinMightBeAuto]
+        { ymin, ymax } = @calculateYBounds()
+        yminscaled = if yMinMightBeAuto is 'auto' then scalePad(ymin, ymax - ymin, -@y.scalePaddingMin()) else yMinMightBeAuto
+        ymaxscaled = if yMaxMightBeAuto is 'auto' then scalePad(ymax, ymax - ymin, @y.scalePaddingMax()) else yMaxMightBeAuto
+        { ymin: yminscaled, ymax: ymaxscaled }
+      else
+        { ymin: yMinMightBeAuto, ymax: yMaxMightBeAuto }
 
 
       ymin = if @y.min() is 'auto' then ymin else @y.min()
       ymax = if @y.max() is 'auto' then ymax else @y.max()
 
 
-      if @y.min() is 'auto' then ymin = scalePad(ymin, ymax - ymin, -@y.scalePaddingMin())
-      if @y.max() is 'auto' then ymax = scalePad(ymax, ymax - ymin, @y.scalePaddingMax())
 
       @yScale.domain(ymin, ymax)
 
@@ -538,6 +537,8 @@ class Axis
       Math.max(start, 0)
 
   calculateYBounds: ->
+    # The series must already be tagged before calling this method
+    # XXX: band series?
     allSeries = @series()
     xscaletype = @x.scaleType()
     yscaledomainmin = @yScale.domainMin

--- a/modules/plot/main/coffee/Axis.coffee
+++ b/modules/plot/main/coffee/Axis.coffee
@@ -558,8 +558,8 @@ class Axis
       group: hx.groupBy series, (s) -> if supportsGroup(s) then s.group() else undefined
   
   
-    typeGroupReductor = (type) =>
-      ({ ymin, ymax }, [seriesGroup, series]) =>
+    typeGroupReductor = (type) ->
+      ({ ymin, ymax }, [seriesGroup, series]) ->
         { yymin, yymax } = if seriesGroup == undefined
           maybeys = allSeries.map (s) ->
             data = s.data()
@@ -579,10 +579,10 @@ class Axis
             yymax: hx.max(ys.map((d) -> d[1]))
           }
         else
-          seriesId = series[series.length-1]._.seriesId + 1
           allX = hx.unique hx.flatten series.map (s) -> s.data().map ({ x }) -> x
-          stackHeights = allX.map (x) =>
-            @getYStack type, seriesGroup, x, seriesId, yscaledomainmin
+          stackHeights = allX.map (x) ->
+            maybeys = series.map (series) -> series.getY x, xscaletype is 'discrete'
+            hx.sum maybeys.filter hx.identity
           {
             yymin: hx.min stackHeights
             yymax: hx.max stackHeights

--- a/modules/plot/main/coffee/Axis.coffee
+++ b/modules/plot/main/coffee/Axis.coffee
@@ -532,14 +532,14 @@ class Axis
 
   getYStack: (type, group, x, seriesId, start = 0) ->
     allSeries = @series()
-    xscaletype = @x.scaleType()
-    yscaledomainmin = @yScale.domainMin
+    xScaleType = @x.scaleType()
+    yScaleDomainMin = @yScale.domainMin
 
     if group
-      yStack = Math.max(yscaledomainmin, 0)
+      yStack = Math.max(yScaleDomainMin, 0)
       maybeys = allSeries.map (series) ->
         if series._.seriesId < seriesId and series.group() == group and series._.type == type
-          series.getY(x, xscaletype is 'discrete')
+          series.getY(x, xScaleType is 'discrete')
       yStack + hx.sum maybeys.filter hx.identity
     else
       Math.max(start, 0)
@@ -548,8 +548,7 @@ class Axis
     # The series must already be tagged before calling this method
     # XXX: band series?
     allSeries = @series()
-    xscaletype = @x.scaleType()
-    yscaledomainmin = @yScale.domainMin
+    xScaleType = @x.scaleType()
 
     initValue = { ymin: 0, ymax: 0 }
     types = hx.groupBy(allSeries, (d) -> d._.type)
@@ -581,7 +580,7 @@ class Axis
         else
           allX = hx.unique hx.flatten series.map (s) -> s.data().map ({ x }) -> x
           stackHeights = allX.map (x) ->
-            maybeys = series.map (series) -> series.getY x, xscaletype is 'discrete'
+            maybeys = series.map (series) -> series.getY x, xScaleType is 'discrete'
             hx.sum maybeys.filter hx.identity
           {
             yymin: hx.min stackHeights

--- a/modules/plot/main/coffee/Axis.coffee
+++ b/modules/plot/main/coffee/Axis.coffee
@@ -564,29 +564,21 @@ class Axis
             extent(data, (d) -> d.y)
         ys = maybeys.filter((d) -> d?)
   
-        yymin = hx.min(ys.map((d) -> d[0]))
-        yymax = hx.max(ys.map((d) -> d[1]))
+        {
+          yymin: hx.min(ys.map((d) -> d[0]))
+          yymax: hx.max(ys.map((d) -> d[1]))
+        }
       else
         topSeries = series[series.length-1]
-        if ymin == undefined
-          ymin = 0
-        else
-          ymin = Math.min(ymin, 0)
-        if ymax == undefined
-          ymax = 0
-        else
-          ymax = Math.max(ymax, 0)
-        stackHeights = topSeries.data().map (d) =>
-          console.log topSeries._
+        stackHeights = topSeries.data().map (d) ->
           @getYStack(topSeries._.type, topSeries.group(), d.x, topSeries._.seriesId+1, yscaledomainmin)
-        console.log stackHeights
         {
           yymin: hx.min stackHeights
           yymax: hx.max stackHeights
         }
       {
-        ymin: if (ymin == undefined or yymin < ymin) then yymin else ymin
-        ymax: if (ymax == undefined or yymax > ymax) then yymax else ymax
+        ymin: Math.min(ymin, yymin)
+        ymax: Math.max(yMax, yymax)
       }
   
     stackGroupReductor = (prev, type) ->

--- a/modules/plot/main/coffee/Axis.coffee
+++ b/modules/plot/main/coffee/Axis.coffee
@@ -545,7 +545,6 @@ class Axis
       Math.max(start, 0)
 
   calculateYBounds: ->
-    # The series must already be tagged before calling this method
     # XXX: band series?
     allSeries = @series()
     xScaleType = @x.scaleType()

--- a/modules/plot/main/coffee/Utils.coffee
+++ b/modules/plot/main/coffee/Utils.coffee
@@ -1,3 +1,67 @@
+supportsGroup = (series) ->
+  series instanceof BarSeries or
+  series instanceof LineSeries
+
+getYStack = (type, group, x, seriesId, start, yscaledomainmin, allSeries, xscaletype) ->
+  if group
+    yStack = Math.max(yscaledomainmin, 0)
+    maybeys = allSeries.map (series) ->
+      if series._.seriesId < seriesId and series.group() == group and series._.type == type
+        series.getY(x, xscaletype is 'discrete')
+    yStack + hx.sum maybeys.filter hx.identity
+  else
+    Math.max(start, 0)
+
+calculateYBounds = (allSeries, yscaledomainmin, xscaletype) ->
+  initValue = { ymin: 0, ymax: 0 }
+  types = hx.groupBy(allSeries, (d) -> d._.type)
+  stackGroups = types.map ([type, series]) ->
+    type: type
+    group: hx.groupBy series, (s) -> if supportsGroup(s) then s.group() else undefined
+
+
+  typeGroupReductor = ({ ymin, ymax }, [seriesGroup, series]) ->
+    { yymin, yymax } = if seriesGroup == undefined
+      maybeys = allSeries.map (s) ->
+        data = s.data()
+        if s instanceof StraightLineSeries
+          if not data.dx and not data.dy and data.y
+            [data.y, data.y]
+          else
+            undefined
+        else if s instanceof BandSeries
+          extent2(data, ((d) -> d.y1), (d) -> d.y2)
+        else
+          extent(data, (d) -> d.y)
+      ys = maybeys.filter((d) -> d?)
+
+      yymin = hx.min(ys.map((d) -> d[0]))
+      yymax = hx.max(ys.map((d) -> d[1]))
+    else
+      topSeries = series[series.length-1]
+      if ymin == undefined
+        ymin = 0
+      else
+        ymin = Math.min(ymin, 0)
+      if ymax == undefined
+        ymax = 0
+      else
+        ymax = Math.max(ymax, 0)
+      stackHeights = topSeries.data().map (d) ->
+        getYStack(topSeries._.type, topSeries.group(), d.x, topSeries._.seriesId+1, yscaledomainmin, yscaledomainmin, allSeries, xscaletype)
+      {
+        yymin: hx.min stackHeights
+        yymax: hx.max stackHeights
+      }
+    {
+      ymin: if (ymin == undefined or yymin < ymin) then yymin else ymin
+      ymax: if (ymax == undefined or yymax > ymax) then yymax else ymax
+    }
+
+  stackGroupReductor = (prev, type) ->
+    type.group.reduce typeGroupReductor, prev
+  stackGroups.reduce stackGroupReductor, initValue
+
 
 # encodes the data into an svg path string
 svgCurve = (data, close) ->

--- a/modules/plot/test/spec.coffee
+++ b/modules/plot/test/spec.coffee
@@ -10,6 +10,12 @@ describe "plot", ->
       array2 = [{x: 1, y1: 4, y2: 3}, {x: 2, y1: 3, y2: 4}, {x: 3, y1: 5, y2: 5}]
       array3 = [{x: 1, y: 2}, {x: 2, y: 3}, {x: 3, y: 4}, {x: 4, y: 2}]
 
+      it 'calculateYBounds: should not ignore non-auto parameters', ->
+        axis = new hx.Axis()
+        axis.calculateYBounds('auto', 'auto').should.eql { ymin: 0, ymax: 0 }
+        axis.calculateYBounds(1, 1).should.eql { ymin: 1, ymax: 1 }
+        axis.calculateYBounds(-1, 'auto').should.eql { ymin: -1, ymax: 0 }
+
       it 'calculateYBounds: should correctly calculate y bounds when the data is sparse and the graph is stacked', ->
         axis = new hx.Axis({
           x: {
@@ -50,7 +56,7 @@ describe "plot", ->
   		})
 
         axis.tagSeries()
-        { ymax } = axis.calculateYBounds()
+        { ymax } = axis.calculateYBounds('auto', 'auto')
         ymax.should.eql(10)
 
       it 'doCollisionDetection: should hide text that gets in the way of other text', ->

--- a/modules/plot/test/spec.coffee
+++ b/modules/plot/test/spec.coffee
@@ -10,6 +10,48 @@ describe "plot", ->
       array2 = [{x: 1, y1: 4, y2: 3}, {x: 2, y1: 3, y2: 4}, {x: 3, y1: 5, y2: 5}]
       array3 = [{x: 1, y: 2}, {x: 2, y: 3}, {x: 3, y: 4}, {x: 4, y: 2}]
 
+      it 'calculateYBounds: should correctly calculate y bounds when the data is sparse and the graph is stacked', ->
+        axis = new hx.Axis({
+          x: {
+            scaleType: 'discrete'
+          },
+          y: {
+            min: 0
+          },
+          series: [
+            {
+              type: 'bar',
+              options: {
+                title: 'Bob',
+                group: 'g0',
+                fillColor: hx.theme.plot.coldCol,
+                data: [{
+                  x: 'verybig',
+                  y: 10
+                }, {
+                  x: 'alwayspresesnt',
+                  y: 1
+                }]
+              }
+            },
+            {
+              type: 'bar',
+              options: {
+                title: 'Lazlo',
+                fillColor: hx.theme.plot.warmCol,
+                group: 'g0',
+                data: [{
+                  x: 'alwayspresesnt',
+                  y: 2
+                }]
+              }
+            }
+          ]
+  		})
+
+        axis.tagSeries()
+        { ymax } = axis.calculateYBounds()
+        ymax.should.eql(10)
       it 'dataAverage: should return the average data point in an array', ->
         s.dataAverage(array).should.eql({x: 2, y: 3})
         s.dataAverage(array2).should.eql({x: 2, y1: 4, y2: 4})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above in the following format -->
<!--- #404: resolved issue with data table -->

## Description
Y bounds calculation pulled out into its own method

Refactored to make it easier to follow (use Array::map, Array::reduce etc rather than coffeescript for loops)

Y bounds calculation not called when overridden by user manual config

Rather than using topseries, all the x values are got out of all the series

## Motivation and Context
Resolves #370 

## How Has This Been Tested?
Regression test added.
Tested visually with same example as in issue

## Screenshots (if appropriate):
Screenshot for example in issue:

![screenshot from 2017-01-11 14-01-50](https://cloud.githubusercontent.com/assets/7927477/21851338/8ce35762-d806-11e6-875f-c71823c99811.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [X] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly. (This includes updating the changelog).
- [X] I have read the **CONTRIBUTING** document.
- [X] All my changes are covered by tests.
- [ ] This request is ready to merge
