### PR TITLE
feature(date/time pickers): Un-deprecate the locale methods

### DIFF
--- a/docs/content/docs/date-picker/api/auto.um
+++ b/docs/content/docs/date-picker/api/auto.um
@@ -900,11 +900,15 @@
 
   @method locale
     @added 0.13.0
-    @deprecated 1.1.0
-      @issue 23
-      @issue 24
-      @description
-        Use @code[hx.preferences.locale] to get the locale for a page.
+    @extra
+      @removed nextReleaseVersion
+      @notice [De-deprecated]
+        @description
+          This method was deprecated in 1.1.0 in favour of using
+          @code[hx.preferences.locale] however after reviewing this it has been
+          de-deprecated in version nextReleaseVersion and updated to work in a more
+          effective manner.
+
 
     @description
       A function for updating the locale used in the date picker.
@@ -924,11 +928,19 @@
 
   @method locale
     @added 0.13.0
-    @deprecated 1.1.0
-      @issue 23
-      @issue 24
+    @updated nextReleaseVersion
+      @issue 468
       @description
-        Use @code[hx.preferences.locale] to set the locale for a page.
+        Updated the locale method to allow per-instance locales and un-deprecated the locale methods
+
+    @extra
+      @removed nextReleaseVersion
+      @notice [De-deprecated]
+        @description
+          This method was deprecated in 1.1.0 in favour of using
+          @code[hx.preferences.locale] however after reviewing this it has been
+          de-deprecated in version nextReleaseVersion and updated to work in a more
+          effective manner.
 
     @description
       A method for getting the currently set locale.

--- a/docs/content/docs/date-time-picker/api/auto.um
+++ b/docs/content/docs/date-time-picker/api/auto.um
@@ -840,6 +840,20 @@
 
   @method locale
     @added 0.13.0
+    @updated nextReleaseVersion
+      @issue 468
+      @description
+        Updated the locale method to allow per-instance locales and un-deprecated the locale methods
+
+    @extra
+      @removed nextReleaseVersion
+      @notice [De-deprecated]
+        @description
+          This method was deprecated in 1.1.0 in favour of using
+          @code[hx.preferences.locale] however after reviewing this it has been
+          de-deprecated in version nextReleaseVersion and updated to work in a more
+          effective manner.
+
     @description
       A function for updating the locale used in the datetimepicker.
 
@@ -858,12 +872,54 @@
 
   @method locale
     @added 0.13.0
+    @updated nextReleaseVersion
+      @issue 468
+      @description
+        Updated the locale method to allow per-instance locales and un-deprecated the locale methods
+
+    @extra
+      @removed nextReleaseVersion
+      @notice [De-deprecated]
+        @description
+          This method was deprecated in 1.1.0 in favour of using
+          @code[hx.preferences.locale] however after reviewing this it has been
+          de-deprecated in version nextReleaseVersion and updated to work in a more
+          effective manner.
+
     @description
       A method for getting the currently set locale.
 
     @returns [String]
       @description
         The currently set locale.
+
+  @method timezone
+    @added nextReleaseVersion
+      @issue 468
+      @description
+        Added a method to allow the setting of per-instance timezones
+
+    @description
+      Sets the timezone for this @type[DateTimePicker]
+
+    @returns [DateTimePicker]
+      @description
+        This DateTimePicker
+
+  @method timezone
+    @added nextReleaseVersion
+      @issue 468
+      @description
+        Added a method to allow the setting of per-instance timezones
+
+    @description
+      Gets the timezone for this @type[DateTimePicker]
+
+    @returns [String]
+      @description
+        The currently set timezone. Falls back to
+        @code[hx.preferences.timezone()] if one has not been set for this
+        instance
 
   @method disabled
     @added 0.15.2

--- a/docs/content/docs/preferences/api/auto.um
+++ b/docs/content/docs/preferences/api/auto.um
@@ -348,6 +348,8 @@
     @added 1.1.0
       @issue 23
 
+    @removed nextReleaseVersion
+
     @description
       A method that takes a date and returns a new date with the timezone offset applied.
 
@@ -358,6 +360,31 @@
     @arg? offset [Number]
       @description
         The offset to apply. If this is not provided, the offset is retrieved from the currently set timezone.
+
+    @returns [Date]
+      @description
+        The date, offset by the timezone amount.
+
+  @method applyTimezoneOffset
+    @added nextReleaseVersion
+      @description
+        Updated the offset argument to additionally take a @code[timezone]
+        string directly instead of needing the numeric offset
+
+    @description
+      A method that takes a date and returns a new date with the timezone offset applied.
+
+    @arg date [Date]
+      @description
+        The date to offset
+
+    @arg? timezoneOrOffset [String/Number]
+      @description
+        The timezone or offset to apply. Gets the offset from the timezone
+        when passing a string or uses the offset value directly.
+
+        If this is not provided, the offset is retrieved from the currently set
+        timezone.
 
     @returns [Date]
       @description
@@ -426,6 +453,40 @@
     @returns [Preferences]
       @description
         This Preferences
+
+  @method isLocaleSupported
+    @added nextReleaseVersion
+      @description
+        Added a method for checking whether the locale is supported
+
+    @description
+      Checks the list of @code[supportedLocales] to see whether the locale is
+      supported
+
+    @arg locale [String]
+      @description
+        The locale to check
+
+    @returns [Boolean]
+      @description
+        Whether the locale is in the list of supported locales
+
+  @method isTimezoneSupported
+    @added nextReleaseVersion
+      @description
+        Added a method for checking whether the timezone is supported
+
+    @description
+      Checks the list of @code[supportedTimezones] to see whether the timezone
+      is supported
+
+    @arg timezone [String]
+      @description
+        The timezone to check
+
+    @returns [Boolean]
+      @description
+        Whether the timezone is in the list of supported timezones
 
   @event timezonechange
     @description

--- a/docs/content/docs/time-picker/api/auto.um
+++ b/docs/content/docs/time-picker/api/auto.um
@@ -546,11 +546,19 @@
 
   @method locale
     @added 0.13.0
