### PR TITLE
fix(autocomplete-picker): Update change event to emit on undefined value

### DIFF
--- a/docs/content/docs/autocomplete-picker/api/AutocompletePicker/events/change.um
+++ b/docs/content/docs/autocomplete-picker/api/AutocompletePicker/events/change.um
@@ -1,4 +1,10 @@
 @event change [String]
+  @bugfix nextReleaseVersion
+    @issue 438
+    @description
+      Updated the AutocompletePicker to update the value when setting the value
+      to @code[undefined]
+
   @description
     The event called whenever the input text is updated by the auto
     complete object. The data is the value of the input field.

--- a/modules/autocomplete-picker/main/index.coffee
+++ b/modules/autocomplete-picker/main/index.coffee
@@ -21,14 +21,15 @@ setPickerValue = (picker, results, cause) ->
   _.valueText.clear()
   if results.length
     _.current = results[0]
-    picker.emit('change', {
-      cause: cause
-      value: results[0]
-    })
     _.renderer _.valueText.node(), results[0]
   else
     _.current = undefined
     _.valueText.text(_.options.chooseValueText)
+
+  picker.emit('change', {
+    cause: cause
+    value: _.current
+  })
 
 class AutocompletePicker extends hx.EventEmitter
   constructor: (selector, items, options = {}) ->

--- a/modules/autocomplete-picker/test/spec.coffee
+++ b/modules/autocomplete-picker/test/spec.coffee
@@ -494,6 +494,18 @@ describe 'autocomplete-picker', ->
       showstart.should.have.been.called.once()
 
 
+    it 'should emit the "change" event when the value is changed to undefined', ->
+      testClosedAutocomplete trivialItems, { value: 'a' }, (ap) ->
+        value = chai.spy()
+        ap.on 'change', value
+        ap.value(undefined)
+        value.should.have.been.called.with({
+          cause: 'api',
+          value: undefined
+        })
+        value.should.have.been.called.once()
+
+
     it 'should emit the "change" event when the value is changed', ->
       testClosedAutocomplete trivialItems, undefined, (ap) ->
         value = chai.spy()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above in the following format -->
<!--- #404: resolved issue with data table -->

## Description
<!--- Describe your changes in detail -->
Changed the event to be emit when setting the value to undefined

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Resolves #404) -->
Resolves #438 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added regression test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document.
- [x] All my changes are covered by tests.
- [x] This request is ready to review and merge
