### PR TITLE
chore(selection/util): Deprecate html getter/setters

### DIFF
--- a/docs/content/changelog/index.um
+++ b/docs/content/changelog/index.um
@@ -446,3 +446,6 @@
         set of plain functions for formatting numbers
 
         Deprecated the @code[request] module in favour of using @code[fetch]
+
+        Deprecated the @code[Selection::html] setter/getter method to prevent
+        XSS vulnerabilities.

--- a/docs/content/docs/selection/api/auto.um
+++ b/docs/content/docs/selection/api/auto.um
@@ -326,6 +326,11 @@
         The text content of the selected element, or nodes if this is a multiple selection.
 
   @method html
+    @deprecated nextReleaseVersion
+      @issue 375
+      @description
+        The @code[html] method for selections has been removed to prevent XSS attacks.
+
     @description
       Sets the html content of all the selected elements
 
@@ -338,6 +343,11 @@
         This Selection
 
   @method html
+    @deprecated nextReleaseVersion
+      @issue 375
+      @description
+        The @code[html] method for selections has been removed to prevent XSS attacks.
+
     @description
       Gets the html content of all the selected elements
 

--- a/docs/content/docs/util/api/auto.um
+++ b/docs/content/docs/util/api/auto.um
@@ -878,6 +878,11 @@
       The passed in item.
 
 @function hx.parseHTML
+  @deprecated nextReleaseVersion
+    @issue 375
+    @description
+      The @code[html] method for selections has been removed to prevent XSS attacks.
+
   @description
     A function for parsing a string to a DocumentFragment. Note: any script tags in the html string will be executed immediately - if you do not want this to happen, sanitize the string before passing into this function or remove the script tags from the document fragment created.
 

--- a/modules/collapsible/test/spec.coffee
+++ b/modules/collapsible/test/spec.coffee
@@ -4,7 +4,7 @@ describe 'collapsible', ->
   select = hx.select
 
   beforeEach ->
-    fixture = select('body').append('div').attr('id', 'fixture').html """
+    fixture = select('body').append('div').attr('id', 'fixture').node().innerHTML = """
       <div id="example" class="hx-collapsible">
         <div class="hx-collapsible-heading">Header</div>
         <div class="hx-collapsible-content">Content</div>

--- a/modules/data-table/test/spec.coffee
+++ b/modules/data-table/test/spec.coffee
@@ -2788,7 +2788,7 @@ describe 'data-table', ->
       hx.dataTable().should.be.an.instanceof(hx.Selection)
 
     it 'should not render if a feed is not defined', ->
-      hx.dataTable().select('.hx-data-table-content').html().should.equal('')
+      hx.dataTable().select('.hx-data-table-content').node().innerHTML.should.equal('')
 
     it 'should render if a feed is defined', ->
       hx.dataTable({feed: hx.dataTable.objectFeed(threeRowsData)}).select('.hx-data-table-content').selectAll('td').empty().should.equal(false)