-    @deprecated 1.1.0
-      @issue 23
-      @issue 24
+    @updated nextReleaseVersion
+      @issue 468
       @description
-        Use @code[hx.preferences.locale] to get the locale for a page.
+        Updated the locale method to allow per-instance locales and un-deprecated the locale methods
+
+    @extra
+      @removed nextReleaseVersion
+      @notice [De-deprecated]
+        @description
+          This method was deprecated in 1.1.0 in favour of using
+          @code[hx.preferences.locale] however after reviewing this it has been
+          de-deprecated in version nextReleaseVersion and updated to work in a more
+          effective manner.
 
     @description
       A function for updating the locale used in the time picker.
@@ -559,6 +567,7 @@
 
       @@codeblock js
         timepicker.locale('pl') // sets the timepicker's locale to Poland
+
 
     @arg locale [String]
       @description
@@ -570,18 +579,60 @@
 
   @method locale
     @added 0.13.0
-    @deprecated 1.1.0
-      @issue 23
-      @issue 24
+    @updated nextReleaseVersion
+      @issue 468
       @description
-        Use @code[hx.preferences.locale] to set the locale for a page.
+        Updated the locale method to allow per-instance locales and un-deprecated the locale methods
+
+    @extra
+      @removed nextReleaseVersion
+      @notice [De-deprecated]
+        @description
+          This method was deprecated in 1.1.0 in favour of using
+          @code[hx.preferences.locale] however after reviewing this it has been
+          de-deprecated in version nextReleaseVersion and updated to work in a more
+          effective manner.
 
     @description
-      A method for getting the currently set locale.
+      @version 0.13.0
+        A method for getting the currently set locale
+
+      @version nextReleaseVersion
+        Gets the locale for this time picker. If one has not been set, falls
+        back to @code[hx.preferences.locale()]
 
     @returns [String]
       @description
-        The currently set locale.
+        The currently set locale. Falls back to @code[hx.preferences.locale()]
+        if one has not been set for this @type[TimePicker]
+
+  @method timezone
+    @added nextReleaseVersion
+      @issue 468
+      @description
+        Added a method to allow the setting of per-instance timezones
+
+    @description
+      Sets the timezone for this @type[TimePicker]
+
+    @returns [TimePicker]
+      @description
+        This TimePicker
+
+  @method timezone
+    @added nextReleaseVersion
+      @issue 468
+      @description
+        Added a method to allow the setting of per-instance timezones
+
+    @description
+      Gets the timezone for this @type[TimePicker]
+
+    @returns [String]
+      @description
+        The currently set timezone. Falls back to
+        @code[hx.preferences.timezone()] if one has not been set for this
+        instance
 
   @method date
     @added 0.13.0

--- a/modules/date-localizer/main/index.coffee
+++ b/modules/date-localizer/main/index.coffee
@@ -1,4 +1,58 @@
-class DateTimeLocalizer
+class PreferencesHandler extends hx.EventEmitter
+  constructor: () ->
+    super
+    @_ = {
+      uniqueId: hx.randomId()
+    }
+
+    hx.preferences.on 'localechange', 'hx.date-time-localizer' + @_.uniqueId, =>
+      if not @_.instanceLocale
+        @emit 'localechange', {
+          cause: 'api',
+          value: hx.preferences.locale()
+        }
+
+    hx.preferences.on 'timezonechange', 'hx.date-time-localizer' + @_.uniqueId, =>
+      if not @_.instanceTimezone
+        @emit 'timezonechange', {
+          cause: 'api',
+          value: hx.preferences.timezone()
+        }
+
+  locale: (locale) ->
+    if arguments.length
+      if not locale? or hx.preferences.localeIsSupported(locale)
+        @_.instanceLocale = if locale then true else false
+        @_.locale = locale
+        @emit 'localechange', {
+          cause: 'api',
+          value: locale or hx.preferences.locale()
+        }
+      else
+        hx.consoleWarning(locale + ' is not a valid locale. If you think the locale should be added to the list contact the maintainers of hexagon')
+      this
+    else
+      @_.locale or hx.preferences.locale()
+
+  timezone: (timezone) ->
+    if arguments.length
+      if not timezone? or hx.preferences.timezoneIsSupported(timezone)
+        @_.instanceTimezone = if timezone then true else false
+        @_.timezone = timezone
+        @emit 'timezonechange', {
+          cause: 'api',
+          value: timezone or hx.preferences.timezone()
+        }
+      else
+        hx.consoleWarning(timezone + ' is not a valid timezone')
+      this
+    else
+      @_.timezone or hx.preferences.timezone()
+
+class DateTimeLocalizer extends PreferencesHandler
+  constructor: () ->
+    super
+
   # get the display order for the date so dates can be displayed correctly when localised
   dateOrder: -> ['DD','MM','YYYY']
 
@@ -33,7 +87,7 @@ class DateTimeLocalizer
 
   # localise a date object to return a time string of hh:mm or hh:mm:ss (or localised format)
   time: (date, showSeconds) ->
-    date = hx.preferences.applyTimezoneOffset(date)
+    date = hx.preferences.applyTimezoneOffset(date, @timezone())
     timeString = date.getHours() + ':' + hx.zeroPad date.getMinutes()
     if showSeconds
       timeString += ':' + hx.zeroPad date.getSeconds()
@@ -75,9 +129,12 @@ class DateTimeLocalizer
       new Date('Invalid Date')
 
 
-class DateTimeLocalizerMoment
+class DateTimeLocalizerMoment extends PreferencesHandler
+  constructor: () ->
+    super
+
   dateOrder: ->
-    date = moment({year:2003, month:11, day:22}).locale(hx.preferences.locale())
+    date = moment({year:2003, month:11, day:22}).locale(@locale())
     dateCheck = date.format('L')
     yearIndex = dateCheck.indexOf(date.format('YYYY'))
     monthIndex = dateCheck.indexOf(date.format('MM'))
