### PR TITLE
WIP: Prevent divide by zero in pie chart calculation

### DIFF
--- a/modules/plot/main/coffee/Utils.coffee
+++ b/modules/plot/main/coffee/Utils.coffee
@@ -34,11 +34,14 @@ svgCurve = (data, close) ->
   else ''
 
 arcCurveMinimumRadius = (startRadians, endRadians, padding) ->
+  if padding is 0
+    return 0
+
   DELTA = 1e-4
   radians = endRadians - startRadians
   theta = if radians < Math.PI then radians / 2 else Math.PI - radians / 2
 
-  if Math.abs(theta) < DELTA
+  if Math.abs(Math.sin(theta)) < DELTA
     return 0
   else
     return padding / 2 / Math.sin(theta)

--- a/modules/plot/main/coffee/Utils.coffee
+++ b/modules/plot/main/coffee/Utils.coffee
@@ -34,10 +34,14 @@ svgCurve = (data, close) ->
   else ''
 
 arcCurveMinimumRadius = (startRadians, endRadians, padding) ->
+  DELTA = 1e-4
   radians = endRadians - startRadians
   theta = if radians < Math.PI then radians / 2 else Math.PI - radians / 2
 
-  padding / 2 / Math.sin(theta)
+  if Math.abs(theta) < DELTA
+    return 0
+  else
+    return padding / 2 / Math.sin(theta)
 
 arcCurve = (x, y, innerRadius, outerRadius, startRadians, endRadians, padding, dontCurveCenter) ->
 


### PR DESCRIPTION
## Description
Fixes a divide by zero issue which caused single segment pie charts not to be rendered

## How Has This Been Tested?
Tested against this example:

```
<!DOCTYPE html>
<html>
<head>
    <meta charset="UTF-8">
    <title>Test</title>
    <link rel="stylesheet" type="text/css" href="https://www.hexagonjs.io/resources/hexagon/1.12.0/hexagon.css"></link>
    <link rel="stylesheet" type="text/css" href="https://www.hexagonjs.io/resources/font-awesome/css/font-awesome.min.css"></link>
    <script type="text/javascript" src="https://www.hexagonjs.io/resources/hexagon/1.12.0/hexagon.js"></script>
</head>
<body >
    <div id="graph" style="width: 400px; height: 400px"></div>

    <script>
        var pieData = {
            title: 'n/a',
            segments: [
                {name: "Seen more than 1 day(s) ago", size: 28, fillColor: "rgb(177,119,190)"}
            ]
        };
        new hx.PieChart('#graph', {
            labelsEnabled: true,
            legendEnabled: true,
            data: pieData
        });
    </script>
</body>
</html>
```

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document.
- [ ] All my changes are covered by tests.
- [ ] This request is ready to review and merge
