### PR TITLE
Update validateForm so that it doesn't check hidden elements

### DIFF
--- a/modules/form/main/index.coffee
+++ b/modules/form/main/index.coffee
@@ -37,27 +37,29 @@ validateForm = (form, options) ->
     if form.children[i].nodeName.toLowerCase() is 'div'
       element = form.children[i].children[1]
 
-      # Deal with standard label/input pairs
-      if element.nodeName.toLowerCase() is 'input' or element.nodeName.toLowerCase() is 'textarea'
-        if not element.checkValidity()
-          type = hx.select(element).attr('type')
-          errors.push {
-            message: getValidationMessage element.validationMessage, type
-            node: element
-            validity: element.validity
-            focused: focusedElement is element
-          }
-      else
-        # Deal with radio groups and other similar structured elements
-        input = hx.select(element).select('input').node()
-        type  = hx.select(element).select('input').attr('type')
-        if input and not input.checkValidity()
-          errors.push {
-            message: getValidationMessage input.validationMessage, type
-            node: element
-            validity: input.validity
-            focused: focusedElement is input
-          }
+      # Don't check the validity of hidden elements
+      if element.offsetParent isnt null
+        # Deal with standard label/input pairs
+        if element.nodeName.toLowerCase() is 'input' or element.nodeName.toLowerCase() is 'textarea'
+          if not element.checkValidity()
+            type = hx.select(element).attr('type')
+            errors.push {
+              message: getValidationMessage element.validationMessage, type
+              node: element
+              validity: element.validity
+              focused: focusedElement is element
+            }
+        else
+          # Deal with radio groups and other similar structured elements
+          input = hx.select(element).select('input').node()
+          type  = hx.select(element).select('input').attr('type')
+          if input and not input.checkValidity()
+            errors.push {
+              message: getValidationMessage input.validationMessage, type
+              node: element
+              validity: input.validity
+              focused: focusedElement is input
+            }
 
   if options.showMessage and errors.length > 0
     # Show the error for the focused element (if there is one) or the first error in the form


### PR DESCRIPTION
Used offsetParent as it seems quicker than selecting and detecting the
display property

https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent

Resolves #301 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document.
- [ ] All my changes are covered by tests.
- [x] This request is ready to review and merge