### PR TITLE
#511 fix(autocomplete-picker): Pass the useCache option through

### DIFF
--- a/docs/content/docs/autocomplete-picker/api/AutocompletePicker/options/useCache.um
+++ b/docs/content/docs/autocomplete-picker/api/AutocompletePicker/options/useCache.um
@@ -1,6 +1,10 @@
 @property useCache [Boolean]
+  @bugfix nextReleaseVersion
+    @description
+      Resolved an issue where this value was ignored
+
   @description
     Determines whether the autocomplete should attempt to cache results. This
-    can be set to @code[false] non-static datasets or when using external
+    can be set to @code[false] for non-static datasets or when using external
     matching
   @default: true

--- a/modules/autocomplete-picker/main/index.coffee
+++ b/modules/autocomplete-picker/main/index.coffee
@@ -85,6 +85,7 @@ class AutocompletePicker extends hx.EventEmitter
       showOtherResults: resolvedOptions.showOtherResults
       trimTrailingSpaces: resolvedOptions.trimTrailingSpaces
       valueLookup: resolvedOptions.valueLookup
+      useCache: resolvedOptions.useCache
 
     feed = new hx.AutocompleteFeed(feedOptions)
 

--- a/modules/autocomplete-picker/test/spec.coffee
+++ b/modules/autocomplete-picker/test/spec.coffee
@@ -288,7 +288,9 @@ describe 'autocomplete-picker', ->
       ap._.selection.select('.hx-autocomplete-picker-text').text().should.equal(hx.userFacingText('autocompletePicker', 'chooseValue'))
       should.not.exist(ap.value())
 
-
+  it 'should pass the "useCache" option to the autocomplete feed', ->
+    testClosedAutocomplete trivialItems, { useCache: false }, (ap) ->
+      ap._.feed._.options.useCache.should.equal(false)
 
   describe 'api', ->
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above in the following format -->
<!--- #404: resolved issue with data table -->

## Description
<!--- Describe your changes in detail -->
Passed the `useCache` property to the underlying autocomplete feed so that the option is not ignored.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Resolves #404) -->
Resolves #511

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added regression test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document.
- [x] All my changes are covered by tests.
- [x] This request is ready to review and merge
