### PR TITLE
fix(builder): Resolve issue with `moduleDirectory` option

### DIFF
--- a/build/main/test.js
+++ b/build/main/test.js
@@ -64,7 +64,7 @@ function buildSingleModuleTestPackage (moduleName) {
       if (specJs) { // only do the rest of the building of the spec existed
         return builder.getModuleList([])
           .then(function (allModules) {
-            return compile.getModuleDependencies(moduleName)
+            return compile.getModuleDependencies(allModules, moduleName)
               .then(function (modules) {
                 return Promise.props({
                   dependencies: compile.buildLibrary({modules: modules, allModules: allModules}),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hexagon-js",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1301,7 +1301,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "requires": {
         "duplexer": "0.1.1",


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above in the following format -->
<!--- #404: resolved issue with data table -->

## Description
<!--- Describe your changes in detail -->

The option allows an additional directory to be passed in to extend
hexagon however part of the compiler config only allowed for modules
to be added from the root directory of core hexagon, causing the builder
to break when passing in `moduleDirectory`


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Resolves #404) -->

Trying to add an internal-only module to our Hexagon build

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manual tests to ensure build output is unchanged when not using the `moduleDirectory` option.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document.
- [ ] All my changes are covered by tests.
- [x] This request is ready to review and merge