@@ -93,18 +150,18 @@ class DateTimeLocalizerMoment
     if result.length is 0 then result = ['DD','MM','YYYY']
     result
 
-  weekStart: -> moment().locale(hx.preferences.locale()).weekday(0).toDate().getDay()
+  weekStart: -> moment().locale(@locale()).weekday(0).toDate().getDay()
 
   weekDays: ->
     dayDate = moment().weekday(0)
-    dayDate.locale(hx.preferences.locale())
+    dayDate.locale(@locale())
     dayNames = [dayDate.format('dd')]
     for i in [0...6]
       dayNames.push(dayDate.add(1,'d').format('dd'))
     dayNames
 
   todayText: ->
-    today = moment({hour: 12, minute: 0, second: 0}).locale(hx.preferences.locale())
+    today = moment({hour: 12, minute: 0, second: 0}).locale(@locale())
     tomorrow = today.clone().add(1, 'day')
     todayArr = today.calendar().split('').reverse()
     tomorrowArr = tomorrow.calendar().split('').reverse()
@@ -115,27 +172,27 @@ class DateTimeLocalizerMoment
     todayArr.reverse().join('')
 
   day: (day, pad) ->
-    moment({day: day, month: 0}).locale(hx.preferences.locale()).format(if pad then 'DD' else 'D')
+    moment({day: day, month: 0}).locale(@locale()).format(if pad then 'DD' else 'D')
 
   month: (month, short) ->
-    moment({month: month}).locale(hx.preferences.locale()).format(if short then 'MM' else 'MMM')
+    moment({month: month}).locale(@locale()).format(if short then 'MM' else 'MMM')
 
   year: (year) ->
-    moment({year: year}).locale(hx.preferences.locale()).format('YYYY')
+    moment({year: year}).locale(@locale()).format('YYYY')
 
   decade: (start, end) ->
     @year(start) + ' - ' + @year(end)
 
   date: (date) ->
-    moment(date).locale(hx.preferences.locale()).format('L')
+    moment(date).locale(@locale()).format('L')
 
   time: (date, showSeconds) ->
-    date = hx.preferences.applyTimezoneOffset(date)
+    date = hx.preferences.applyTimezoneOffset(date, @timezone())
     format = if showSeconds then 'H:mm:ss' else 'H:mm'
-    moment(date).locale(hx.preferences.locale()).format(format)
+    moment(date).locale(@locale()).format(format)
 
   checkTime: (time) ->
-    moment({hours: time[0], minutes: time[1], seconds: time[2]}).locale(hx.preferences.locale()).isValid()
+    moment({hours: time[0], minutes: time[1], seconds: time[2]}).locale(@locale()).isValid()
 
   stringToDate: (dateString) ->
     order = @dateOrder()
@@ -156,7 +213,7 @@ class DateTimeLocalizerMoment
             yearsValid = part.length < 5 and part isnt ''
             format += 'YYYY'
       if daysValid and monthsValid and yearsValid
-        moment(dateString, format, hx.preferences.locale()).toDate()
+        moment(dateString, format, @locale()).toDate()
       else
         new Date('Invalid Date')
     else

--- a/modules/date-localizer/main/index.coffee
+++ b/modules/date-localizer/main/index.coffee
@@ -21,7 +21,7 @@ class PreferencesHandler extends hx.EventEmitter
 
   locale: (locale) ->
     if arguments.length
