### PR TITLE
Prevent the heading getting squashed in mobile mode

### DIFF
--- a/modules/data-table/main/index.scss
+++ b/modules/data-table/main/index.scss
@@ -466,6 +466,7 @@
 
     .hx-data-table-control-panel-compact-visible {
       display: flex;
+      flex-shrink: 0;
     }
 
     .hx-data-table-control-panel-inner {


### PR DESCRIPTION
Prevent the headings from shrinking when in mobile mode

**Broken old behaviour**
![screen shot 2017-05-25 at 16 50 01](https://cloud.githubusercontent.com/assets/11637484/26458119/48ca0d82-416a-11e7-996d-b864f7455493.png)

**With this change** (the horizontal divider is in the right place)
![screen shot 2017-05-25 at 16 50 08](https://cloud.githubusercontent.com/assets/11637484/26458124/4a3d1646-416a-11e7-82de-19a7c3b76cb3.png)
