### PR TITLE
feature(date-picker): Allow range and validRange in the constructor

### DIFF
--- a/docs/content/docs/date-picker/api/auto.um
+++ b/docs/content/docs/date-picker/api/auto.um
@@ -738,6 +738,43 @@
         @default
           false
 
+      @property range [Object]
+        @added nextReleaseVersion
+          @description
+            Added the ability to set the range when constructing a date picker
+
+        @description
+          An object containing the date range to set. The start/end dates will
+          be sorted internally if the end date is before the start date.
+
+        @property start [Date]
+          @description
+            The first date of the range
+
+        @property end [Date]
+          @description
+            The second date of the range
+
+      @property validRange [Object]
+        @added nextReleaseVersion
+          @description
+            Added the ability to set the valid range when constructing a date
+            picker
+
+        @description
+          An object containing the valid range to set. The start/end dates will
+          be sorted internally if the end date is before the start date.
+
+        @property start [Date]
+          @description
+            The first date of the valid range. Dates after this point will be
+            selectable
+
+        @property end [Date]
+          @description
+            The second date of the valid range. Dates before this point will be
+            selectable.
+
   @method visibleMonth
     @added 0.13.0
     @description

--- a/modules/date-picker/main/index.coffee
+++ b/modules/date-picker/main/index.coffee
@@ -347,6 +347,8 @@ class DatePicker extends hx.EventEmitter
       defaultView: 'm' # 'm' for month, 'y' for year, or 'd' for decade
       closeOnSelect: true
       selectRange: false
+      validRange: undefined
+      range: undefined
       showTodayButton: true
       allowInbuiltPicker: true # Option to allow preventing use of the inbuilt datepicker
       disabled: false
@@ -380,7 +382,7 @@ class DatePicker extends hx.EventEmitter
       @options.type = 'calendar'
       @options.showTodayButton = false
       _.preventFeedback = true
-      @range({})
+      @range(@options.range or {})
       _.preventFeedback = false
 
       inputUpdate = (which) ->
@@ -552,6 +554,7 @@ class DatePicker extends hx.EventEmitter
 
     setupInput this
     if _.disable then @disabled(_.disabled)
+    if @options.validRange then @validRange(@options.validRange)
 
 
   disabled: (disable) ->

--- a/modules/date-picker/test/spec.coffee
+++ b/modules/date-picker/test/spec.coffee
@@ -152,6 +152,14 @@ describe 'hx-date-picker', ->
         dp = new hx.DatePicker(hx.detached('div').node())
         dp.validRange().should.eql({start: undefined, end: undefined})
 
+      it 'can be set in the constructor', ->
+        validRange = {
+          start: roundedDate(),
+          end: roundedDate()
+        }
+        dp = new hx.DatePicker(hx.detached('div'), { validRange })
+        dp.validRange().should.eql(validRange)
+
 
     describe 'range', ->
       it 'should do nothing when attempting to use without setting selectRange', ->
@@ -188,3 +196,9 @@ describe 'hx-date-picker', ->
       it 'defaults should be today', ->
         dp = new hx.DatePicker(hx.detached('div').node(), {selectRange: true})
         dp.range().should.eql({start: roundedDate(null, true), end: roundedDate(null, true)})
+
+      it 'can be set in the constructor', ->
+        range = {start: roundedDate(true), end: roundedDate()}
+        dp = new hx.DatePicker(hx.detached('div'), { selectRange: true, range: range })
+        dp.range().should.eql({start: roundedDate(true), end: roundedDate()})
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above in the following format -->
<!--- #404: resolved issue with data table -->

## Description
<!--- Describe your changes in detail -->
- Added the `validRange` option to the date picker constructor
- Added the `range` option to the date picker constructor

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Resolves #404) -->
Resolves #350 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests + existing tests pass

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document.
- [x] All my changes are covered by tests.
- [x] This request is ready to review and merge
