### PR TITLE
feature(data-table): Add selectedRows and expandedRows to constructor

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -943,6 +943,9 @@
           <div id="dataTable4"></div>
           <h4>Grouped Headings</h4>
           <div id="dataTable5"></div>
+
+          <h4>Selectable/Collapsible</h4>
+          <div id="dataTable6"></div>
           <script>
           const tableFeed = hx.dataTable.objectFeed({
             headers: [
@@ -1030,6 +1033,15 @@
             feed: tableFeedGrouped
           }).render()
 
+          const table6 = new hx.DataTable('#dataTable6', {
+            feed: tableFeed,
+            selectedRows: [1],
+            selectEnabled: true,
+            expandedRows: [0],
+            rowCollapsibleLookup: () => true,
+            collapsibleRenderer: (e) => hx.select(e).text('Opened Collapsible')
+          }).render()
+
           new hx.Toggle('#compactToggle')
             .on('change', (value) => {
               console.log(value)
@@ -1038,6 +1050,7 @@
               table3.compact(value)
               table4.compact(value)
               table5.compact(value)
+              table6.compact(value)
             })
           </script>
         </div>

--- a/docs/content/docs/data-table/api/DataTable.um
+++ b/docs/content/docs/data-table/api/DataTable.um
@@ -394,6 +394,19 @@
           Whether the row should hightlight when the user hovers over it
         @default: true
 
+      @property selectedRows [Array]
+        @added nextReleaseVersion
+          @description
+            Added the ability to set the selectedRows in the constructor
+        @description
+          The selected rows to initialise the table with
+
+      @property expandedRows [Array]
+        @added nextReleaseVersion
+          @description
+            Added the ability to set the expandedRows in the constructor
+        @description
+          The expanded rows to initialise the table with
 
 
   # Methods for changing the options

--- a/docs/content/docs/data-table/api/DataTable.um
+++ b/docs/content/docs/data-table/api/DataTable.um
@@ -396,6 +396,7 @@
 
       @property selectedRows [Array]
         @added nextReleaseVersion
+          @issue 86
           @description
             Added the ability to set the selectedRows in the constructor
         @description
@@ -403,6 +404,7 @@
 
       @property expandedRows [Array]
         @added nextReleaseVersion
+          @issue 86
           @description
             Added the ability to set the expandedRows in the constructor
         @description

--- a/modules/data-table/main/index.coffee
+++ b/modules/data-table/main/index.coffee
@@ -302,6 +302,8 @@ class DataTable extends hx.EventEmitter
       sort: undefined
       sortEnabled: true
       highlightOnHover: true
+      selectedRows: []
+      expandedRows: []
 
       # functions used for getting row state
       rowIDLookup: (row) -> row.id
@@ -497,8 +499,8 @@ class DataTable extends hx.EventEmitter
       pageSizePickers: [pageSizePicker, pageSizePickerBottom]
       statusBar: statusBar
       sortColPicker: sortColPicker
-      selectedRows: new hx.Set   # holds the ids of the selected rows
-      expandedRows: new hx.Set
+      selectedRows: new hx.Set(resolvedOptions.selectedRows)   # holds the ids of the selected rows
+      expandedRows: new hx.Set(resolvedOptions.expandedRows)
       renderedCollapsibles: {}
       compactState: (resolvedOptions.compact is 'auto' and selection.width() < collapseBreakPoint) or resolvedOptions.compact is true
       advancedSearchView: advancedSearchView
@@ -1011,7 +1013,7 @@ class DataTable extends hx.EventEmitter
               delete @_.renderedCollapsibles[rowId]
 
             @_.expandedRows[if currentVis then 'add' else 'delete'](rowId)
-            @_.stickyHeaders.render()
+            @_.stickyHeaders?.render()
 
             @_.collapsibleSizeDiff = parseInt(selection.style('width')) - parseInt(hx.select(cc.contentDiv.node().parentNode).style('width'))
 

--- a/modules/data-table/test/spec.coffee
+++ b/modules/data-table/test/spec.coffee
@@ -253,6 +253,8 @@ describe 'data-table', ->
     checkOption('rowSelectableLookup', [((d) -> d), ((d) -> d*2), ((d) -> d+'')])
     checkOption('selectEnabled', [true, false])
     checkOption('singleSelection', [true, false])
+    checkOption('selectedRows', [[1,2,3], []])
+    checkOption('expandedRows', [[1,2,3], []])
     checkOption('sort', [{column: 'name', direction: 'asc'}, {column: 'age', direction: 'desc'}, undefined])
 
   describe 'column options', ->
@@ -789,6 +791,35 @@ describe 'data-table', ->
 
 
     describe 'selectedRows', ->
+      it 'should be possible for the user to deselect a row selected in the constructor', (done) ->
+        feed = hx.dataTable.objectFeed
+          headers: [
+            name: 'Name'
+            id: 'name'
+          ]
+          rows: [
+            id: 0
+            cells:
+              name: 'Bob'
+          ]
+        tableSel = hx.detached 'div'
+        tableOpts =
+          feed: feed
+          singleSelection: true
+          selectEnabled: true
+          selectedRows: [0]
+        table = new hx.DataTable tableSel.node(), tableOpts
+        table.render()
+
+        table.on 'selectedrowschange', (data) ->
+          if data.cause is 'user'
+            # Row 0 was selected before, so now we're unselecting it
+            data.value.should.eql []
+            done()
+        checkSel = tableSel.select '.hx-sticky-table-wrapper .hx-data-table-checkbox'
+        faker = testHelpers.fakeNodeEvent checkSel.node()
+        faker fakeEvent
+
       it 'should be possible for the user to deselect a row selected by the api', (done) ->
         feed = hx.dataTable.objectFeed
           headers: [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above in the following format -->
<!--- #404: resolved issue with data table -->

## Description
<!--- Describe your changes in detail -->
- Added `selectedRows` to constructor options
- Added `expandedRows` to constructor options
- Added tests for options
- Added new test for selectedRows when rendering from constructor
- Added demo with open collapsible + selected row

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Resolves #404) -->
Resolves #86 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Added tests for options
- Added new test for selectedRows when rendering from constructor

## Screenshots (if appropriate):
Screenshot of new demo section:
![screen shot 2018-07-10 at 08 39 14](https://user-images.githubusercontent.com/3194349/42496143-0a896148-841d-11e8-92c2-615c3ef10d40.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document.
- [x] All my changes are covered by tests.
- [x] This request is ready to review and merge