--- a/modules/dropdown/main/index.coffee
+++ b/modules/dropdown/main/index.coffee
@@ -62,7 +62,7 @@ calculateDropdownPosition = (alignments, selectionRect, dropdownRect, windowRect
 dropdownContentToSetupDropdown = (dropdownContent) ->
   setupDropdown = switch
     when hx.isString dropdownContent
-      (node) -> hx.select(node).html(dropdownContent)
+      (node) -> hx.select(node).node().innerHTML = dropdownContent
     when hx.isFunction dropdownContent
       dropdownContent
     else

--- a/modules/dropdown/test/spec.coffee
+++ b/modules/dropdown/test/spec.coffee
@@ -189,7 +189,7 @@ describe 'hx-dropdown', ->
 
     dd._.visible.should.equal(true)
     hx.select('.hx-dropdown').empty().should.equal(false)
-    hx.select('.hx-dropdown').html().should.equal(content)
+    hx.select('.hx-dropdown').node().innerHTML.should.equal(content)
 
   it 'should not do anything if show is called and the dropdown is already open', ->
     dd = new hx.Dropdown(id, content)
@@ -199,12 +199,12 @@ describe 'hx-dropdown', ->
     dd.show()
     dd._.visible.should.equal(true)
     hx.select('.hx-dropdown').empty().should.equal(false)
-    hx.select('.hx-dropdown').html().should.equal(content)
+    hx.select('.hx-dropdown').node().innerHTML.should.equal(content)
 
     dd.show()
     dd._.visible.should.equal(true)
     hx.select('.hx-dropdown').empty().should.equal(false)
-    hx.select('.hx-dropdown').html().should.equal(content)
+    hx.select('.hx-dropdown').node().innerHTML.should.equal(content)
 
   it 'should not do anything if hide is called and the dropdown is already closed', ->
     dd = new hx.Dropdown(id, content)

--- a/modules/paginator/main/index.coffee
+++ b/modules/paginator/main/index.coffee
@@ -70,7 +70,7 @@ class Paginator extends hx.EventEmitter
     @container.append('button')
       .attr('type', 'button')
       .class('hx-btn ' + hx.theme.paginator.arrowButton)
-        .html('<i class="hx-icon hx-icon-step-backward"></i>')
+        .add(hx.detached('i').class('hx-icon hx-icon-step-backward'))
         .on 'click', 'hx.paginator', ->
           if self._.pageCount is undefined
             select(self, self._.page - 1, 'user')
@@ -92,7 +92,7 @@ class Paginator extends hx.EventEmitter
     @container.append('button')
       .attr('type', 'button')
       .class('hx-btn ' + hx.theme.paginator.arrowButton)
-        .html('<i class="hx-icon hx-icon-step-forward"></i>')
+        .add(hx.detached('i').class('hx-icon hx-icon-step-forward'))
         .on 'click', 'hx.paginator', ->
           if self._.pageCount is undefined
             select(self, self._.page + 1, 'user')

--- a/modules/request/main/index.coffee
+++ b/modules/request/main/index.coffee
@@ -107,7 +107,7 @@ hx.request = ->
 
 parsers =
   'application/json': (text) -> if text then JSON.parse text
-  'text/html': (text) -> hx.parseHTML text
+  'text/html': (text) -> hx.parseHTML.call(hx.request, text)
   'text/plain': (text) -> text
 
 reshapedRequest = (type) ->

--- a/modules/selection/main/index.coffee
+++ b/modules/selection/main/index.coffee
@@ -364,6 +364,7 @@ class Selection
 
   # gets or sets the inner html of the nodes in the selection
   html: (html) ->
+    hx.deprecatedWarning('Selection::html', 'N/A')
     if arguments.length == 1
       for node in @nodes
         node.innerHTML = if html? then html else ''

--- a/modules/selection/test/spec.coffee
+++ b/modules/selection/test/spec.coffee
@@ -2,7 +2,7 @@ describe 'Selection Api', ->
   origConsoleWarning = hx.consoleWarning
 
   beforeEach ->
-    fixture = hx.select('body').append('div').attr('id', 'fixture').html """
+    fixture = hx.select('body').append('div').attr('id', 'fixture').node().innerHTML =  """
       <div class="wrapper">
         <div id="outer-1">
           <span class="first one"></span>
@@ -1054,7 +1054,7 @@ describe 'Selection Api', ->
     selection.class().should.eql(['one two three', 'one two three'])
 
   it 'closest should work', ->
-    hx.select('#fixture').html(
+    hx.select('#fixture').node().innerHTML = (
       """
         <div id="closest-root" class="cr">
           <span id="child" class="ch">
@@ -1066,7 +1066,7 @@ describe 'Selection Api', ->
     hx.select('#grandchild').closest('span').class().should.equal('ch')
 
   it 'closest should work for grandparents', ->
-    hx.select('#fixture').html(
+    hx.select('#fixture').node().innerHTML = (
       """
         <div id="closest-root" class="cr">
           <span id="child" class="ch">
@@ -1078,7 +1078,7 @@ describe 'Selection Api', ->
     hx.select('#grandchild').closest('div').class().should.equal('cr')
 
   it 'closest should return an empty selection when there is no match', ->
-    hx.select('#fixture').html(
+    hx.select('#fixture').node().innerHTML = (
       """
         <div id="closest-root" class="cr">
           <span id="child" class="ch">
@@ -1101,7 +1101,7 @@ describe 'Selection Api', ->
     hx.select('#fixture').closest('potato').empty().should.equal(true)
 
   it 'closest should find by class', ->
-    hx.select('#fixture').html(
+    hx.select('#fixture').node().innerHTML = (
       """
         <div id="closest-root" class="cr">
           <span id="child" class="ch">
@@ -1113,7 +1113,7 @@ describe 'Selection Api', ->
     hx.select('#grandchild').closest('.cr').attr('id').should.equal('closest-root')
 
   it 'closest should find by id', ->
-    hx.select('#fixture').html(
+    hx.select('#fixture').node().innerHTML = (
       """
         <div id="closest-root" class="cr">
           <span id="child" class="ch">
@@ -1125,7 +1125,7 @@ describe 'Selection Api', ->
     hx.select('#grandchild').closest('#closest-root').class().should.equal('cr')
 
   it 'closest should not find a child by mistake', ->
-    hx.select('#fixture').html(
+    hx.select('#fixture').node().innerHTML = (
       """
         <div id="closest-root" class="cr">
           <span id="child" class="ch">

--- a/modules/sidebar/main/index.coffee
+++ b/modules/sidebar/main/index.coffee
@@ -29,7 +29,7 @@ class Sidebar extends hx.EventEmitter
     btn = hx.select(options.headerSelector).prepend('button')
       .attr('type', 'button')
       .class('hx-titlebar-sidebar-button')
-      .html('<i class="hx-icon hx-icon-bars"></i>')
+      .add(hx.detached('i').class('hx-icon hx-icon-bars'))
     btn.on 'click', 'hx.sidebar', => @toggle()
 
   toggle: ->

--- a/modules/titlebar/test/spec.coffee
+++ b/modules/titlebar/test/spec.coffee
@@ -2,7 +2,7 @@
 describe 'hx-titlebar', ->
   origWarn = console.warn
   beforeEach ->
-    fixture = hx.select('body').append('div').attr('id', 'fixture').html """
+    fixture = hx.select('body').append('div').attr('id', 'fixture').node().innerHTML = """
       <div class="hx-heading">
         <div class="hx-titlebar">
           <div class="hx-titlebar-container">

--- a/modules/tree/main/index.coffee
+++ b/modules/tree/main/index.coffee
@@ -123,7 +123,7 @@ class Tree
     @options = hx.merge.defined {
       hideDisabledButtons: false
       animate: true
-      renderer: (elem, data) -> hx.select(elem).html(data.name || data)
+      renderer: (elem, data) -> hx.select(elem).node().innerHTML = data.name || data
       items: []
       lazy: false
     }, options

--- a/modules/util/main/index.coffee
+++ b/modules/util/main/index.coffee
@@ -321,7 +321,10 @@ hx.vendor = (obj, prop) ->
 hx.identity = (d) -> d
 
 hx_parseHTML = null
+
 hx.parseHTML = (html) ->
+  # unless this is hx.request
+  hx.deprecatedWarning('hx.parseHTML', 'N/A')
   if not hx_parseHTML
     ###
     istanbul ignore next:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above in the following format -->
<!--- #404: resolved issue with data table -->

## Description
<!--- Describe your changes in detail -->

Deprecate:
- `Selection::html`
- `hx.parseHTML`

Update docs to add deprecation warnings

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Resolves #404) -->
Resolves #375 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run existing tests, check that they pass and display the deprecation warning (or don't for internal methods)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document.
- [x] All my changes are covered by tests.
- [x] This request is ready to review and merge
