### PR TITLE
401 data table advanced filter criteria

### DIFF
--- a/modules/data-table/main/index.coffee
+++ b/modules/data-table/main/index.coffee
@@ -289,7 +289,6 @@ class DataTable extends hx.EventEmitter
       showSearchAboveTable: false
       filter: undefined
       filterEnabled: true
-      filterCriteria: 'contains'
       showAdvancedSearch: false
       advancedSearchEnabled: false
       advancedSearchCriteria: undefined
@@ -1195,9 +1194,9 @@ objectFeed = (data, options) ->
         filterCacheTerm = range.advancedSearch
         sorted = undefined
       else
-        filterFn = (row) -> options.filter(range.filter, row, range.filterCriteria)
+        filterFn = (row) -> options.filter(range.filter, row)
         filterCache = getFiltered(data.rows, range.filter, filterCache, filterCacheTerm, filterFn)
-        filterCacheTerm = range.filter + (range.filterCriteria or '')
+        filterCacheTerm = range.filter
         sorted = undefined
 
       if sorted is undefined or sortCacheTerm.column isnt range.sort?.column or sortCacheTerm.direction isnt range.sort?.direction

--- a/modules/data-table/main/index.coffee
+++ b/modules/data-table/main/index.coffee
@@ -35,7 +35,7 @@ columnOptionLookup = (options, name, id) ->
     options[name]
 
 toCriteriaItems = (list) ->
-  new hx.Set(list).values().map (item) ->
+  hx.unique(list).map (item) ->
     {
       value: item,
       text: hx.userFacingText('dataTable', item)

--- a/modules/data-table/main/index.coffee
+++ b/modules/data-table/main/index.coffee
@@ -144,8 +144,8 @@ createAdvancedSearchView = (selection, dataTable, options) ->
             [leftFilters, filter, rightFilters] = splitArray(filterGroup, trueIndex)
             newFilter = hx.merge(filter, {
               column: data.value.value
-              criteria: 'contains'
             })
+            delete newFilter.criteria
             columnCriteria = columnOptionLookup(options, 'advancedSearchCriteria', data.value.value) || []
             criteriaItems = ['contains', columnCriteria...]
             criteriaPickerSel.component()
@@ -1156,16 +1156,16 @@ defaultTermLookup = (term, rowSearchTerm, criteria = 'contains') ->
   lookupArr = if hx.isString(rowSearchTerm) then [rowSearchTerm] else rowSearchTerm
   arr = term.replace(stripLeadingAndTrailingWhitespaceRegex,'')
     .split whitespaceSplitRegex
-  validPart = hx.find arr, (part) -> hx.filter[criteria](lookupArr, part).length
+  validPart = hx.find arr, (part) -> hx.filter[criteria](lookupArr, part.toLowerCase()).length
   hx.defined validPart
 
 getAdvancedSearchFilter = (cellValueLookup = hx.identity, termLookup = defaultTermLookup) ->
   (filters, row) ->
-    rowSearchTerms = (v for k, v of row.cells).map(cellValueLookup)
+    rowSearchTerm = (v for k, v of row.cells).map(cellValueLookup).join(' ').toLowerCase()
     # If term is empty this will return false
     validFilters = hx.find filters, (groupedFilters) ->
       invalidFilter = hx.find groupedFilters, (filter) ->
-        searchTerm = if filter.column is 'any' then rowSearchTerms else (cellValueLookup(row.cells[filter.column]) + '').toLowerCase()
+        searchTerm = if filter.column is 'any' then rowSearchTerm else (cellValueLookup(row.cells[filter.column]) + '').toLowerCase()
         filter.term and not termLookup(filter.term.toLowerCase(), searchTerm, filter.criteria)
       not hx.defined invalidFilter
     hx.defined validFilters

--- a/modules/data-table/main/index.coffee
+++ b/modules/data-table/main/index.coffee
@@ -44,7 +44,7 @@ toCriteriaItems = (list) ->
 advancedSearchCriteriaValidate = (value) ->
   allowedTypes = hx.filter.types()
   if (hx.isArray(value) and value.every((c) -> ~allowedTypes.indexOf(c))) or value is undefined
-    value
+    value or []
   else if hx.isArray(value)
     invalidTypes = value.filter((c) -> not ~allowedTypes.indexOf(c))
     hx.consoleWarning('Invalid Filter Criteria Specified:', invalidTypes, '\nPlease select a value from hx.filter.stringTypes()', allowedTypes)

--- a/modules/data-table/main/index.coffee
+++ b/modules/data-table/main/index.coffee
@@ -170,6 +170,9 @@ createAdvancedSearchView = (selection, dataTable, options) ->
             })
             dataTable.advancedSearch([leftFilterGroups..., [leftFilters..., newFilter, rightFilters...], rightFilterGroups...])
 
+      criteriaAnyPlaceholder = hx.div('hx-data-table-advanced-search-criteria-placeholder hx-text-disabled hx-background-disabled')
+        .text(hx.userFacingText('dataTable', 'contains'))
+
       debouncedInput = hx.debounce 200, (e) ->
         prevFilters = dataTable.advancedSearch()
         [leftFilterGroups, filterGroup, rightFilterGroups] = splitArray(prevFilters, filterGroupIndex)
@@ -207,6 +210,7 @@ createAdvancedSearchView = (selection, dataTable, options) ->
       @append('div').class('hx-data-table-advanced-search-filter hx-section hx-input-group hx-input-group-full-width')
         .add(typePickerSel)
         .add(columnPickerSel)
