### PR TITLE
TitleBar: add a minimal fluid api

### DIFF
--- a/modules/titlebar/main/index.coffee
+++ b/modules/titlebar/main/index.coffee
@@ -75,5 +75,32 @@ class TitleBar
 
 hx.TitleBar = TitleBar
 
+hx.titleBar = (options = {}) ->
+  {
+    title = 'Title',
+    subtitle = '',
+    showIcon = true,
+    iconLink = '#',
+    iconClass = 'hx-logo'
+  } = options
+
+  icon = if showIcon
+    hx.detached('a')
+      .class('hx-titlebar-icon')
+      .attr('href', iconLink)
+      .add(hx.detached('img').class(iconClass))
+
+  selection = hx.div('hx-heading')
+    .add(hx.div('hx-titlebar')
+      .add(hx.div('hx-titlebar-container')
+        .add(hx.div('hx-titlebar-header')
+          .add(icon)
+          .add(if title then hx.div('hx-titlebar-title').text(title))
+          .add(if subtitle then hx.div('hx-titlebar-subtitle').text(subtitle)))))
+
+  new hx.TitleBar(selection)
+
+  return selection
+
 # set up the titlebar
 if hx.select('.hx-heading').size() > 0 then hx.titlebar = new hx.TitleBar('.hx-heading')

--- a/modules/titlebar/module.json
+++ b/modules/titlebar/module.json
@@ -3,7 +3,8 @@
     "component",
     "selection",
     "animate",
-    "morphs"
+    "morphs",
+    "fluid"
   ],
   "keywords": [
     "titlebar"

--- a/modules/titlebar/test/spec.coffee
+++ b/modules/titlebar/test/spec.coffee
@@ -79,3 +79,33 @@ describe 'hx-titlebar', ->
     hx.selectAll('.hx-titlebar-link').classed('hx-selected').should.eql([true, false, false, false, false])
     titlebar.active(undefined)
     hx.selectAll('.hx-titlebar-link').classed('hx-selected').should.eql([false, false, false, false, false])
+
+  describe 'fluid', ->
+    it 'should create a fluid titlebar', ->
+      titlebar = hx.titleBar()
+      titlebar.api().should.be.an.instanceOf(hx.TitleBar)
+      titlebar.classed('hx-heading').should.equal(true)
+
+    it 'should be able to set the title', ->
+      titlebar = hx.titleBar({title: 'My Title'})
+      titlebar.select('.hx-titlebar-title').text().should.equal('My Title')
+
+    it 'should be able to set the subtitle', ->
+      titlebar = hx.titleBar({subtitle: 'My Subtitle'})
+      titlebar.select('.hx-titlebar-subtitle').text().should.equal('My Subtitle')
+
+    it 'should show icon by default', ->
+      titlebar = hx.titleBar()
+      titlebar.select('.hx-titlebar-icon').empty().should.equal(false)
+
+    it 'should not add the icon when showIcon is false', ->
+      titlebar = hx.titleBar({showIcon: false})
+      titlebar.select('.hx-titlebar-icon').empty().should.equal(true)
+
+    it 'should be able to set the icon link', ->
+      titlebar = hx.titleBar({iconLink: '/home'})
+      titlebar.select('.hx-titlebar-icon').attr('href').should.equal('/home')
+
+    it 'should be able to set the icon link', ->
+      titlebar = hx.titleBar({iconClass: 'my-icon-class'})
+      titlebar.select('.hx-titlebar-icon').select('img').classed('my-icon-class').should.equal(true)


### PR DESCRIPTION
## Description
Add a simple fluid api that covers construction of a basic titlebar - it can be extended to include menu icons and linkbar links in the future?

Partially resolves #399 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document.
- [x] All my changes are covered by tests.
- [x] This request is ready to review and merge
