### PR TITLE
[Patch] Number Picker: introduced step property

### DIFF
--- a/modules/number-picker/main/index.coffee
+++ b/modules/number-picker/main/index.coffee
@@ -47,6 +47,7 @@ class NumberPicker extends hx.EventEmitter
       value: 0
       incrementOnHold: true
       incrementDelay: 50
+      step: undefined
     }, options)
 
     @_ = {}
@@ -71,6 +72,7 @@ class NumberPicker extends hx.EventEmitter
 
     if @options.max isnt undefined then @max @options.max
     if @options.min isnt undefined then @min @options.min
+    if @options.step isnt undefined then @step(@options.step)
     if @options.disabled then @disabled(@options.disabled)
     @value @options.value
 
@@ -124,7 +126,8 @@ class NumberPicker extends hx.EventEmitter
   increment: ->
     unless @options.disabled
       prevValue = @value()
-      @value(@value() + 1)
+      step = @options.step || 1
+      @value(@value() + step)
       if prevValue isnt @value()
         @emit 'increment'
     this
@@ -132,7 +135,8 @@ class NumberPicker extends hx.EventEmitter
   decrement: ->
     unless @options.disabled
       prevValue = @value()
-      @value(@value() - 1)
+      step = @options.step || 1
+      @value(@value() - step)
       if prevValue isnt @value()
         @emit 'decrement'
     this
@@ -146,6 +150,15 @@ class NumberPicker extends hx.EventEmitter
       this
     else
       @options.disabled
+
+  step: (val) ->
+    if val?
+      @options.step = val
+      @selectInput.attr('step', val)
+      @value(@value())
+      this
+    else
+      @options.step
 
 hx.numberPicker = (options) ->
   selection = hx.detached('div')

--- a/modules/number-picker/test/spec.coffee
+++ b/modules/number-picker/test/spec.coffee
@@ -39,6 +39,19 @@ describe 'number picker', ->
     np = new hx.NumberPicker(hx.detached('div').node())
     np.value(5).max(0).value().should.equal(0)
 
+  it 'should check the value when the max option is set', ->
+    np = new hx.NumberPicker(hx.detached('div').node())
+    np.value(5).max(0).value().should.equal(0)
+
+  it 'should have a default step of undefined', ->
+    np = new hx.NumberPicker(hx.detached('div').node())
+    should.not.exist(np.step())
+
+  it 'should set and get the step option properly', ->
+    np = new hx.NumberPicker(hx.detached('div').node(), { step: 5 })
+    np.step().should.equal(5)
+    np.step(3).step().should.equal(3)
+
   it 'should set and get the value properly', ->
     np = new hx.NumberPicker(hx.detached('div').node(), { value: 20 })
     np.value().should.equal(20)


### PR DESCRIPTION
## Description
Added step property to options that can be passed to new `NumberPicker` instances.
The value is saved in `@options` object and later applied during `@increment` and `@decrement` methods.

## Motivation and Context
Resolves #149.

## How Has This Been Tested?
I have tested it manually in my browsers (Chrome, FF, Opera) on MacOS.
I have also added new unit tests covering the changes.

## Checklist:
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document.
- [x] All my changes are covered by tests.
- [x] This request is ready to review and merge