-      if not locale? or hx.preferences.localeIsSupported(locale)
+      if not locale? or hx.preferences.isLocaleSupported(locale)
         @_.instanceLocale = if locale then true else false
         @_.locale = locale
         @emit 'localechange', {
@@ -36,7 +36,7 @@ class PreferencesHandler extends hx.EventEmitter
 
   timezone: (timezone) ->
     if arguments.length
-      if not timezone? or hx.preferences.timezoneIsSupported(timezone)
+      if not timezone? or hx.preferences.isTimezoneSupported(timezone)
         @_.instanceTimezone = if timezone then true else false
         @_.timezone = timezone
         @emit 'timezonechange', {

--- a/modules/date-localizer/test/spec.coffee
+++ b/modules/date-localizer/test/spec.coffee
@@ -2,13 +2,26 @@ describe 'dateTimeLocalizerMoment', ->
   # Not sure how to test this...
 
 describe 'dateTimeLocalizer', ->
-  localizer = hx.dateTimeLocalizer()
+  localizer = undefined
   timezonesOffsetPattern = /(.)(\d{2}):(\d{2})$/
   testDate = new Date(1452130200000) # Thu Jan 07 2016 01:30:00 GMT+0000 (GMT)
   zeroHourDate = new Date(1452124800000) # Thu Jan 07 2016 00:00:00 GMT+0000 (GMT)
   invalidDate = new Date('Invalid Date')
   # 0 - London, -120 - Sofia, -60 Krakow, -540 Tokio, 420 Pinal (Arizona/United states)
   timezonesOffsets = [0, -120, -60, -540, 420]
+
+  origWarning = hx.consoleWarning()
+  origLocale = hx.preferences.locale()
+  origTimezone = hx.preferences.timezone()
+
+  beforeEach ->
+    hx.consoleWarning = chai.spy()
+    localizer = hx.dateTimeLocalizer()
+
+  afterEach ->
+    hx.consoleWarning = origWarning
+    hx.preferences.locale(origLocale)
+    hx.preferences.timezone(origTimezone)
 
   getHexagonTimeZoneOffset = ->
     timezonesOffsetParts = timezonesOffsetPattern.exec(hx.preferences.timezone())
@@ -47,176 +60,290 @@ describe 'dateTimeLocalizer', ->
       hx.preferences.timezone(oldTimeZone)
 
 
-  it 'dateOrder: should get the display order for the date so dates can be displayed correctly when localized', ->
-    localizer.dateOrder().should.eql(['DD','MM','YYYY'])
-
-  it 'dateOrder: should get the display order for the date so dates can be displayed correctly when localized in all timezones', ->
-    executeFunctionInAllTimeZones ->
+  describe 'dateOrder', ->
+    it 'gets the display order for the date so dates can be displayed correctly when localized', ->
       localizer.dateOrder().should.eql(['DD','MM','YYYY'])
 
-  it 'weekStart: should return Monday as the week start (Sunday - Saturday, 0 - 6)', ->
-    localizer.weekStart().should.equal(1)
+    it 'gets the display order for the date so dates can be displayed correctly when localized in all timezones', ->
+      executeFunctionInAllTimeZones ->
+        localizer.dateOrder().should.eql(['DD','MM','YYYY'])
 
-  it 'weekStart: should return Monday as the week start (Sunday - Saturday, 0 - 6) in all timezones', ->
-    executeFunctionInAllTimeZones ->
+
+  describe 'weekStart', ->
+    it 'returns Monday as the week start (Sunday - Saturday, 0 - 6)', ->
       localizer.weekStart().should.equal(1)
 
-  it 'weekDays: should localize the days of the week and return as array of 2 char days', ->
-    localizer.weekDays().should.eql(['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'])
+    it 'returns Monday as the week start (Sunday - Saturday, 0 - 6) in all timezones', ->
+      executeFunctionInAllTimeZones ->
+        localizer.weekStart().should.equal(1)
 
-  it 'weekDays: should localize the days of the week and return as array of 2 char days in all timezones', ->
-    executeFunctionInAllTimeZones ->
+
+  describe 'weekDays', ->
+    it 'localizes the days of the week and return as array of 2 char days', ->
       localizer.weekDays().should.eql(['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'])
 
-  it 'todayText: should localize "today" text', ->
-    localizer.todayText().should.equal('Today')
+    it 'localizes the days of the week and return as array of 2 char days in all timezones', ->
+      executeFunctionInAllTimeZones ->
+        localizer.weekDays().should.eql(['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'])
 
-  it 'todayText: should localize "today" text in all timezones', ->
-    executeFunctionInAllTimeZones ->
+
+  describe 'todayText', ->
+    it 'localizes "today" text', ->
       localizer.todayText().should.equal('Today')
 
-  it 'day: should localize the day of the month', ->
-    localizer.day(1).should.equal(1)
-    localizer.day(15).should.equal(15)
+    it 'localizes "today" text in all timezones', ->
+      executeFunctionInAllTimeZones ->
+        localizer.todayText().should.equal('Today')
 
-  it 'day: should localize the day of the month in all timezones', ->
-    executeFunctionInAllTimeZones ->
+
+  describe 'day', ->
+    it 'localizes the day of the month', ->
       localizer.day(1).should.equal(1)
       localizer.day(15).should.equal(15)
 
-  it 'day: should zeropad correctly localize the day of the month', ->
-    localizer.day(1, true).should.equal('01')
-    localizer.day(15, true).should.equal('15')
+    it 'localizes the day of the month in all timezones', ->
+      executeFunctionInAllTimeZones ->
+        localizer.day(1).should.equal(1)
+        localizer.day(15).should.equal(15)
 
-  it 'day: should zeropad correctly localize the day of the month in all timezones', ->
-    executeFunctionInAllTimeZones ->
+    it 'zeropads correctly the day of the month', ->
       localizer.day(1, true).should.equal('01')
       localizer.day(15, true).should.equal('15')
 
-  it 'month: should localize the month in the format of mmm', ->
-    localizer.month(0).should.equal('Jan')
+    it 'zeropads correctly the day of the month in all timezones', ->
+      executeFunctionInAllTimeZones ->
+        localizer.day(1, true).should.equal('01')
+        localizer.day(15, true).should.equal('15')
 
-  it 'month: should localize the month in the format of mmm in all timezones', ->
-    executeFunctionInAllTimeZones ->
+
+  describe 'month', ->
+    it 'localizes the month in the format of mmm', ->
       localizer.month(0).should.equal('Jan')
 
-  it 'month: should localize the month in the form at of MM', ->
-    localizer.month(0, true).should.equal('01')
+    it 'localizes the month in the format of mmm in all timezones', ->
+      executeFunctionInAllTimeZones ->
+        localizer.month(0).should.equal('Jan')
 
-  it 'month: should localize the month in the form at of MM in all timezones', ->
-    executeFunctionInAllTimeZones ->
+    it 'localizes the month in the form at of MM', ->
       localizer.month(0, true).should.equal('01')
 
-  it 'year: should localize the full year in the format of yyyy', ->
-    localizer.year(2015).should.equal(2015)
+    it 'localizes the month in the form at of MM in all timezones', ->
+      executeFunctionInAllTimeZones ->
+        localizer.month(0, true).should.equal('01')
 
-  it 'year: should localize the full year in the format of yyyy in all timezones', ->
-    executeFunctionInAllTimeZones ->
+
+  describe 'year', ->
+    it 'localizes the full year in the format of yyyy', ->
       localizer.year(2015).should.equal(2015)
 
-  it 'date: should localize a date object to return a date string of dd/mm/yyyy', ->
-    expectedDate = hx.zeroPad(testDate.getDate()) + "/" + hx.zeroPad(testDate.getMonth() + 1) + "/" + hx.zeroPad(testDate.getFullYear())
-    localizer.date(testDate).should.equal(expectedDate)
+    it 'localizes the full year in the format of yyyy in all timezones', ->
+      executeFunctionInAllTimeZones ->
+        localizer.year(2015).should.equal(2015)
 
-  it 'date: should localize a date object to return a date string of dd/mm/yyyy in all timezones', ->
-    executeFunctionInAllTimeZones ->
-      localeDate = new Date(testDate.getTime())
-      expectedDate = hx.zeroPad(localeDate.getDate()) + "/" + hx.zeroPad(localeDate.getMonth() + 1) + "/" + hx.zeroPad(localeDate.getFullYear())
-      localizer.date(localeDate).should.equal(expectedDate, getHexagonTimeZoneOffset())
 
-  it 'date: should localize a date object to return a date string of yyyy-mm-dd', ->
-    expectedDate = hx.zeroPad(testDate.getFullYear()) + "-" + hx.zeroPad(testDate.getMonth() + 1) + "-" + hx.zeroPad(testDate.getDate())
-    localizer.date(testDate, true).should.equal(expectedDate)
+  describe 'date', ->
+    it 'localizes a date object to return a date string of dd/mm/yyyy', ->
+      expectedDate = hx.zeroPad(testDate.getDate()) + "/" + hx.zeroPad(testDate.getMonth() + 1) + "/" + hx.zeroPad(testDate.getFullYear())
+      localizer.date(testDate).should.equal(expectedDate)
 
-  it 'date: should localize a date object to return a date string of yyyy-mm-dd in all timezones', ->
-    executeFunctionInAllTimeZones ->
+    it 'localizes a date object to return a date string of dd/mm/yyyy in all timezones', ->
+      executeFunctionInAllTimeZones ->
+        localeDate = new Date(testDate.getTime())
+        expectedDate = hx.zeroPad(localeDate.getDate()) + "/" + hx.zeroPad(localeDate.getMonth() + 1) + "/" + hx.zeroPad(localeDate.getFullYear())
+        localizer.date(localeDate).should.equal(expectedDate, getHexagonTimeZoneOffset())
+
+    it 'localizes a date object to return a date string of yyyy-mm-dd', ->
       expectedDate = hx.zeroPad(testDate.getFullYear()) + "-" + hx.zeroPad(testDate.getMonth() + 1) + "-" + hx.zeroPad(testDate.getDate())
       localizer.date(testDate, true).should.equal(expectedDate)
 
-  it 'time: should localize a date object to return a time string of hh:mm', ->
-    expectedValue = testDate.getHours() + ":" + testDate.getMinutes()
-    localizer.time(testDate).should.equal(expectedValue)
+    it 'localizes a date object to return a date string of yyyy-mm-dd in all timezones', ->
+      executeFunctionInAllTimeZones ->
+        expectedDate = hx.zeroPad(testDate.getFullYear()) + "-" + hx.zeroPad(testDate.getMonth() + 1) + "-" + hx.zeroPad(testDate.getDate())
+        localizer.date(testDate, true).should.equal(expectedDate)
 
-  it 'time: should localize a date object to return a time string of hh:mm in all timezones', ->
-    executeFunctionInAllTimeZones ->
-      localeDate = new Date(testDate.getTime())
-      localeDate.setTime(localeDate.getTime() + (getHexagonTimeZoneOffset() * 60000))
-      localeDate.setTime(localeDate.getTime() + localeDate.getTimezoneOffset() * 60 * 1000)
-      localeDateString = localeDate.getHours() + ":" + localeDate.getMinutes()
-      localizer.time(testDate).should.equal(localeDateString)
 
-  it 'time: should localize a date object to return a time string of hh:mm:ss', ->
-    localDate = new Date(testDate.getTime())
-    localDate.setTime(localDate.getTime() + localDate.getTimezoneOffset() * 60 * 1000)
-    localizer.time(localDate, true).should.equal('1:30:00')
+  describe 'time', ->
+    it 'localizes a date object to return a time string of hh:mm', ->
+      expectedValue = testDate.getHours() + ":" + testDate.getMinutes()
+      localizer.time(testDate).should.equal(expectedValue)
 
-  it 'checkTime: should return true when time is valid', ->
-    localizer.checkTime('1:30:00'.split(':')).should.equal(true)
+    it 'localizes a date object to return a time string of hh:mm in all timezones', ->
+      executeFunctionInAllTimeZones ->
+        localeDate = new Date(testDate.getTime())
+        localeDate.setTime(localeDate.getTime() + (getHexagonTimeZoneOffset() * 60000))
+        localeDate.setTime(localeDate.getTime() + localeDate.getTimezoneOffset() * 60 * 1000)
+        localeDateString = localeDate.getHours() + ":" + localeDate.getMinutes()
+        localizer.time(testDate).should.equal(localeDateString)
 
-  it 'checkTime: should return true when time is valid in all timezones', ->
-    executeFunctionInAllTimeZones ->
+    it 'localizes a date object to return a time string of hh:mm:ss', ->
+      localDate = new Date(testDate.getTime())
+      localDate.setTime(localDate.getTime() + localDate.getTimezoneOffset() * 60 * 1000)
+      localizer.time(localDate, true).should.equal('1:30:00')
+
+
+  describe 'checkTime', ->
+    it 'returns true when time is valid', ->
       localizer.checkTime('1:30:00'.split(':')).should.equal(true)
 
-  it 'checkTime: should return false when time is not valid', ->
-    localizer.checkTime('a:30'.split(':')).should.equal(false)
-    localizer.checkTime('1:b:00'.split(':')).should.equal(false)
+    it 'returns true when time is valid in all timezones', ->
+      executeFunctionInAllTimeZones ->
+        localizer.checkTime('1:30:00'.split(':')).should.equal(true)
 
-  it 'checkTime: should return false when time is not valid in all timezones', ->
-    executeFunctionInAllTimeZones ->
+    it 'returns false when time is not valid', ->
       localizer.checkTime('a:30'.split(':')).should.equal(false)
       localizer.checkTime('1:b:00'.split(':')).should.equal(false)
 
-  it 'stringToDate: should convert a localized date string back to a date object', ->
-    localizer.stringToDate('07/01/2016').should.eql(zeroHourDate)
+    it 'returns false when time is not valid in all timezones', ->
+      executeFunctionInAllTimeZones ->
+        localizer.checkTime('a:30'.split(':')).should.equal(false)
+        localizer.checkTime('1:b:00'.split(':')).should.equal(false)
 
-  it 'stringToDate: should convert a localized date string back to a date object in all timezones', ->
-    executeFunctionInAllTimeZones ->
+
+  describe 'stringToDate', ->
+    it 'converts a localized date string back to a date object', ->
       localizer.stringToDate('07/01/2016').should.eql(zeroHourDate)
 
-  it 'stringToDate: should convert a localized date string back to a date object for inbuilt dates', ->
-    localizer.stringToDate('2016-01-07', true).should.eql(zeroHourDate)
+    it 'converts a localized date string back to a date object in all timezones', ->
+      executeFunctionInAllTimeZones ->
+        localizer.stringToDate('07/01/2016').should.eql(zeroHourDate)
 
-  it 'stringToDate: should convert a localized date string back to a date object for inbuilt dates in all timezones', ->
-    executeFunctionInAllTimeZones ->
+    it 'converts a localized date string back to a date object for inbuilt dates', ->
       localizer.stringToDate('2016-01-07', true).should.eql(zeroHourDate)
 
-  it 'stringToDate: should handle dates with short years correctly', ->
-    localizer.stringToDate('07/01/16').should.eql(zeroHourDate)
+    it 'converts a localized date string back to a date object for inbuilt dates in all timezones', ->
+      executeFunctionInAllTimeZones ->
+        localizer.stringToDate('2016-01-07', true).should.eql(zeroHourDate)
 
-  it 'stringToDate: should handle dates with short years correctly in all timezones', ->
-    executeFunctionInAllTimeZones ->
+    it 'handles dates with short years correctly', ->
       localizer.stringToDate('07/01/16').should.eql(zeroHourDate)
 
-  it 'stringToDate: should return an invalid date object when passed an incomplete date', ->
-    localizer.stringToDate('07/01').should.eql(invalidDate)
+    it 'handles dates with short years correctly in all timezones', ->
+      executeFunctionInAllTimeZones ->
+        localizer.stringToDate('07/01/16').should.eql(zeroHourDate)
 
-  it 'stringToDate: should return an invalid date object when passed an incomplete date in all timezones', ->
-    executeFunctionInAllTimeZones ->
+    it 'returns an invalid date object when passed an incomplete date', ->
       localizer.stringToDate('07/01').should.eql(invalidDate)
 
-  it 'stringToDate: should return an invalid date object when the day is invalid', ->
-    localizer.stringToDate('/01/16').should.eql(invalidDate)
-    localizer.stringToDate('999/01/16').should.eql(invalidDate)
+    it 'returns an invalid date object when passed an incomplete date in all timezones', ->
+      executeFunctionInAllTimeZones ->
+        localizer.stringToDate('07/01').should.eql(invalidDate)
 
-  it 'stringToDate: should return an invalid date object when the day is invalid in all timezones', ->
-    executeFunctionInAllTimeZones ->
+    it 'returns an invalid date object when the day is invalid', ->
       localizer.stringToDate('/01/16').should.eql(invalidDate)
       localizer.stringToDate('999/01/16').should.eql(invalidDate)
 
-  it 'stringToDate: should return an invalid date object when the month is invalid', ->
-    localizer.stringToDate('07//16').should.eql(invalidDate)
-    localizer.stringToDate('07/999/16').should.eql(invalidDate)
+    it 'returns an invalid date object when the day is invalid in all timezones', ->
+      executeFunctionInAllTimeZones ->
+        localizer.stringToDate('/01/16').should.eql(invalidDate)
+        localizer.stringToDate('999/01/16').should.eql(invalidDate)
 
-  it 'stringToDate: should return an invalid date object when the month is invalid in all timezones', ->
-    executeFunctionInAllTimeZones ->
+    it 'returns an invalid date object when the month is invalid', ->
       localizer.stringToDate('07//16').should.eql(invalidDate)
       localizer.stringToDate('07/999/16').should.eql(invalidDate)
 
-  it 'stringToDate: should return an invalid date object when the year is invalid', ->
-    localizer.stringToDate('07/01/').should.eql(invalidDate)
-    localizer.stringToDate('07/01/99999').should.eql(invalidDate)
+    it 'returns an invalid date object when the month is invalid in all timezones', ->
+      executeFunctionInAllTimeZones ->
+        localizer.stringToDate('07//16').should.eql(invalidDate)
+        localizer.stringToDate('07/999/16').should.eql(invalidDate)
 
-  it 'stringToDate: should return an invalid date object when the year is invalid in all timezones', ->
-    executeFunctionInAllTimeZones ->
+    it 'returns an invalid date object when the year is invalid', ->
       localizer.stringToDate('07/01/').should.eql(invalidDate)
       localizer.stringToDate('07/01/99999').should.eql(invalidDate)
+
+    it 'returns an invalid date object when the year is invalid in all timezones', ->
+      executeFunctionInAllTimeZones ->
+        localizer.stringToDate('07/01/').should.eql(invalidDate)
+        localizer.stringToDate('07/01/99999').should.eql(invalidDate)
+
+
+  describe 'locale', ->
+    it 'returns the preferences locale by default', ->
+      localizer.locale().should.equal(hx.preferences.locale())
+
+    describe 'when setting an invalid locale', ->
+      beforeEach ->
+        localizer.locale('bob')
+
+      it 'shows a console warning', ->
+        hx.consoleWarning.should.have.been.called.with('bob is not a valid locale. If you think the locale should be added to the list contact the maintainers of hexagon')
+
+      it 'does not update the timezone', ->
+        localizer.timezone().should.equal(hx.preferences.timezone())
+
+    describe 'when changing preferences locale', ->
+      localeSpy = undefined
+      beforeEach ->
+        localeSpy = chai.spy()
+        localizer.on 'localechange', localeSpy
+        hx.preferences.locale('fy')
+
+      it 'fires the localechange event', ->
+        localeSpy.should.have.been.called.with({ cause: 'api', value: 'fy' })
+
+    describe 'when changing preferences locale with custom instance locale', ->
+      localeSpy = undefined
+      beforeEach ->
+        localeSpy = chai.spy()
+        localizer.locale('af')
+        localizer.on 'localechange', localeSpy
+        hx.preferences.locale('fy')
+
+      it 'does not fire the localechange event', ->
+        localeSpy.should.not.have.been.called()
+
+      describe 'and un-setting the instance locale', ->
+        beforeEach ->
+          localeSpy = chai.spy()
+          localizer.on 'localechange', localeSpy
+          localizer.locale(undefined)
+
+        it 'fires the localechange event', ->
+          localeSpy.should.have.been.called.with({ cause: 'api', value: hx.preferences.locale() })
+
+
+
+  describe 'timezone', ->
+    it 'returns the preferences timezone by default', ->
+      localizer.timezone().should.equal(hx.preferences.timezone())
+
+    describe 'when setting an invalid timezone', ->
+      beforeEach ->
+        localizer.timezone('bob')
+
+      it 'shows a console warning', ->
+        hx.consoleWarning.should.have.been.called.with('bob is not a valid timezone')
+
+      it 'does not update the timezone', ->
+        localizer.timezone().should.equal(hx.preferences.timezone())
+
+    describe 'when changing preferences timezone', ->
+      timezoneSpy = undefined
+      beforeEach ->
+        timezoneSpy = chai.spy()
+        localizer.on 'timezonechange', timezoneSpy
+        hx.preferences.timezone('UTC+09:30')
+
+      it 'fires the timezonechange event', ->
+        timezoneSpy.should.have.been.called.with({ cause: 'api', value: 'UTC+09:30' })
+
+    describe 'when changing preferences timezone with custom instance timezone', ->
+      timezoneSpy = undefined
+      beforeEach ->
+        timezoneSpy = chai.spy()
+        localizer.timezone('UTC+08:30')
+        localizer.on 'timezonechange', timezoneSpy
+        hx.preferences.timezone('UTC+09:30')
+
+      it 'does not fire the timezonechange event', ->
+        timezoneSpy.should.not.have.been.called()
+
+      describe 'and un-setting the instance timezone', ->
+        beforeEach ->
+          timezoneSpy = chai.spy()
+          localizer.on 'timezonechange', timezoneSpy
+          localizer.timezone(undefined)
+
+        it 'fires the timezonechange event', ->
+          timezoneSpy.should.have.been.called.with({ cause: 'api', value: hx.preferences.timezone() })
+
+

--- a/modules/date-picker/main/index.coffee
+++ b/modules/date-picker/main/index.coffee
@@ -359,16 +359,15 @@ class DatePicker extends hx.EventEmitter
       mode: @options.defaultView
       startDate: new Date
       endDate: new Date
-      uniqueId: hx.randomId()
     }
 
-    hx.preferences.on 'localechange', 'hx.date-picker-' + _.uniqueId, => updateDatepicker this, true
-    hx.preferences.on 'timezonechange', 'hx.date-picker-' + _.uniqueId, => updateDatepicker this, true
+    @localizer = hx.dateTimeLocalizer()
+    @localizer.on 'localechange', 'hx.date-picker', => updateDatepicker this, true
+    @localizer.on 'timezonechange', 'hx.date-picker', => updateDatepicker this, true
 
     _.startDate.setHours(0, 0, 0, 0)
     _.endDate.setHours(0, 0, 0, 0)
 
-    @localizer = hx.dateTimeLocalizer()
 
     @selection = hx.select(@selector).classed('hx-date-picker', true)
 
@@ -695,12 +694,11 @@ class DatePicker extends hx.EventEmitter
       _.validRange
 
   locale: (locale) ->
-    hx.deprecatedWarning 'hx.DatePicker::locale is deprecated. Use hx.preferences.locale instead.'
     if arguments.length > 0
-      hx.preferences.locale locale
+      @localizer.locale(locale)
       this
     else
-      hx.preferences.locale()
+      @localizer.locale()
 
 hx.datePicker = (options) ->
   selection = hx.detached('div')

--- a/modules/date-time-picker/main/index.coffee
+++ b/modules/date-time-picker/main/index.coffee
@@ -25,12 +25,6 @@ class DateTimePicker extends hx.EventEmitter
     @datePicker = new hx.DatePicker(dtNode, @options.datePickerOptions)
     @timePicker = new hx.TimePicker(tpNode, @options.timePickerOptions)
 
-    @_ = {
-      uniqueId: hx.randomId()
-    }
-
-    hx.preferences.on 'timezonechange', 'hx.date-time-picker-' + @_.uniqueId, -> updateDatePicker()
-
     @datePicker.pipe(this, 'date', ['show', 'hide'])
     @timePicker.pipe(this, 'time', ['show', 'hide'])
 
@@ -103,13 +97,19 @@ class DateTimePicker extends hx.EventEmitter
   getScreenTime: -> @timePicker.getScreenTime()
 
   locale: (locale) ->
-    hx.deprecatedWarning 'hx.DateTimePicker::locale is deprecated. Please use hx.preferences.locale.'
     if arguments.length > 0
-      hx.preferences.locale locale
+      @datePicker.localizer.locale(locale)
+      @timePicker.localizer.locale(locale)
       this
     else
-      hx.preferences.locale()
+      @datePicker.localizer.locale()
 
+  timezone: (timezone) ->
+    if arguments.length > 0
+      @timePicker.localizer.timezone(timezone)
+      this
+    else
+      @timePicker.localizer.timezone()
 
   disabled: (disable) ->
     dpDisabled = @datePicker.disabled(disable)

--- a/modules/preferences/main/index.coffee
+++ b/modules/preferences/main/index.coffee
@@ -241,7 +241,7 @@ class Preferences extends hx.EventEmitter
 
   timezone: (timezone) ->
     if arguments.length > 0
-      if hx.isString(timezone) and @_.supportedTimezones.indexOf(timezone) isnt -1
+      if @timezoneIsSupported(timezone)
         if @_.preferences['timezone'] isnt timezone
           @_.preferences['timezone'] = timezone
           @emit('timezonechange', timezone)
@@ -255,7 +255,8 @@ class Preferences extends hx.EventEmitter
   locale: (locale) ->
     if arguments.length > 0
       # check that the locale being set is supported
-      if hx.isString(locale) and (localeObject = lookupLocale(locale))
+      if @localeIsSupported(locale)
+        localeObject = lookupLocale(locale)
         if @_.preferences['locale'] isnt localeObject.value
           @_.preferences['locale'] = localeObject.value
 
@@ -283,8 +284,17 @@ class Preferences extends hx.EventEmitter
   supportedTimezones: option 'supportedTimezones'
   timezoneOffsetLookup: option 'timezoneOffsetLookup'
 
-  applyTimezoneOffset: (date, offset) ->
-    offset ?= @_.timezoneOffsetLookup(@timezone(), date.getTime()) || 0
+  timezoneIsSupported: (timezone) ->
+    hx.isString(timezone) and @_.supportedTimezones.indexOf(timezone) isnt -1
+
+  localeIsSupported: (locale) ->
+    hx.isString(locale) and lookupLocale(locale)
+
+  applyTimezoneOffset: (date, timezoneOrOffset) ->
+    offset =  if isNaN(timezoneOrOffset)
+      @_.timezoneOffsetLookup(timezoneOrOffset || @timezone(), date.getTime()) || 0
+    else
+      offset || @_.timezoneOffsetLookup(@timezone(), date.getTime()) || 0
     utc = date.getTime() + (date.getTimezoneOffset() * 60000)
     new Date(utc + offset * 60 * 60 * 1000)
 

--- a/modules/preferences/main/index.coffee
+++ b/modules/preferences/main/index.coffee
@@ -241,7 +241,7 @@ class Preferences extends hx.EventEmitter
 
   timezone: (timezone) ->
     if arguments.length > 0
-      if @timezoneIsSupported(timezone)
+      if @isTimezoneSupported(timezone)
         if @_.preferences['timezone'] isnt timezone
           @_.preferences['timezone'] = timezone
           @emit('timezonechange', timezone)
@@ -255,7 +255,7 @@ class Preferences extends hx.EventEmitter
   locale: (locale) ->
     if arguments.length > 0
       # check that the locale being set is supported
-      if @localeIsSupported(locale)
+      if @isLocaleSupported(locale)
         localeObject = lookupLocale(locale)
         if @_.preferences['locale'] isnt localeObject.value
           @_.preferences['locale'] = localeObject.value
@@ -284,10 +284,10 @@ class Preferences extends hx.EventEmitter
   supportedTimezones: option 'supportedTimezones'
   timezoneOffsetLookup: option 'timezoneOffsetLookup'
 
-  timezoneIsSupported: (timezone) ->
+  isTimezoneSupported: (timezone) ->
     hx.isString(timezone) and @_.supportedTimezones.indexOf(timezone) isnt -1
 
-  localeIsSupported: (locale) ->
+  isLocaleSupported: (locale) ->
     hx.isString(locale) and lookupLocale(locale)
 
   applyTimezoneOffset: (date, timezoneOrOffset) ->

--- a/modules/time-picker/main/index.coffee
+++ b/modules/time-picker/main/index.coffee
@@ -42,13 +42,11 @@ class TimePicker extends hx.EventEmitter
 
     _ = @_ = {
       disabled: @options.disabled
-      uniqueId: hx.randomId()
     }
 
-    hx.preferences.on 'localechange', 'hx.time-picker-' + _.uniqueId, => updateTimePicker this, true
-    hx.preferences.on 'timezonechange', 'hx.time-picker-' + _.uniqueId, => updateTimePicker this, true
-
-    _.localizer = hx.dateTimeLocalizer()
+    @localizer = hx.dateTimeLocalizer()
+    @localizer.on 'localechange', 'hx.time-picker', => updateTimePicker this, true
+    @localizer.on 'timezonechange', 'hx.time-picker', => updateTimePicker this, true
 
     _.selectedDate = new Date
     _.selectedDate.setMilliseconds(0)
@@ -76,7 +74,7 @@ class TimePicker extends hx.EventEmitter
         timeout = setTimeout =>
           time = event.target.value.split(':')
           time[2] ?= 0
-          if _.localizer.checkTime(time)
+          if @localizer.checkTime(time)
             @hour(time[0])
             @minute(time[1])
             @second(time[2] or 0)
@@ -172,15 +170,21 @@ class TimePicker extends hx.EventEmitter
     else
       _.selectedDate.getSeconds()
 
-  getScreenTime: -> @_.localizer.time(@date(), @options.showSeconds)
+  getScreenTime: -> @localizer.time(@date(), @options.showSeconds)
 
   locale: (locale) ->
-    hx.deprecatedWarning 'hx.TimePicker::locale is deprecated. Use hx.preferences.locale instead.'
     if arguments.length > 0
-      hx.preferences.locale locale
+      @localizer.locale(locale)
       this
     else
-      hx.preferences.locale()
+      @localizer.locale()
+
+  timezone: (timezone) ->
+    if arguments.length > 0
+      @localizer.timezone(timezone)
+      this
+    else
+      @localizer.timezone()
 
   disabled: (disable) ->
     _ = @_


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above in the following format -->
<!--- #404: resolved issue with data table -->

## Description
<!--- Describe your changes in detail -->
Un-deprecated the `locale` methods for Date, Time and DateTime pickers and added per-instance locale/timezone support to the date time localizer with fall back to use the `hx.preferences` object

Added `timezone` setter/getter to Time/DateTime picker 

Also added methods for checking validity of locales/timezones to the `hx.preferences` object

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Resolves #404) -->
Resolves #468 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added some tests and updated the existing tests

## Screenshots
De-deprecation message:

![screen shot 2018-07-27 at 10 08 02](https://user-images.githubusercontent.com/3194349/43312388-07b52220-9185-11e8-8a31-315243d12e34.png)

Will find/replace `nextReleaseVersion` when merging


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document.
- [x] All my changes are covered by tests.
- [x] This request is ready to review and merge
