### PR TITLE
Potential Fix: Fast click handling for links

### DIFF
--- a/modules/fast-click/main/index.coffee
+++ b/modules/fast-click/main/index.coffee
@@ -4,7 +4,8 @@ if hx.supports('touch')
     'INPUT',
     'TEXTAREA',
     'SELECT',
-    'LABEL'
+    'LABEL',
+    'A'
   ]
 
   setupFastClick = (node, eventEmitter) ->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above in the following format -->
<!--- #404: resolved issue with data table -->

## Description
<!--- Describe your changes in detail -->
The current fast click handling causes links to be disabled in tables
as iPad event bubbling happens in a different order from desktops /
other devices.

Adding `A` to the list of elements seems to resolve the issue, however
it may be that it was intentionally not added to the list of elements.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Resolves #404) -->
Related to: #418 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in Chrome iPad emulator (will test on iPad when available)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document.
- [ ] All my changes are covered by tests.
- [x] This request is ready to review and merge
