### PR TITLE
feature(form-builder): Make submit buttons behave like regular components

### DIFF
--- a/docs/content/docs/form-builder/api/auto.um
+++ b/docs/content/docs/form-builder/api/auto.um
@@ -1175,6 +1175,7 @@
 
     @method addSubmit
       @added 0.15.2
+      @removed nextReleaseVersion
       @description
         Adds a submit button to the form
 
@@ -1193,6 +1194,114 @@
         @arg form [Form]
           @description
             The form being submitted
+
+      @returns [Form]
+        @description
+          This Form
+
+    @method addSubmit
+      @added nextReleaseVersion
+        @issue 395
+        @description
+          Added the @code[options] argument to allow the button to be hidden or
+          disabled when it is added to the form
+
+      @description
+        Adds a submit button to the form
+
+      @arg text [String]
+        @description
+          The text to give the button
+
+      @arg icon [String]
+        @description
+          The icon class for the button's icon
+
+      @arg? submitAction [Function]
+        @description
+          The function to call when the form is submitted instead of calling @code[form.submit()] . Useful for setting custom error messages for properties before submitting the form.
+
+        @arg form [Form]
+          @description
+            The form being submitted
+
+      @arg? options [Object]
+        @property key [String]
+          @description
+            The key to use when hiding/showing the submit button
+
+          @default: The @code[text] argument
+
+        @property hidden [Boolean]
+          @description
+            Whether the submit button should be hidden
+          @default: false
+
+        @property disabled [Boolean]
+          @description
+            Whether the submit button should be disabled
+          @default: false
+
+      @returns [Form]
+        @description
+          This Form
+
+    @method addButton
+      @added nextReleaseVersion
+        @issue 395
+        @description
+          Added the ability to add multiple buttons to the bottom of a form
+
+      @description
+        Adds a button to the bottom of the form.
+
+        All added buttons will display at the bottom of the form in the order
+        they are added.
+
+      @arg text [String]
+        @description
+          The text to display on the button
+
+      @arg action [Function]
+        @description
+          The action to perform when the button is clicked
+
+      @arg? options [Object]
+        @property icon [String]
+          @description
+            The icon class for the button's icon
+
+        @property key [String]
+          @description
+            The property name to map the button to when disabling/enabling the
+            button.
+
+          @default: The @code[text] argument
+
+        @property context [String]
+          @description
+            The context to apply to the button.
+
+          @default: 'action'
+
+        @property buttonType [String]
+          @description
+            The
+            @hyperlink(https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type)[type]
+            of the button
+
+          @default: 'button'
+
+        @property hidden [Boolean]
+          @description
+            Whether the button should be hidden
+          @default: false
+
+        @property disabled [Boolean]
+          @description
+            Whether the button should be disabled
+          @default: false
+
 
       @returns [Form]
         @description

--- a/docs/content/docs/form-builder/examples/auto.um
+++ b/docs/content/docs/form-builder/examples/auto.um
@@ -142,3 +142,29 @@
           .addSubmit('Submit', 'fa fa-check')
           .on('submit', function (data) {console.log(data)})
 
+@version nextReleaseVersion
+  @examples
+    @example
+      @@html
+        <form id="form"></form>
+
+      @@js
+        var form = new hx.Form('#form')
+          .addText('Text', { required: true, placeholder: 'Name' })
+          .addTextArea('Text Area', { placeholder: 'Name' })
+          .addEmail('Email', { required: true, placeholder: 'your.name@ocado.com' })
+          .addUrl('Url', { placeholder: 'http://www.example.co.uk/' }) // Allows blank or valid URL (with http:// prefix)
+          .addNumber('Number', {required: true})
+          .addPicker('Select', ['red', 'green', 'blue'])
+          .addCheckbox('Checkbox')
+          .addPassword('Password')
+          .addRadio('Radio', ['One', 'Two', 'Three'])
+          .addTagInput('Tag Input')
+          .addFileInput('File Input')
+          .addDatePicker('Date Picker')
+          .addTimePicker('Time Picker')
+          .addDateTimePicker('Date Time Picker')
+          .addButton('Button', () => console.log('Clicked Button'))
+          .addSubmit('Submit', 'fa fa-check')
+          .on('submit', function (data) {console.log(data)})
+

