### PR TITLE
fix(plot): Add defaults for `x` and `y` property for series label formatters

### DIFF
--- a/docs/content/docs/plot/api/auto.um
+++ b/docs/content/docs/plot/api/auto.um
@@ -36,6 +36,12 @@
   @description
     Prevent text wrapping in basic labels (e.g. sparklines)
 
+@bugfix nextReleaseVersion
+  @issue 348
+  @description
+    Resolves an issue where the label formatters were not correctly being read
+    for series.
+
 @object hx.theme.plot
   @property colors [Array[String]]
     @description

--- a/modules/plot/main/coffee/Series.coffee
+++ b/modules/plot/main/coffee/Series.coffee
@@ -1,7 +1,7 @@
 
 class Series extends hx.EventEmitter
 
-  defaultLabelValuesExtractor = (series, dataPoint, xAccessor, yAccessor, xProperty, yProperty) ->
+  defaultLabelValuesExtractor = (series, dataPoint, xAccessor, yAccessor, xProperty='x', yProperty='y') ->
     [
       {
         name: series.axis.x.title(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above in the following format -->
<!--- #404: resolved issue with data table -->

## Description
<!--- Describe your changes in detail -->
Added default `xProperty` and `yProperty` to the `defaultLabelValuesExtractor` 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Resolves #404) -->
Resolves #348 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in browser

## Screenshots (if appropriate):
![screen shot 2018-07-11 at 12 34 37](https://user-images.githubusercontent.com/3194349/42568952-cbf7aefe-8506-11e8-8f10-d5966c5a2484.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document.
- [x] All my changes are covered by tests.
- [x] This request is ready to review and merge