+        .add(criteriaAnyPlaceholder)
         .add(criteriaPickerSel)
         .add(hx.div('hx-data-table-advanced-search-filter-input-container hx-input-group hx-no-pad hx-no-border')
           .add(termInput)
@@ -233,6 +237,8 @@ createAdvancedSearchView = (selection, dataTable, options) ->
       .items(toCriteriaItems(criteriaItems))
       .value(criteria || 'contains')
 
+    filterRowSel.select('.hx-data-table-advanced-search-criteria-placeholder')
+      .style('display', if criteriaItems.length is 1 then 'block' else 'none')
 
     filterRowSel.select('.hx-data-table-advanced-search-input')
       .value(term or '')

--- a/modules/data-table/main/index.scss
+++ b/modules/data-table/main/index.scss
@@ -148,6 +148,13 @@
     margin-right: 0.2em;
   }
 
+  .hx-data-table-advanced-search-container {
+    flex-grow: 100;
+    flex-shrink: 1;
+    max-width: 100%;
+    min-width: 320px;
+  }
+
   .hx-data-table-advanced-search-toggle,
   .hx-data-table-advanced-search-container {
     display: none;
@@ -176,34 +183,39 @@
 
   .hx-data-table-advanced-search:not(:empty) {
     margin: 0.2em;
-    max-width: 25em;
   }
 
   .hx-data-table-advanced-search-filter-group + .hx-data-table-advanced-search-filter-group {
-    margin-top: 8px;
+    margin-top: 0.75em;
   }
 
   .hx-data-table-advanced-search-filter {
-    margin: 2px 0 0 0;
+    margin: 0.25em 0 0 0;
+    flex-wrap: wrap;
+    max-width: 40em;
   }
 
   .hx-data-table-advanced-search-filter + .hx-data-table-advanced-search-filter {
-    margin-left: 8px;
+    margin-left: 0.5em;
+    max-width: 39.5em;
   }
 
   .hx-data-table-advanced-search-column,
-  .hx-data-table-advanced-search-type {
+  .hx-data-table-advanced-search-criteria,
+  .hx-data-table-advanced-search-type,
+  .hx-data-table-advanced-search-filter-input-container {
     flex-shrink: 0;
+    flex-grow: 1;
+    width: auto;
   }
+
+  .hx-data-table-advanced-search-filter-input-container {
+    flex-grow: 5;
+  }
+
 
   .hx-data-table-advanced-search-input {
     min-width: 3em;
-  }
-
-  .hx-data-table-advanced-search-filter {
-    > *:not(:last-child) {
-      border-right-style: none;
-    }
   }
 
   .hx-data-table-advanced-search-button {

--- a/modules/data-table/main/index.scss
+++ b/modules/data-table/main/index.scss
@@ -213,7 +213,6 @@
     flex-grow: 5;
   }
 
-
   .hx-data-table-advanced-search-input {
     min-width: 3em;
   }

--- a/modules/filter/main/index.coffee
+++ b/modules/filter/main/index.coffee
@@ -111,3 +111,29 @@ hx.filter =
     (item) ->
       match = item.match(term)
       if match? then match.index + match[0].length else -1
+
+hx.filter.stringTypes = () -> [
+  'contains',
+  'exact'
+  'excludes',
+  'startsWith'
+  'regex',
+  'fuzzy'
+]
+
+hx.filter.numberTypes = () -> [
+  'exact',
+  'greater',
+  'less'
+]
+
+hx.filter.types = () -> [
+  'contains',
+  'exact'
+  'greater',
+  'less',
+  'excludes',
+  'startsWith'
+  'regex',
+  'fuzzy'
+]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above in the following format -->
<!--- #404: resolved issue with data table -->

## Description
<!--- Describe your changes in detail -->
- Added `hx.filter.types`, `hx.filter.stringTypes` and `hx.filter.numberTypes` to expose the lists of filters for other modules to use
- Added the ability to use the `hx.filter` types when using the advancedSearch
- Changed the UI to make the advanced search flow better on smaller devices

#### API Changes
```js
hx.DataTable::advancedSearchCriteria([subset of hx.filter.types]) // Set global
hx.DataTable::advancedSearchCriteria(columnId, [subset of hx.filter.types]) // Set column
```
Added `criteria` argument to `termLookup` function (defaults to `contains` for the defaultTermLookup)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Resolves #404) -->
Resolves #401 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
TODO

## Screenshots (if appropriate):

#### Compact Flow Any Column
![Compact Flow Any Column](https://cloud.githubusercontent.com/assets/3194349/25744408/b441ba30-3191-11e7-8662-23c4921734bd.png)

#### Compact Flow Column
![Compact Flow Column](https://cloud.githubusercontent.com/assets/3194349/25744420/bca25414-3191-11e7-8a9f-6f8a87b6f082.png)

#### Full Table Any Column
![Full Table Any Column](https://cloud.githubusercontent.com/assets/3194349/25744422/bfa057a6-3191-11e7-9260-f780857cce04.png)

#### Full Table Column
![Full Table Column](https://cloud.githubusercontent.com/assets/3194349/25744426/c31f3aa0-3191-11e7-9059-9ef8480cd96e.png)

#### Full Table Flow Column
![Full Table Flow Column](https://cloud.githubusercontent.com/assets/3194349/25744427/c5738c5c-3191-11e7-89b4-2ed755b2ec6b.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document.
- [x] All my changes are covered by tests.
- [x] This request is ready to review and merge
