### PR TITLE
Selection: Add a method for setting the children

### DIFF
--- a/modules/selection/main/index.coffee
+++ b/modules/selection/main/index.coffee
@@ -270,6 +270,9 @@ class Selection
         removeChild.call(node, node.firstChild)
     this
 
+  # cleas the contents of a node and then adds the children passed in
+  set: (children) -> this.clear().add(children)
+
   # gets the nth node in the selection, defaulting to the first
   node: (i=0) -> @nodes[i]
 

--- a/modules/selection/main/index.coffee
+++ b/modules/selection/main/index.coffee
@@ -270,7 +270,7 @@ class Selection
         removeChild.call(node, node.firstChild)
     this
 
-  # cleas the contents of a node and then adds the children passed in
+  # clears the contents of a node and then adds the children passed in
   set: (children) -> this.clear().add(children)
 
   # gets the nth node in the selection, defaulting to the first

--- a/modules/selection/test/spec.coffee
+++ b/modules/selection/test/spec.coffee
@@ -614,6 +614,22 @@ describe 'Selection Api', ->
     selection = hx.select('#fixture')
     selection.clear().should.equal(selection)
 
+  it 'set works', ->
+    children = [
+      hx.detached('div'),
+      hx.detached('div'),
+      hx.detached('div')
+    ]
+
+    parent = hx.detached('div')
+      .add(hx.detached('span'))
+      .add(hx.detached('span'))
+      .add(hx.detached('span'))
+
+    parent.set(children).should.equal(parent)
+    parent.selectAll('span').size().should.equal(0)
+    parent.selectAll('div').size().should.equal(3)
+
   # getting / setting properties
 
   it 'get a property from a single selection', ->


### PR DESCRIPTION
## Description

Adds a new method means you can do

```
hx.select('#container')
  .set([
    hx.detached('div'),
    hx.detached('div'),
    hx.detached('div')  
  ])
```

in place of

```
hx.select('#container')
  .clear()
  .add([
    hx.detached('div'),
    hx.detached('div'),
    hx.detached('div')
  ]) 
```

## Motivation and Context
A `clear` followed by an `add` is a fairly common pattern, so having a method that does both in one go makes things a bit more concise.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document.
- [x] All my changes are covered by tests.
- [x] This request is ready to review and merge
