### PR TITLE
fix(datepicker): Update date localizer week start day to match ISO 8601

### DIFF
--- a/docs/content/docs/date-picker/api/auto.um
+++ b/docs/content/docs/date-picker/api/auto.um
@@ -21,6 +21,13 @@
     Fixed an issue where IE was displaying the datepicker calendar in compact
     mode
 
+@bugfix nextReleaseVersion
+  @description
+    Fixed an issue where the default calendar display was showing Sunday as the
+    week start instead of Monday as dictated by ISO standards and an issue where
+    momentjs was using the browser locale instead of the currently set locale to
+    calculate the week start.
+
 @prototype hx.DatePicker
   @updated 0.11.0
     @description

--- a/modules/date-localizer/main/index.coffee
+++ b/modules/date-localizer/main/index.coffee
@@ -5,10 +5,10 @@ class DateTimeLocalizer
   dateOrder: -> ['DD','MM','YYYY']
 
   # get the day the week starts on, 0 for sunday, 1 for monday etc.
-  weekStart: -> 0
+  weekStart: -> 1
 
   # localise the days of the week and return as array of 2 char days ('Su', 'Mo' etc.)
-  weekDays: -> ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']
+  weekDays: -> ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su']
 
   # localise 'today' text
   todayText: -> 'Today'
@@ -95,7 +95,7 @@ class DateTimeLocalizerMoment
     if result.length is 0 then result = ['DD','MM','YYYY']
     result
 
-  weekStart: -> moment().weekday(0).toDate().getDay()
+  weekStart: -> moment().locale(hx.preferences.locale()).weekday(0).toDate().getDay()
 
   weekDays: ->
     dayDate = moment().weekday(0)

--- a/modules/date-localizer/test/spec.coffee
+++ b/modules/date-localizer/test/spec.coffee
@@ -55,19 +55,19 @@ describe 'dateTimeLocalizer', ->
     executeFunctionInAllTimeZones ->
       localizer.dateOrder().should.eql(['DD','MM','YYYY'])
 
-  it 'weekStart: should get the day the week starts on, 0 for sunday, 1 for monday etc.', ->
-    localizer.weekStart().should.equal(0)
+  it 'weekStart: should return Monday as the week start (Sunday - Saturday, 0 - 6)', ->
+    localizer.weekStart().should.equal(1)
 
-  it 'weekStart: should get the day the week starts on, 0 for sunday, 1 for monday etc. in all timezones', ->
+  it 'weekStart: should return Monday as the week start (Sunday - Saturday, 0 - 6) in all timezones', ->
     executeFunctionInAllTimeZones ->
-      localizer.weekStart().should.equal(0)
+      localizer.weekStart().should.equal(1)
 
   it 'weekDays: should localize the days of the week and return as array of 2 char days', ->
-    localizer.weekDays().should.eql(['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'])
+    localizer.weekDays().should.eql(['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'])
 
   it 'weekDays: should localize the days of the week and return as array of 2 char days in all timezones', ->
     executeFunctionInAllTimeZones ->
-      localizer.weekDays().should.eql(['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'])
+      localizer.weekDays().should.eql(['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'])
 
   it 'todayText: should localize "today" text', ->
     localizer.todayText().should.equal('Today')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above in the following format -->
<!--- #404: resolved issue with data table -->

## Description
<!--- Describe your changes in detail -->
Changes week start date to Monday by default and uses the locale when using Moment.js

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Resolves #404) -->
It was pointed out that according to ISO 8601 the start of the week is Monday. The date localiser was using `0` as the start date which is the American start date (Sunday)

This change updates the calendar to show with Monday as the start of the week by default and also updates moment to use the currently set locale when getting the week start date

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Updated existing tests to match expectation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document.
- [x] All my changes are covered by tests.
- [x] This request is ready to review and merge
