### PR TITLE
#376 stopped hx.select from warning on selecting a Selection

### DIFF
--- a/modules/selection/main/index.coffee
+++ b/modules/selection/main/index.coffee
@@ -486,11 +486,6 @@ select = (selector, isArray) ->
 # expose
 hx.select = (selector) ->
   if selector instanceof Selection
-    hx.consoleWarning(
-      'hx.select was passed a selection',
-      'Calling hx.select on a selection returns the same selection',
-      selector
-    )
     selector
   else if not ((selector instanceof HTMLElement) or (selector instanceof SVGElement) or hx.isString(selector) or selector is document or selector is window)
     hx.consoleWarning(

--- a/modules/selection/test/spec.coffee
+++ b/modules/selection/test/spec.coffee
@@ -133,6 +133,12 @@ describe 'Selection Api', ->
     selection.class().should.equal('first one')
     selection.node().tagName.toLowerCase().should.equal('span')
 
+  it 'hx.select a selection as no-op', ->
+    selection = hx.select('#fixture')
+    selection2 = hx.select(selection)
+    selection2.should.equal(selection)
+    hx.consoleWarning.should.not.have.been.called()
+
   it 'hx.selectAll elements by id', ->
     selection = hx.select('#fixture').selectAll('#outer-1')
     selection.size().should.equal(1)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above in the following format -->
<!--- #404: resolved issue with data table -->

## Description
<!--- Describe your changes in detail -->
Removed hx.consoleWarning
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Resolves #404) -->
hexagon should not warn about being passed in a Selection instead of a node/string to, say, an hx.Graph
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
checked that hx.select(Selection) returns the given selection and no warning is printed
## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document.
- [x] All my changes are covered by tests.
- [x] This request is ready to merge
