### PR TITLE
Update FormBuilder pickers validation when the value is unset

### DIFF
--- a/modules/form-builder/main/index.coffee
+++ b/modules/form-builder/main/index.coffee
@@ -113,10 +113,17 @@ class Form extends hx.EventEmitter
 
       picker.value(values[0]) unless typeof options.required is 'boolean'
 
-      if options.required
+      setValidity = () ->
         input.node().setCustomValidity(hx.userFacingText('form', 'pleaseSelectAValue'))
-        picker.on 'change', 'hx.form-builder', ->
-          input.node().setCustomValidity('')
+
+      if options.required
+        setValidity()
+        picker.on 'change', 'hx.form-builder', ({ value, cause }) ->
+          console.log(value, cause)
+          if value is undefined
+            setValidity()
+          else
+            input.node().setCustomValidity('')
 
       {
         required: options.required

--- a/modules/form-builder/main/index.coffee
+++ b/modules/form-builder/main/index.coffee
@@ -119,7 +119,6 @@ class Form extends hx.EventEmitter
       if options.required
         setValidity()
         picker.on 'change', 'hx.form-builder', ({ value, cause }) ->
-          console.log(value, cause)
           if value is undefined
             setValidity()
           else
@@ -151,10 +150,16 @@ class Form extends hx.EventEmitter
 
       autocompletePicker.value(values[0]) unless typeof options.required is 'boolean'
 
+      setValidity = () ->
+        input.node().setCustomValidity(hx.userFacingText('form', 'pleaseSelectAValue'))
+
       if options.required
-        input.node().setCustomValidity('Please select a value from the list')
-        autocompletePicker.on 'change', 'hx.form-builder', ->
-          input.node().setCustomValidity('')
+        setValidity()
+        autocompletePicker.on 'change', 'hx.form-builder', ({ value, cause }) ->
+          if value is undefined
+            setValidity()
+          else
+            input.node().setCustomValidity('')
 
       {
         required: options.required


### PR DESCRIPTION
This re-sets the validation message when the value is set to undefined

Resolves #304 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document.
- [ ] All my changes are covered by tests.
- [x] This request is ready to review and merge
