### PR TITLE
386: Fix caret issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.orig
 *.sublime-project
 *.sublime-workspace
 *.swp

--- a/modules/data-table/main/index.coffee
+++ b/modules/data-table/main/index.coffee
@@ -621,9 +621,12 @@ class DataTable extends hx.EventEmitter
 
     advancedSearchVisibleAndEnabled = (not options.filterEnabled or options.showAdvancedSearch) and options.advancedSearchEnabled
 
-    selection.select('.hx-data-table-filter')
+    filterSel = selection.select('.hx-data-table-filter')
       .classed('hx-data-table-filter-visible', options.filterEnabled and not advancedSearchVisibleAndEnabled)
-      .value(@filter())
+    nextFilterValue = @filter()
+    prevFilterValue = filterSel.value()
+    if nextFilterValue isnt prevFilterValue
+      filterSel.value(nextFilterValue)
 
     @_.advancedSearchToggleButton.value(options.advancedSearchEnabled)
 

--- a/modules/data-table/test/spec.coffee
+++ b/modules/data-table/test/spec.coffee
@@ -314,6 +314,7 @@ describe 'data-table', ->
           container.select('.hx-data-table-filter').size().should.equal(1)
           container.select('.hx-data-table-filter').classed('hx-data-table-filter-visible').should.equal(true)
 
+
         it 'should not show collapsible expand icons', ->
           container.select('.hx-sticky-table-header-left').selectAll('.hx-data-table-collapsible-toggle').size().should.equal(0)
 
@@ -558,6 +559,25 @@ describe 'data-table', ->
           testTable {tableOptions: {filterEnabled: false}}, done, (container, dt, options, data) ->
             container.select('.hx-data-table-filter').size().should.equal(1)
             container.select('.hx-data-table-filter').classed('hx-data-table-filter-visible').should.equal(false)
+
+
+    describe 'filter', ->
+      it 'should do the filter table with the right position', (done) ->
+        testTable {tableOptions: {filterEnabled: true, filter: 'Bob'}}, (-> undefined), (container, dt, options, data) ->
+          # Sense checks
+          container.select('.hx-data-table-filter').value().should.equal('Bob')
+          container.select('.hx-data-table-filter').node().selectionStart.should.equal(3)
+
+          # Given
+          container.select('.hx-data-table-filter').node().selectionStart = 1
+          container.select('.hx-data-table-filter').node().selectionStart.should.equal(1)
+
+          # when
+          container.component().render ->
+            # then
+            container.select('.hx-data-table-filter').node().selectionStart.should.equal(1)
+            done()
+
 
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above in the following format -->
#386: resolved issue with data table caret

## Description
The problem is that when editing the filter, we rerender the table, which sets the filter input value. This change only sets the filter input value if that would cause the behavior to change

## Motivation and Context
To avoid confusing the user. Resolves #386
 
## How Has This Been Tested?
Visually and with regression test

## Screenshots (if appropriate):
This cannot be demoed without a video

## Checklist:
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document.
- [x] All my changes are covered by tests.
- [x] This request is ready to merge
