### PR TITLE
fix(tag-input): Use the input map when using an Autocomplete

### DIFF
--- a/docs/content/docs/tag-input/api/auto.um
+++ b/docs/content/docs/tag-input/api/auto.um
@@ -37,6 +37,12 @@
     @description
       Fixed an issue where using an autocomplete allowed multiple tags to be entered at once
 
+  @bugfix nextReleaseVersion
+    @issue 405
+    @description
+      Fixed an issue where @code[[object Object]] would be displayed when using
+      object items in an autocomplete within the tag input.
+
   @description
     Initialises a tag input.
 

--- a/docs/content/docs/tag-input/examples/auto.um
+++ b/docs/content/docs/tag-input/examples/auto.um
@@ -58,3 +58,70 @@
         tagInput.add('goodbye', 'hx-negative')
         tagInput.add(['tag', 'tag2'])
 
+@version nextReleaseVersion
+  @examples
+    @example
+      @@html
+        <div id="tag-input"></div>
+
+      @@js
+        var tagInput = new hx.TagInput('#tag-input')
+        tagInput.items(['tag-1', 'tag-2', 'tag-3'])
+
+    @example
+      @@html
+        <div id="tag-input-2"></div>
+
+      @@js
+        var tagInput = new hx.TagInput('#tag-input-2', {
+          classifier: function(value) {
+            switch(value){
+              case 'hello':
+                return 'hx-positive'
+              case 'goodbye':
+                return 'hx-negative'
+            }
+          }
+        })
+        tagInput.add('hello', 'hx-positive')
+        tagInput.add('goodbye', 'hx-negative')
+        tagInput.add(['tag', 'tag2'])
+
+    @example
+      @@html
+        <div id="autocomplete-example"></div>
+
+      @@js
+        var items = [
+          {
+            type: 'A',
+            name: 'A Text'
+          },
+          {
+            type: 'B',
+            name: 'B Text'
+          },
+          {
+            type: 'D',
+            name: 'D Text'
+          },
+          {
+            type: 'C',
+            name: 'C Text'
+          }
+        ]
+
+        var ti = new hx.TagInput('#autocomplete-example', {
+          autocompleteOptions: {
+            renderer: function (elem, item) {
+              hx.select(elem).text(item.name)
+            },
+            inputMap: function (item) { return item.name }
+          },
+          autocompleteData: function (term, cb) {
+            // Remove duplicates and filter based on search term
+            cb(items.filter(function (item) {
+              return ti.items().indexOf(item.name) === -1 && item.name.indexOf(term) > -1
+            }))
+          }
+        })

--- a/modules/tag-input/main/index.coffee
+++ b/modules/tag-input/main/index.coffee
@@ -61,8 +61,9 @@ class TagInput extends hx.EventEmitter
       acData = createFilteredData filterFn, @options.autocompleteData
 
       @_.autocomplete = new hx.AutoComplete(@input.node(), acData, @options.autocompleteOptions)
+      inputMap = @_.autocomplete.options.inputMap || hx.identity
       @_.autocomplete.on 'change', 'hx.taginput', (value) =>  # add the item to the tag list on first enter/tab
-        @add value
+        @add inputMap(value)
         setTimeout (=> @_.autocomplete.show()), 0
 
     backspacedown = false

--- a/modules/tag-input/test/spec.coffee
+++ b/modules/tag-input/test/spec.coffee
@@ -177,6 +177,18 @@ describe 'tag-input', ->
       ti._.autocomplete.emit 'change', 'a'
       ti.add.should.have.been.called().with('a')
 
+    it 'should create the tag using the autocomplete input map', ->
+      ti = new hx.TagInput(hx.detached('div').node(), {
+        autocompleteData: ['a', 'b', 'c'],
+        autocompleteOptions: {
+          inputMap: (item) -> "#{item} Text"
+        }
+      })
+      expect(ti._.autocomplete).to.not.be.undefined
+      chai.spy.on(ti, 'add')
+      ti._.autocomplete.emit 'change', 'a'
+      ti.add.should.have.been.called().with('a Text')
+
     it 'should open the dropdown again after the tag has been created', ->
       clock = sinon.useFakeTimers()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above in the following format -->
<!--- #404: resolved issue with data table -->

## Description
<!--- Describe your changes in detail -->
Utilise the `inputMap` from the internal `Autocomplete` when adding an item to the tag input

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Resolves #404) -->
Resolves #405 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added regression test + browser tests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document.
- [x] All my changes are covered by tests.
- [x] This request is ready to review and merge