--- a/modules/form-builder/main/index.coffee
+++ b/modules/form-builder/main/index.coffee
@@ -4,6 +4,14 @@ hx.userFacingText({
   }
 })
 
+# XXX: Refactor into constructor in 2.0.0
+getButtons = (form) ->
+  selection = hx.select(form.selector)
+  sel = selection.select('.hx-form-buttons')
+  buttons = if sel.empty()
+    selection.append('div').class('hx-form-buttons')
+  else sel
+
 class Form extends hx.EventEmitter
   constructor: (@selector) ->
     super
@@ -20,7 +28,11 @@ class Form extends hx.EventEmitter
 
   add: (name, type, nodeType, f) ->
     id = @formId + name.split(" ").join("-")
-    entry = hx.select(@selector).append('div')
+    formSel = hx.select(@selector)
+    entry = formSel.append('div')
+
+    formSel.append(getButtons(this))
+
     entry.append('label').attr("for", id).text(name)
     selection = entry.append(nodeType).attr("id",id)
     extras = f.call(selection) or {}
@@ -315,19 +327,49 @@ class Form extends hx.EventEmitter
         disable: (sel, disabled) -> toggle.disabled(disabled)
       }
 
-  addSubmit: (text, icon, submitAction) ->
-    hx.select(@selector).append('button')
-      .attr('type', 'submit')
-      .class('hx-btn hx-action hx-form-submit')
-      .add(hx.detached('i').class(icon))
+  addButton: (text, action, opts = {}) =>
+    id = @formId + text.split(" ").join("-")
+    options = hx.merge({
+      key: text,
+      context: 'action',
+      buttonType: 'button',
+      icon: undefined,
+      hidden: false,
+      disabled: false,
+    }, opts)
+
+    button = hx.detached('button')
+      .attr('type', options.buttonType)
+      .attr('id',id)
+      .class("hx-btn hx-#{options.context}")
+      .add(if options.icon then hx.detached('i').class(options.icon) else undefined)
       .add(hx.detached('span').text(" " + text))
       .on 'click', 'hx.form-builder', (e) =>
         e.preventDefault()
-        if submitAction?
-          submitAction(this)
-        else
-          @submit()
+        action?()
+
+    elem = getButtons(this).append('div').add(button)
+
+    @properties.set options.key,
+      type: 'submit'
+      node: button.node()
+      extras: {
+        disable: (s, disabled) -> button.attr('disabled', if disabled then 'disabled' else undefined)
+      }
+
+    if options.hidden then @hidden options.key, options.hidden
+    if options.disabled then @disabled options.key, options.disabled
     this
+
+  addSubmit: (text, icon, submitAction, options = {}) ->
+    @addButton(text, (submitAction || () => @submit()), {
+      key: options.key,
+      context: 'action',
+      buttonType: 'submit',
+      icon: icon,
+      hidden: options.hidden,
+      disabled: options.disabled,
+    })
 
   submit: ->
     {valid, errors} = hx.validateForm(@selector)
@@ -341,7 +383,7 @@ class Form extends hx.EventEmitter
     else
       result = {}
       @properties.forEach (key, it) =>
-        if not it.hidden
+        if not it.hidden and not it.type is 'button'
           result[key] = @value(key)
       result
 

--- a/modules/form-builder/main/index.coffee
+++ b/modules/form-builder/main/index.coffee
@@ -362,8 +362,8 @@ class Form extends hx.EventEmitter
     this
 
   addSubmit: (text, icon, submitAction, options = {}) ->
