### PR TITLE
Allow setting the children of a Selection as a Promise

### DIFF
--- a/build/main/karma.js
+++ b/build/main/karma.js
@@ -135,7 +135,8 @@ function runKarma (files, destDir, phantomOnly) {
     jsonReporter: jsonReporter,
     singleRun: true,
     browsers: null,
-    frameworks: ['mocha', 'sinon', 'chai-spies', 'chai'],
+    frameworks: ['mocha', 'sinon', 'chai-spies', 'chai', 'polyfill'],
+    polyfill: ['Promise'],
     autoWatch: false,
     reporters: ['coverage', 'html', 'json', 'mocha'],
     client: {

--- a/modules/selection/main/index.coffee
+++ b/modules/selection/main/index.coffee
@@ -271,7 +271,15 @@ class Selection
     this
 
   # clears the contents of a node and then adds the children passed in
-  set: (children) -> this.clear().add(children)
+  set: (children) ->
+    # The use of Promise.resolve can delay when the replacement happens, so
+    # check to only do this when needed. This makes testing nicer when adding
+    # non-promise content
+    if children.then
+      Promise.resolve(children).then((sel) => this.clear().add(sel))
+    else
+      this.clear().add(children)
+    return this
 
   # gets the nth node in the selection, defaulting to the first
   node: (i=0) -> @nodes[i]

--- a/modules/selection/test/spec.coffee
+++ b/modules/selection/test/spec.coffee
@@ -630,6 +630,24 @@ describe 'Selection Api', ->
     parent.selectAll('span').size().should.equal(0)
     parent.selectAll('div').size().should.equal(3)
 
+  it 'set(Promise) works', () ->
+    children = Promise.resolve([
+      hx.detached('div'),
+      hx.detached('div'),
+      hx.detached('div')
+    ])
+
+    parent = hx.detached('div')
+      .add(hx.detached('span'))
+      .add(hx.detached('span'))
+      .add(hx.detached('span'))
+
+    parent.set(children).should.equal(parent)
+
+    return children.then () ->
+      parent.selectAll('span').size().should.equal(0)
+      parent.selectAll('div').size().should.equal(3)
+
   # getting / setting properties
 
   it 'get a property from a single selection', ->

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "karma-mocha-reporter": "^1.1.1",
     "karma-opera-launcher": "^0.3.0",
     "karma-phantomjs-launcher": "^0.2.1",
+    "karma-polyfill": "^1.0.0",
     "karma-safari-launcher": "^0.1.1",
     "karma-sinon": "^1.0.4",
     "mocha": "^2.3.3",


### PR DESCRIPTION
## Description
Allows feeding a `Promise` into `Selection::set`

## Motivation and Context
Makes it possible to do things like: 

    hx.select('body')
       .set(api.getDasboardData().then(dashboardComponent))

## How Has This Been Tested?
New unit tests added 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document.
- [x] All my changes are covered by tests.
- [x] This request is ready to review and merge
