### PR TITLE
fix(autocomplete-picker): Make it possible to clear the value

### DIFF
--- a/docs/content/docs/autocomplete-picker/api/AutocompletePicker.um
+++ b/docs/content/docs/autocomplete-picker/api/AutocompletePicker.um
@@ -28,6 +28,12 @@
   @added 1.4.0
     @issue 17
 
+  @bugfix nextReleaseVersion
+    @issue 435
+    @description
+      Resolved an issue to make it possible to clear the value of the
+      autocomplete picker using @code[.value(undefined)]
+
   @description
     Creates a new AutocompletePicker set up on a detached element, wrapped in a
     selection

--- a/modules/autocomplete-feed/main/index.coffee
+++ b/modules/autocomplete-feed/main/index.coffee
@@ -49,55 +49,59 @@ class AutocompleteFeed
     @_.resultsCache = new hx.Map
     this
 
-  filter: (term = '', callback) ->
+  filter: (term, callback) ->
     _ = @_
-    thisFilter = term + hx.randomId()
-    _.lastFilter = thisFilter
-
-    cacheItemsThenCallback = (results, otherResults = []) =>
-      if _.options.trimTrailingSpaces and results.length is 0 and term.lastIndexOf(' ') is term.length - 1
-        # The term has trailing spaces and no results were found
-        @filter(trimTrailingSpaces(term), callback)
-      else
-        # Cache the currently searched term items
-        if _.options.useCache
-          _.resultsCache.set(term, {
-            results: results,
-            otherResults: otherResults
-          })
-        # Only call back if this is the filter that was called last
-        if thisFilter is _.lastFilter
-          callback(results, otherResults)
-
-    if _.options.useCache and _.resultsCache.has(term)
-      # Get the result from the cache
-      cacheditems = _.resultsCache.get(term)
-      callback(cacheditems.results, cacheditems.otherResults)
-    else if _.options.matchType is 'external' and hx.isFunction(_.items)
-      # The matching is external so we don't filter here
-      _.items(term, cacheItemsThenCallback)
+    if term is undefined
+      callback([])
     else
-      filterAndCallback = (unfilteredItems) ->
-        filteredItems = _.options.filter(unfilteredItems, term)
-        if _.options.showOtherResults
-          unpartitioned = unfilteredItems.filter (datum) ->
-              filteredItems.indexOf(datum) is -1
-            .sort sortItems(_.options.valueLookup)
+      term ?= ''
+      thisFilter = term + hx.randomId()
+      _.lastFilter = thisFilter
 
-          { active, inactive } = sortActive(unpartitioned)
-          otherResults = [active..., inactive...]
+      cacheItemsThenCallback = (results, otherResults = []) =>
+        if _.options.trimTrailingSpaces and results.length is 0 and term.lastIndexOf(' ') is term.length - 1
+          # The term has trailing spaces and no results were found
+          @filter(trimTrailingSpaces(term), callback)
+        else
+          # Cache the currently searched term items
+          if _.options.useCache
+            _.resultsCache.set(term, {
+              results: results,
+              otherResults: otherResults
+            })
+          # Only call back if this is the filter that was called last
+          if thisFilter is _.lastFilter
+            callback(results, otherResults)
 
-        cacheItemsThenCallback(filteredItems, otherResults)
-
-      if hx.isFunction(_.items)
-        # Call the function then apply filtering
-        _.items(term, filterAndCallback)
-      else if term.length
-        # Apply filtering to the static object
-        filterAndCallback(_.items)
+      if _.options.useCache and _.resultsCache.has(term)
+        # Get the result from the cache
+        cacheditems = _.resultsCache.get(term)
+        callback(cacheditems.results, cacheditems.otherResults)
+      else if _.options.matchType is 'external' and hx.isFunction(_.items)
+        # The matching is external so we don't filter here
+        _.items(term, cacheItemsThenCallback)
       else
-        # Skip filtering and return the entire itemsset
-        cacheItemsThenCallback(_.items)
+        filterAndCallback = (unfilteredItems) ->
+          filteredItems = _.options.filter(unfilteredItems, term)
+          if _.options.showOtherResults
+            unpartitioned = unfilteredItems.filter (datum) ->
+                filteredItems.indexOf(datum) is -1
+              .sort sortItems(_.options.valueLookup)
+
+            { active, inactive } = sortActive(unpartitioned)
+            otherResults = [active..., inactive...]
+
+          cacheItemsThenCallback(filteredItems, otherResults)
+
+        if hx.isFunction(_.items)
+          # Call the function then apply filtering
+          _.items(term, filterAndCallback)
+        else if term.length
+          # Apply filtering to the static object
+          filterAndCallback(_.items)
+        else
+          # Skip filtering and return the entire itemsset
+          cacheItemsThenCallback(_.items)
 
   validateItems: (items) -> hx.isArray(items) or hx.isFunction(items)
 

--- a/modules/autocomplete-feed/test/spec.coffee
+++ b/modules/autocomplete-feed/test/spec.coffee
@@ -85,18 +85,6 @@ describe 'autocomplete-feed', ->
       af.items().should.equal(items)
 
 
-    it 'filter: should use "" if the term is undefined', ->
-      af = new hx.AutocompleteFeed
-      cb = chai.spy()
-      items = (term, callback) ->
-        should.exist(term)
-        callback(['a'])
-      af.items(items)
-      af.filter(undefined, cb)
-      cb.should.have.been.called()
-      cb.should.have.been.called.with(['a'], [])
-
-
     it 'filter: should not perform filtering when using external matching and items as a function', ->
       af = new hx.AutocompleteFeed({
         matchType: 'external'

--- a/modules/autocomplete-picker/test/spec.coffee
+++ b/modules/autocomplete-picker/test/spec.coffee
@@ -371,6 +371,14 @@ describe 'autocomplete-picker', ->
         hx.consoleWarning.should.not.have.been.called()
 
 
+    it 'value: should clear the value when set to undefined', ->
+      testClosedAutocomplete trivialItems, undefined, (ap) ->
+        should.not.exist(ap.value())
+        ap.value('b')
+        ap.value().should.equal('b')
+        ap.value(undefined)
+        should.not.exist(ap.value())
+
     it 'value: should call the callback correctly when the value is in the item set', ->
       testClosedAutocomplete trivialAsyncItems, undefined, (ap) ->
         should.not.exist(ap.value())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above in the following format -->
<!--- #404: resolved issue with data table -->

## Description
<!--- Describe your changes in detail -->
Updated to make it possible to clear the autocomplete picker with `.value(undefined)`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Resolves #404) -->
Resolves #435 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added regression test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document.
- [x] All my changes are covered by tests.
- [x] This request is ready to review and merge