-    @addButton(text, (submitAction || () => @submit()), {
-      key: options.key,
+    @addButton(text, (submitAction or () => @submit()), {
+      key: text or options.key,
       context: 'action',
       buttonType: 'submit',
       icon: icon,
@@ -383,7 +383,7 @@ class Form extends hx.EventEmitter
     else
       result = {}
       @properties.forEach (key, it) =>
-        if not it.hidden and not it.type is 'button'
+        if not it.hidden and it.type isnt 'submit'
           result[key] = @value(key)
       result
 

--- a/modules/form-builder/test/spec.coffee
+++ b/modules/form-builder/test/spec.coffee
@@ -72,3 +72,43 @@ describe "hx-form-builder", ->
       'Password': 'abc'
       'Radio': 'Two'
     })
+
+  it 'should allow buttons to be disabled', () ->
+    noop = () -> undefined
+    form = new hx.Form(hx.detached('div'))
+      .addButton('Button 1', noop)
+      .addButton('Button 2', noop, { disabled: true })
+      .addSubmit('Submit')
+
+    form.disabled('Button 1').should.equal(false)
+    form.disabled('Button 1', true).should.equal(form)
+    form.disabled('Button 1').should.equal(true)
+
+    form.disabled('Button 2').should.equal(true)
+    form.disabled('Button 2', false).should.equal(form)
+    form.disabled('Button 2').should.equal(false)
+
+    console.log(form.disabled('Submit'))
+
+    form.disabled('Submit').should.equal(false)
+    form.disabled('Submit', true).should.equal(form)
+    form.disabled('Submit').should.equal(true)
+
+  it 'should allow buttons to be hidden', () ->
+    noop = () -> undefined
+    form = new hx.Form(hx.detached('div'))
+      .addButton('Button 1', noop)
+      .addButton('Button 2', noop, { hidden: true })
+      .addSubmit('Submit')
+
+    form.hidden('Button 1').should.equal(false)
+    form.hidden('Button 1', true).should.equal(form)
+    form.hidden('Button 1').should.equal(true)
+
+    form.hidden('Button 2').should.equal(true)
+    form.hidden('Button 2', false).should.equal(form)
+    form.hidden('Button 2').should.equal(false)
+
+    form.hidden('Submit').should.equal(false)
+    form.hidden('Submit', true).should.equal(form)
+    form.hidden('Submit').should.equal(true)

--- a/modules/form-builder/test/spec.coffee
+++ b/modules/form-builder/test/spec.coffee
@@ -88,8 +88,6 @@ describe "hx-form-builder", ->
     form.disabled('Button 2', false).should.equal(form)
     form.disabled('Button 2').should.equal(false)
 
-    console.log(form.disabled('Submit'))
-
     form.disabled('Submit').should.equal(false)
     form.disabled('Submit', true).should.equal(form)
     form.disabled('Submit').should.equal(true)

--- a/modules/form/main/index.scss
+++ b/modules/form/main/index.scss
@@ -3,7 +3,11 @@
   text-align: right;
   display: inline-block;
 
-  > div {
+  .hx-form-buttons > * {
+    display: inline-block;
+  }
+
+  > div:not(.hx-form-buttons) {
     text-align: left;
     display: table-row;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above in the following format -->
<!--- #404: resolved issue with data table -->

## Description
<!--- Describe your changes in detail -->
- Added `addButton` as a generic method to add a form button
    - Multiple previous comments suggested more buttons would be useful (e.g. cancel, submit)
    - Duplicated the functionality in `Form::add` to add properties for the buttons
- Updated `addSubmit` to use `addButton` and converted it into a form of 'helper' method

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Resolves #404) -->
Resolves #395 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests to check new functionality.

Also tested in browser:
```js
window.form = new hx.Form(hx.select('body').append('form'))
  .addText('Text A')
  .addText('Text B')
  .addButton('Cancel', () => console.log('Cancelled'), { icon: 'fa fa-times', context: 'negative' })
  .addButton('Accept', () => console.log('Accepted'), { icon: 'fa fa-check', context: 'positive' })
  .addSubmit('Submit', 'fa fa-save')
  .on('submit', function (data) {console.log(data)})
```

## Screenshots (if appropriate):
![screen shot 2018-07-10 at 12 07 34](https://user-images.githubusercontent.com/3194349/42506457-dcf17140-8439-11e8-9321-c30151abfddb.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document.
- [x] All my changes are covered by tests.
- [x] This request is ready to review and merge
