### PR TITLE
feat(user-facing-text): Add new parameter replacement functionality

### DIFF
--- a/docs/content/docs/user-facing-text/api/auto.um
+++ b/docs/content/docs/user-facing-text/api/auto.um
@@ -36,6 +36,13 @@
       The object with module/key objects to set.
 
 @function hx.userFacingText
+  @updated nextReleaseVersion
+    @description
+      This function will now show a console warning when it returns a string with a @code[$param] in.
+
+      Call with @code[hx.userFacingText(module, key, parameters)] to replace the parameters immediately or
+      call @code[hx.userFacingText(module, key, true)] if you need to retain the current functionality and hide the warning.
+
   @description
     Gets the text for a module key
 
@@ -47,6 +54,12 @@
     @description
       The key to get text for
 
+  @arg? parseLater [Boolean]
+    @description
+      Set to true to parse parameters with @code[$param]s that you are parsing at a later point in the code
+
+    @default: @code[false]
+
   @returns [String]
     @description
       The currently set text
@@ -54,6 +67,13 @@
 @function hx.userFacingText
   @description
     Sets the text for a module key
+
+  @extra
+    @@codeblock js
+      hx.userFacingText('something', 'value', 'the value')
+
+      hx.userFacingText('something', 'value')
+      // => 'the value'
 
   @arg module [String]
     @description
@@ -67,8 +87,218 @@
     @description
       The text to set
 
+
+@function hx.userFacingText
+  @updated nextReleaseVersion
+    @description
+      Added a new function for getting the user facing text with parameters
+
+  @extra
+    @@codeblock js
+      hx.userFacingText({
+        myModule: {
+          helloUser: 'Hello $user!',
+        },
+      })
+
+      hx.userFacingText('myModule', 'helloUser', { user: 'Bob' })
+      // => Hello Bob!
+
+  @description
+    Gets the text for a module key with parameter replacement.
+
+    Uses @code[hx.userFacingText.format(string, parameters)] and allows only @code[$param] style parameters.
+
+  @arg module [String]
+    @description
+      The module to get text from
+
+  @arg key [String]
+    @description
+      The key to get text for
+
+  @arg parameters [Object]
+    @description
+      The parameter object with keys to inject into the string.
+
+    @default: @code[false]
+
+  @returns [String]
+    @description
+      The currently set text
+
+
+@function hx.userFacingText.format
+  @added nextReleaseVersion
+    @description
+      Expose the function used in Hexagon to format strings with parameters
+
+  @extra
+    @@codeblock js
+      hx.userFacingText.format('Hello $name!', { name: 'Bob' })
+      // => Hello Bob!
+
+    @h4: Replace based on array arguments
+    @@codeblock js
+      function arrayReplacer (str, key, array) {
+        return str.replace(new RegExp("\\\{#{key}\\\}", 'g'), array[key])
+      }
+      hx.userFacingText.format('{0} {1}', ['A', 'B'], arrayReplacer)
+      // => 'A B'
+
+    @h4: Use rest/spread arguments to mimic other formatting libraries
+    @@codeblock js
+      function arrayReplacer (str, key, array) {
+        return str.replace(new RegExp("\\\{#{key}\\\}", 'g'), array[key])
+      }
+      function replaceNumericArgs(string, thingsToReplace...) {
+        return hx.userFacingText.format(text, thingsToReplace, arrayReplacer)
+      }
+      replaceNumericArgs('{0} {1} {2}', 'A', 'B', 'C')
+      // => 'A B C'
+
+  @arg string [String]
+    @description
+      The string to format. By default, this should be a string with @code[$param] values to replace.
+
+
+  @arg parameters [Object]
+    @description
+      The parameter object with keys to inject into the string.
+
+      By default this expects a plain object with string/number key value pairs however a custom replacer can be used to allow other things to be used (e.g. an array)
+
+
+  @arg? replacer [Function]
+    @description
+      An optional replacer function that is run for every key in the parameters.
+
+      @code[format] uses @code[Object.keys(parameters)] and then reduces over the string with this function to produce the final parsed string.
+
+    @arg string [String]
+      @description
+        The string that is being reduced over to find and replace parameters
+
+    @arg key [String]
+      @description
+        The current param key
+
+    @arg parameters [Object]
+      @description
+        The parameters object as passed in to @code[format]
+
+    @returns String
+      @description
+        The replaced string
+
+    @default
+      @@codeblock js
+        // Replaces $key with parameters[key]
+        function (str, key, parameters) {
+          return str.replace(new RegExp("\\\$#{key}", 'g'), parameters[key])
+        }
+
+
 @function hx.userFacingText.defaults
+  @description
+    Gets the set of values that were first set in the user facing text before any changes or updates were applied to the user facing text.
+
+  @extra
+    @@codeblock js
+      textFirst = {
+        module: {
+          key1: 'value1orig',
+          key2: 'value2orig',
+          key4: 'value4orig'
+        }
+      }
+
+      textSecond = {
+        module: {
+          key1: 'value1changed',
+          key3: 'value3orig',
+          key4: 'value4changed',
+        }
+        otherModule: {
+          key: 'valueorig',
+        }
+      }
+      userFacingText(textFirst)
+      userFacingText(textSecond)
+
+      userFacingText()
+      // => {
+      //   module: {
+      //     key1: 'value1changed',
+      //     key2: 'value2orig',
+      //     key3: 'value3orig',
+      //     key4: 'value4changed',
+      //   },
+      //   otherModule: {
+      //     key: 'valueorig'
+      //   }
+      // }
+
+      userFacingText.defaults()
+      // => {
+      //   module: {
+      //     key1: 'value1orig',
+      //     key2: 'value2orig',
+      //     key3: 'value3orig',
+      //     key4: 'value4orig',
+      //   },
+      //   otherModule: {
+      //     key: 'valueorig'
+      //   }
+      // }
+
+
   @returns [Object]
     @description
       The initial value set for the userFacingText object.
 
+@function hx.userFacingText.toMultilineSelection
+  @added nextReleaseVersion
+    @description
+      Added a utility for converting a text string with @code[\n] characters into
+      a selection containing @code[span] elements separated by @code[br] elements
+
+  @extra
+    @example
+      @@html
+        <h4>Basic Example</h4>
+        <div id="toMultiline-example-1"></div>
+        <h4>Paragraph Example</h4>
+        <div id="toMultiline-example-2"></div>
+      @@js
+        const stringWithMultiline = 'First Line\nSecond Line\nThird Line';
+
+        hx.select('#toMultiline-example-1').add(hx.userFacingText.toMultilineSelection(stringWithMultiline))
+
+        hx.select('#toMultiline-example-2').add(hx.userFacingText.toMultilineSelection(stringWithMultiline, 'p', true))
+
+  @description
+    A utility for converting a text string with @code[\n] characters into
+    a selection containing text elements separated by @code[br] elements.
+
+    The element tag can be configured, as well as the presence of the @code[br] tag.
+
+  @arg stringToSplit [String]
+    @description
+      The string to split on @code[\n] characters.
+
+  @arg? textElement [String]
+    @description
+      The type of element to wrap each line of text with
+
+    @default: @code['span']
+
+  @arg? dontAddBreak [Boolean]
+    @description
+      Set to true to remove the @code[br] elements from the selection
+
+    @default: @code[false]
+
+  @returns Selection
+    @description
+      A selection containing the string split into multiple elements joined by @code[br] tags.

--- a/docs/content/docs/user-facing-text/api/auto.um
+++ b/docs/content/docs/user-facing-text/api/auto.um
@@ -65,8 +65,37 @@
       The currently set text
 
 @function hx.userFacingText
+  @updated nextReleaseVersion
+    @description
+      Updated the value argument to allow an array to be set, allowing plurals.
+
+      @@codeblock js
+        hx.userFacingText('example', 'plural-key', [
+          [null, 0, 'Value Zero'],
+          [1, 1, 'Value Singular'],
+          [2, 2, 'Value Two'],
+          [3, null, 'Value $n']
+        ])
+
+        hx.userFacingText('example', 'plural-key')
+        hx.userFacingText('example', 'plural-key', { n: 1 })
+        // => 'Value Singular'
+
+        hx.userFacingText('example', 'plural-key', { n: 0 })
+        // => 'Value Zero'
+
+        hx.userFacingText('example', 'plural-key', { n: 2 })
+        // => 'Value Two'
+
+        hx.userFacingText('example', 'plural-key', { n: 100 })
+        // => 'Value 100'
+
   @description
-    Sets the text for a module key
+    Sets the text for a module key.
+
+    When using a plurals array, the @code[$n] parameter is used to indicate how many of the value are being used.
+
+    If the @code[$n] parameter is not provided when getting the value, it defaults to 1.
 
   @extra
     @@codeblock js
@@ -75,17 +104,60 @@
       hx.userFacingText('something', 'value')
       // => 'the value'
 
+
+      // Plurals use the `$n` parameter. This defaults to 1 if not provided.
+      hx.userFacingText('example', 'plural-key', [
+        [null, 0, 'Value Zero'],
+        [1, 1, 'Value Singular'],
+        [2, 2, 'Value Two'],
+        [3, null, 'Value $n']
+      ])
+
+      hx.userFacingText('example', 'plural-key')
+      hx.userFacingText('example', 'plural-key', { n: 1 })
+      // => 'Value Singular'
+
+      hx.userFacingText('example', 'plural-key', { n: 0 })
+      // => 'Value Zero'
+
+      hx.userFacingText('example', 'plural-key', { n: 2 })
+      // => 'Value Two'
+
+      hx.userFacingText('example', 'plural-key', { n: 100 })
+      // => 'Value 100'
+
   @arg module [String]
     @description
       The module to set text for
 
   @arg key [String]
     @description
-      The key to set text for
+      The key to set text for.
 
-  @arg value [String]
+  @arg value [String/Array]
     @description
       The text to set
+
+
+      When using an array the format is an array of arrays
+      @@codeblock js
+        [
+          [min, max, string]
+        ]
+
+    @extra
+      @property min [Number/Null]
+        @description
+          The minimum value of @code[$n] that will show this string. When using @code[null], this is treated as 'everything below max'.
+
+      @property max [Number/Null]
+        @description
+          The maximum value of @code[$n] that will show this string. When using @code[null], this is treated as 'everything above min'.
+
+      @property string [String]
+        @description
+          The string to display when @code[$n] is between min/max.
+
 
 
 @function hx.userFacingText

--- a/docs/content/docs/user-facing-text/examples/auto.um
+++ b/docs/content/docs/user-facing-text/examples/auto.um
@@ -23,3 +23,82 @@
       }
       hx.userFacingText(text)
 
+@version nextReleaseVersion
+  @examples
+    @@codeblock js
+      // Get all currently set values
+      hx.userFacingText()
+
+      // Get all values that were first set
+      hx.userFacingText.defaults()
+
+      // Set multiple values
+      var text = {
+        form: {
+          missingValue: 'Value Missing'
+        },
+        yourComponentName: {
+          yourKeyValue: 'Some Text'
+        }
+      }
+      hx.userFacingText(text)
+
+      // Get and set inbuilt values:
+      hx.userFacingText('form', 'missingValue') // Get the text for the 'form' module and 'missingValue' key
+      hx.userFacingText('form', 'missingValue', 'Value Missing') // Set the text
+
+      // Get and set custom values
+      hx.userFacingText('yourComponentName', 'yourKeyValue', 'Some Text') // Set a custom user facing text
+      hx.userFacingText('yourComponentName', 'yourKeyValue') // Returns: "Some Text"
+
+
+    @example
+      @@html
+        <h4>Main Page - <span id="currentVersion"></span></h4>
+        <h4>Main Page - <span id="currentVersion-noparse"></span></h4>
+        <h4>Main Page - <span id="currentVersion-arrayparam"></span></h4>
+        <div id="introduction"></div>
+
+        <button id="confirmBtn" class="hx-btn"></button>
+        <button id="cancelBtn" class="hx-btn"></button>
+
+      @@js
+        // Translation text is two-levels deep
+        const myText = {
+          buttons: {
+            confirm: 'Confirm',
+          },
+          homePage: {
+            introduction: 'This is an introduction.\nIt contains multiple lines',
+            version: 'Current version: $version',
+            versionCustom: 'Current version: {0}',
+          },
+        }
+
+        // Set with an object
+        hx.userFacingText(myText)
+
+        // Set with a specific key
+        hx.userFacingText('buttons', 'cancel', 'Cancel')
+
+        // Use keys
+        hx.select('#confirmBtn').text(hx.userFacingText('buttons', 'confirm'))
+        hx.select('#cancelBtn').text(hx.userFacingText('buttons', 'cancel'))
+
+        // Use multiline strings in selections
+        hx.select('#introduction').add(hx.userFacingText.toMultilineSelection(hx.userFacingText('homePage', 'introduction')))
+
+        // Inject parameters
+        hx.select('#currentVersion').text(hx.userFacingText('homePage', 'version', { version: '10.10.10' }))
+
+        // Parse parameters after creation
+        const customVersionText = hx.userFacingText('homePage', 'version', true)
+        hx.select('#currentVersion-noparse').text(hx.userFacingText.format(customVersionText, { version: '1.2.3' }))
+
+        // Custom param replacement
+        const customText = hx.userFacingText('homePage', 'versionCustom')
+        const arrayReplacer = (str, key, array) => str.replace(new RegExp(`\\\{${key}\\\}`, 'g'), array[key]);
+        hx.select('#currentVersion-arrayparam').text(hx.userFacingText.format(customText, ['10.11.12'], arrayReplacer));
+
+
+

--- a/docs/content/docs/user-facing-text/examples/auto.um
+++ b/docs/content/docs/user-facing-text/examples/auto.um
@@ -52,6 +52,32 @@
       hx.userFacingText('yourComponentName', 'yourKeyValue') // Returns: "Some Text"
 
 
+      // Plurals use the `$n` parameter. This defaults to 1 if not provided.
+      hx.userFacingText('example', 'plural-key', [
+        [null, 0, 'Value Zero'],
+        [1, 1, 'Value Singular'],
+        [2, 2, 'Value Two'],
+        [3, null, 'Value $n']
+      ])
+
+      hx.userFacingText('example', 'plural-key')
+      hx.userFacingText('example', 'plural-key', { n: 0 })
+      // => 'Value Singular'
+
+      hx.userFacingText('example', 'plural-key', { n: 0 })
+      // => 'Value Zero'
+
+      hx.userFacingText('example', 'plural-key', { n: 2 })
+      // => 'Value Two'
+
+      hx.userFacingText('example', 'plural-key', { n: 100 })
+      // => 'Value 100'
+
+      // The following are equivalent:
+      hx.userFacingText('form', 'missingValue', 'Value Missing') // Set the text
+      hx.userFacingText('form', 'missingValue', [[null, null, 'Value Missing']) // Set the text
+
+
     @example
       @@html
         <h4>Main Page - <span id="currentVersion"></span></h4>

--- a/modules/autocomplete/main/index.coffee
+++ b/modules/autocomplete/main/index.coffee
@@ -3,7 +3,8 @@ hx.userFacingText({
     loading: 'Loading...',
     noResultsFound: 'No results found',
     otherResults: 'Other Results',
-    pleaseEnterMinCharacters: 'Please enter $minLength or more characters'
+    pleaseEnterMinCharacters: 'Please enter $minLength or more characters',
+    minCharacters: 'Min length $minLength characters',
   }
 })
 
@@ -132,7 +133,7 @@ buildAutoComplete = (searchTerm, fromCallback, loading) ->
     if not filteredData?
       message.text = @options.loadingMessage
     else if searchTerm.length < @options.minLength
-      message.text = hx.userFacingText.format(@options.pleaseEnterMinCharactersMessage, { minLength: options.minLength })
+      message.text = hx.userFacingText.format(@options.pleaseEnterMinCharactersMessage, { minLength: @options.minLength })
     else if (searchTerm.length > 0 or @options.showAll) and filteredData.length is 0
       if @options.trimTrailingSpaces and _.input.value().lastIndexOf(' ') is _.input.value().length - 1
         trimAndReload = true
@@ -197,6 +198,7 @@ class AutoComplete extends hx.EventEmitter
         noResultsMessage: hx.userFacingText('autoComplete', 'noResultsFound')
         otherResultsMessage: hx.userFacingText('autoComplete', 'otherResults')
         pleaseEnterMinCharactersMessage: hx.userFacingText('autoComplete', 'pleaseEnterMinCharacters', true)
+        minCharactersMessage: hx.userFacingText('autoComplete', 'minCharacters', true)
       }, opts
 
       @_ = _ = {}
@@ -233,7 +235,7 @@ class AutoComplete extends hx.EventEmitter
         (elem, item) -> hx.select(elem).text(item)
 
       @options.placeholder ?= if @options.minLength > 0
-        "Min length #{@options.minLength} characters"
+        hx.userFacingText.format(@options.minCharactersMessage, { minLength: @options.minLength })
 
       # create input and menu objects
       input = hx.select @selector

--- a/modules/autocomplete/main/index.coffee
+++ b/modules/autocomplete/main/index.coffee
@@ -132,7 +132,7 @@ buildAutoComplete = (searchTerm, fromCallback, loading) ->
     if not filteredData?
       message.text = @options.loadingMessage
     else if searchTerm.length < @options.minLength
-      message.text = @options.pleaseEnterMinCharactersMessage.replace('$minLength', @options.minLength)
+      message.text = hx.userFacingText.format(@options.pleaseEnterMinCharactersMessage, { minLength: options.minLength })
     else if (searchTerm.length > 0 or @options.showAll) and filteredData.length is 0
       if @options.trimTrailingSpaces and _.input.value().lastIndexOf(' ') is _.input.value().length - 1
         trimAndReload = true
@@ -196,7 +196,7 @@ class AutoComplete extends hx.EventEmitter
         loadingMessage: hx.userFacingText('autoComplete', 'loading')
         noResultsMessage: hx.userFacingText('autoComplete', 'noResultsFound')
         otherResultsMessage: hx.userFacingText('autoComplete', 'otherResults')
-        pleaseEnterMinCharactersMessage: hx.userFacingText('autoComplete', 'pleaseEnterMinCharacters')
+        pleaseEnterMinCharactersMessage: hx.userFacingText('autoComplete', 'pleaseEnterMinCharacters', true)
       }, opts
 
       @_ = _ = {}

--- a/modules/data-table/main/index.coffee
+++ b/modules/data-table/main/index.coffee
@@ -325,7 +325,7 @@ class DataTable extends hx.EventEmitter
       noSortText: hx.userFacingText('dataTable', 'noSort')
       rowsPerPageText: hx.userFacingText('dataTable','rowsPerPage')
       searchPlaceholder: hx.userFacingText('dataTable','search')
-      selectedRowsText: hx.userFacingText('dataTable', 'selectedRows')
+      selectedRowsText: hx.userFacingText('dataTable', 'selectedRows', true)
       sortByText: hx.userFacingText('dataTable','sortBy')
 
       addFilterText: hx.userFacingText('dataTable', 'addFilter')
@@ -940,7 +940,7 @@ class DataTable extends hx.EventEmitter
             if totalCount isnt undefined
               @_.statusBar
                 .select('.hx-data-table-status-bar-text')
-                .text(options.selectedRowsText.replace('$selected', @_.selectedRows.size).replace('$total', totalCount))
+                .text(hx.userFacingText.format(options.selectedRowsText, { selected: @_.selectedRows.size, total: totalCount }))
 
           # handles multi row selection ('select all' and shift selection)
           selectMulti = (start, end, force) =>

--- a/modules/file-input/main/index.coffee
+++ b/modules/file-input/main/index.coffee
@@ -51,7 +51,7 @@ class FileInput extends hx.EventEmitter
       buttonClass: 'hx-action'
 
       buttonText: hx.userFacingText('fileInput', 'chooseFile')
-      filesSelectedText: hx.userFacingText('fileInput', 'filesSelected')
+      filesSelectedText: hx.userFacingText('fileInput', 'filesSelected', true)
       noFilesText: hx.userFacingText('fileInput', 'noFile')
 
     resolvedOptions = hx.merge defaults, options
@@ -136,7 +136,7 @@ class FileInput extends hx.EventEmitter
           selectedFiles.append filePreview(fileMap.values()[0])
         else
           localizedLength = length.toLocaleString(hx.preferences.locale())
-          filesSelectedText = resolvedOptions.filesSelectedText.replace('$numFiles', localizedLength)
+          filesSelectedText = hx.userFacingText.format(resolvedOptions.filesSelectedText, { numFiles: localizedLength })
           selectedFiles
             .classed 'hx-btn', true
             .add hx.section().text filesSelectedText

--- a/modules/paginator/main/index.coffee
+++ b/modules/paginator/main/index.coffee
@@ -71,10 +71,10 @@ class Paginator extends hx.EventEmitter
       visibleCount: 10,
       updatePageOnSelect: true,
       paginatorAria: hx.userFacingText('paginator', 'paginatorAria'),
-      currentPageAria: hx.userFacingText('paginator', 'currentPageAria'),
-      gotoPageAria: hx.userFacingText('paginator', 'gotoPageAria'),
-      prevPageAria: hx.userFacingText('paginator', 'prevPageAria'),
-      nextPageAria: hx.userFacingText('paginator', 'nextPageAria'),
+      currentPageAria: hx.userFacingText('paginator', 'currentPageAria', true),
+      gotoPageAria: hx.userFacingText('paginator', 'gotoPageAria', true),
+      prevPageAria: hx.userFacingText('paginator', 'prevPageAria', true),
+      nextPageAria: hx.userFacingText('paginator', 'nextPageAria', true),
       prevText: hx.userFacingText('paginator', 'prev'),
       nextText: hx.userFacingText('paginator', 'next'),
       v2Features: {
@@ -230,14 +230,14 @@ class Paginator extends hx.EventEmitter
           return {
             isPrevNextButton: true,
             text: @prevText(),
-            aria: @prevPageAria().replace('$page', currentPage - 1),
+            aria: hx.userfacingText.format(@prevPageAria(), { page: currentPage - 1 }),
             onClick: () => selectPage.call(this, 'user', currentPage - 1),
           }
         if item is 'next'
           return {
             isPrevNextButton: true,
             text: @nextText(),
-            aria: @nextPageAria().replace('$page', currentPage + 1),
+            aria: hx.userfacingText.format(@nextPageAria(), { page: currentPage + 1 }),
             onClick: () => selectPage.call(this, 'user', currentPage + 1),
           }
         if item is '...'
@@ -250,7 +250,7 @@ class Paginator extends hx.EventEmitter
         aria = if selected then @currentPageAria() else @gotoPageAria()
         return {
           text: numericItem,
-          aria: aria.replace('$page', numericItem),
+          aria: hx.userfacingText.format(aria, { page: numericItem }),
           selected: selected,
           onClick: () => selectPage.call(this, 'user', numericItem)
         }

--- a/modules/paginator/main/index.coffee
+++ b/modules/paginator/main/index.coffee
@@ -230,14 +230,14 @@ class Paginator extends hx.EventEmitter
           return {
             isPrevNextButton: true,
             text: @prevText(),
-            aria: hx.userfacingText.format(@prevPageAria(), { page: currentPage - 1 }),
+            aria: hx.userFacingText.format(@prevPageAria(), { page: currentPage - 1 }),
             onClick: () => selectPage.call(this, 'user', currentPage - 1),
           }
         if item is 'next'
           return {
             isPrevNextButton: true,
             text: @nextText(),
-            aria: hx.userfacingText.format(@nextPageAria(), { page: currentPage + 1 }),
+            aria: hx.userFacingText.format(@nextPageAria(), { page: currentPage + 1 }),
             onClick: () => selectPage.call(this, 'user', currentPage + 1),
           }
         if item is '...'
@@ -250,7 +250,7 @@ class Paginator extends hx.EventEmitter
         aria = if selected then @currentPageAria() else @gotoPageAria()
         return {
           text: numericItem,
-          aria: hx.userfacingText.format(aria, { page: numericItem }),
+          aria: hx.userFacingText.format(aria, { page: numericItem }),
           selected: selected,
           onClick: () => selectPage.call(this, 'user', numericItem)
         }

--- a/modules/user-facing-text/main/index.coffee
+++ b/modules/user-facing-text/main/index.coffee
@@ -2,6 +2,8 @@ _ =
   initialValues: {}
   localisedText: {}
 
+{ detached, Selection } = hx
+
 setWholeObject = (object) ->
   # Setter - set multiple module/key values
   if hx.isPlainObject(object)
@@ -19,6 +21,16 @@ defaultReplacer = (str, key, params) -> str.replace(new RegExp("\\\$#{key}", 'g'
 format = (string, params, replacer = defaultReplacer) ->
   replaceStringValues = (str, key) => replacer(str, key, params)
   return Object.keys(params).sort().reverse().reduce(replaceStringValues, string)
+
+
+toMultilineSelection = (string, textElement = 'span', dontAddBreak) ->
+  return new Selection(string.split('\n')
+    .reduce(((prev, curr, i) -> [
+      prev...,
+      (if not dontAddBreak and i > 0 then detached('br').node() else null),
+      detached(textElement).text(curr).node()
+    ]), [])
+  )
 
 
 # Getter - get the localised text for a module/key
@@ -111,6 +123,7 @@ userFacingTextDefaults = -> hx.clone _.initialValues
 hx.userFacingText = userFacingText
 hx.userFacingText.format = format
 hx.userFacingText.defaults = userFacingTextDefaults
+hx.userFacingText.toMultilineSelection = toMultilineSelection
 
 # For tests
 hx._.userFacingText = _

--- a/modules/user-facing-text/main/index.coffee
+++ b/modules/user-facing-text/main/index.coffee
@@ -16,9 +16,9 @@ isStringWithLength = (value) -> hx.isString(value) and value.length
 
 defaultReplacer = (str, key, params) -> str.replace(new RegExp("\\\$#{key}", 'g'), params[key])
 
-replaceParams = (value, params, replacer = defaultReplacer) ->
+format = (string, params, replacer = defaultReplacer) ->
   replaceStringValues = (str, key) => replacer(str, key, params)
-  return Object.keys(params).sort().reverse().reduce(replaceStringValues, value)
+  return Object.keys(params).sort().reverse().reduce(replaceStringValues, string)
 
 
 # Getter - get the localised text for a module/key
@@ -32,9 +32,9 @@ getValue = (module, key, parseLater, params) ->
 
   if parseLater isnt true and valueToGet.match(paramRegex)
     if params
-      return replaceParams(valueToGet, params)
+      return format(valueToGet, params)
 
-    hx.consoleWarning "hx.userFacingText: Parameterised string was returned without parsing parameters: #{valueToGet}"
+    hx.consoleWarning "hx.userFacingText: Parameterised string was returned without parsing parameters: #{valueToGet}.\nCall userFacingText(module, key, parameters) to replace the parameters or userFacingText(module, key, true) if you are handling this externally."
 
   return valueToGet
 
@@ -109,7 +109,7 @@ userFacingText = ->
 userFacingTextDefaults = -> hx.clone _.initialValues
 
 hx.userFacingText = userFacingText
-hx.userFacingText.replaceParams = replaceParams
+hx.userFacingText.format = format
 hx.userFacingText.defaults = userFacingTextDefaults
 
 # For tests

--- a/modules/user-facing-text/main/index.coffee
+++ b/modules/user-facing-text/main/index.coffee
@@ -2,52 +2,114 @@ _ =
   initialValues: {}
   localisedText: {}
 
-completeGetterSetter = (object) ->
-  if arguments.length
-    # Setter - set multiple module/key values
-    if hx.isPlainObject(object)
-      for module of object
-        for key of object[module]
-          partialGetterSetter(module, key, object[module][key])
-      undefined
-    else
-      hx.consoleWarning "hx.userFacingText: Expected a plain object but was instead passed: #{object}"
+setWholeObject = (object) ->
+  # Setter - set multiple module/key values
+  if hx.isPlainObject(object)
+    for module of object
+      for key of object[module]
+        setValue(module, key, object[module][key])
   else
-    # Getter - get the entire set of localised text
-    hx.clone _.localisedText
+    hx.consoleWarning "hx.userFacingText: Expected a plain object but was instead passed: #{object}"
+  return undefined
 
-isValid = (value) -> hx.isString(value) and value.length
+isStringWithLength = (value) -> hx.isString(value) and value.length
 
-partialGetterSetter = (module, key, value) ->
-  if isValid(module) and isValid(key)
-    if isValid(value)
-      # Setter - set the localised text for a module/key
-      _.localisedText[module] ?= {}
-      _.localisedText[module][key] = value
-      _.initialValues[module] ?= {}
-      _.initialValues[module][key] ?= value
-      undefined
-    else if not value?
-      # Getter - get the localised text for a module/key
-      text = _.localisedText[module]?[key]
-      if text
-        text
-      else
-        hx.consoleWarning "hx.userFacingText: No text was found for key: #{key} in module: #{module}"
-    else
-      hx.consoleWarning "hx.userFacingText: The value provided must be a string but was passed value: #{value}"
-  else
-    hx.consoleWarning "hx.userFacingText: A module and key are expected as strings but was passed module: #{module} and key: #{key}"
+defaultReplacer = (str, key, params) -> str.replace(new RegExp("\\\$#{key}", 'g'), params[key])
 
+replaceParams = (value, params, replacer = defaultReplacer) ->
+  replaceStringValues = (str, key) => replacer(str, key, params)
+  return Object.keys(params).sort().reverse().reduce(replaceStringValues, value)
+
+
+# Getter - get the localised text for a module/key
+paramRegex = /\$\D/g
+getValue = (module, key, parseLater, params) ->
+  valueToGet = _.localisedText[module]?[key]
+
+  if not valueToGet
+    hx.consoleWarning "hx.userFacingText: No text was found for key: #{key} in module: #{module}"
+    return undefined
+
+  if parseLater isnt true and valueToGet.match(paramRegex)
+    if params
+      return replaceParams(valueToGet, params)
+
+    hx.consoleWarning "hx.userFacingText: Parameterised string was returned without parsing parameters: #{valueToGet}"
+
+  return valueToGet
+
+# Setter - set the localised text for a module/key
+setValue = (module, key, valueToSet) ->
+  if not isStringWithLength(valueToSet)
+    hx.consoleWarning "hx.userFacingText: The value provided must be a string but was passed value: #{valueToSet}"
+    return undefined
+
+  _.localisedText[module] ?= {}
+  _.localisedText[module][key] = valueToSet
+
+  _.initialValues[module] ?= {}
+  # Set the initial value, don't update it
+  _.initialValues[module][key] ?= valueToSet
+  undefined
+
+# Interface
+# interface UserFacingTextData {
+#   [module: string]: {
+#     [key: string]: value
+#   }
+# }
+#
+# API
+#
+# userFacingText() => UserFacingTextData
+#
+# userFacingText(textObject: UserFacingTextData)
+#
+#
+# userFacingText(module: string, key: string) => string
+# userFacingText(module: string, key: string, parseLater: boolean) => string // Throws a warning when parseLater = false and there is a parameter in string
+# userFacingText(module: string, key: string, parameters: { [key: string]: string }) => string
+#
+# userFacingText(module: string, key: string, value: string)
 userFacingText = ->
-  if arguments.length <= 1
-    completeGetterSetter.apply(this, arguments)
-  else
-    partialGetterSetter.apply(this, arguments)
+  if not arguments.length
+    # Get the current localised text
+    return hx.clone _.localisedText
+
+  if arguments.length is 1
+    # Set the entire localised text
+    return setWholeObject(arguments[0])
+
+  module = arguments[0]
+  key = arguments[1]
+
+  if not isStringWithLength(module) or not isStringWithLength(key)
+    hx.consoleWarning "hx.userFacingText: A module and key are expected as strings but was passed module: #{module} and key: #{key}"
+    return undefined
+
+  if arguments.length is 2
+    # Get the value for a key
+    return getValue(module, key, false)
+
+  if arguments[2] is true
+    # Get the parameterised value for a key but inject the value later
+    parseLater = arguments[2]
+    return getValue(module, key, parseLater)
+
+  if hx.isPlainObject(arguments[2])
+    # Get the parameterised value for a key with the values to inject
+    paramsToParse = arguments[2]
+    return getValue(module, key, false, paramsToParse)
+
+  # Set the value for a key
+  valueToSet = arguments[2]
+  return setValue(module, key, valueToSet)
+
 
 userFacingTextDefaults = -> hx.clone _.initialValues
 
 hx.userFacingText = userFacingText
+hx.userFacingText.replaceParams = replaceParams
 hx.userFacingText.defaults = userFacingTextDefaults
 
 # For tests

--- a/modules/user-facing-text/module.json
+++ b/modules/user-facing-text/module.json
@@ -1,5 +1,6 @@
 {
   "dependencies": [
-    "util"
+    "util",
+    "selection"
   ]
 }

--- a/modules/user-facing-text/test/spec.coffee
+++ b/modules/user-facing-text/test/spec.coffee
@@ -1,3 +1,368 @@
+describe 'user-facing-text', ->
+  userFacingText = hx.userFacingText
+  origConsoleWarning = hx.consoleWarning
+  initial = undefined
+
+  before ->
+    initial = userFacingText()
+
+  beforeEach ->
+    hx.consoleWarning = chai.spy()
+
+  afterEach ->
+    hx._.userFacingText.localisedText = {}
+    hx._.userFacingText.initialValues = {}
+    userFacingText(initial)
+    hx.consoleWarning = origConsoleWarning
+
+  describe 'userFacingText', ->
+    # Get
+    #
+    # userFacingText() => { [module: string]: { [key: string]: value }}
+    # userFacingText(module: string, key: string) => string
+    # userFacingText(module: string, key: string, parseLater = false: boolean) => string // Warning when parseLater = false and parameter in string
+    # userFacingText(module: string, key: string, parameters: { [key: string]: string }) => string // No warning
+
+    describe 'when getting values', ->
+      mockText = undefined
+      beforeEach ->
+        mockText = {
+          moduleWithPlainStrings: {
+            key1: 'value1',
+            key2: 'value2',
+          },
+          moduleWithParams: {
+            keyParam1: 'value $param1',
+            keyParam2: 'value $100',
+          },
+        }
+        userFacingText(mockText)
+
+      describe 'from the whole object', ->
+        textObject = undefined
+        beforeEach ->
+          textObject = userFacingText()
+
+        it 'returns the complete object', ->
+          textObject.should.eql(mockText)
+
+        it 'returns a clone of the complete object', ->
+          textObject.should.not.equal(mockText)
+
+      describe 'using a missing module', ->
+        value = undefined
+        beforeEach ->
+          value = userFacingText('bob', 'key1')
+
+        it 'does not return anything', ->
+          should.not.exist(value)
+
+        it 'shows a console warning', ->
+          hx.consoleWarning.should.have.been.called.with('hx.userFacingText: No text was found for key: key1 in module: bob')
+
+      describe 'using a missing key', ->
+        value = undefined
+        beforeEach ->
+          value = userFacingText('moduleWithPlainStrings', 'bob')
+
+        it 'does not return anything', ->
+          should.not.exist(value)
+
+        it 'shows a console warning', ->
+          hx.consoleWarning.should.have.been.called.with('hx.userFacingText: No text was found for key: bob in module: moduleWithPlainStrings')
+
+      describe 'with an invalid module', ->
+        value = undefined
+        beforeEach ->
+          value = userFacingText(123, 'bob')
+
+        it 'does not return anything', ->
+          should.not.exist(value)
+
+        it 'shows a console warning', ->
+          hx.consoleWarning "hx.userFacingText: A module and key are expected as strings but was passed module: 123 and key: bob"
+
+
+      describe 'with an invalid key', ->
+        value = undefined
+        beforeEach ->
+          value = userFacingText('moduleWithParams', 123)
+
+        it 'does not return anything', ->
+          should.not.exist(value)
+
+        it 'shows a console warning', ->
+          hx.consoleWarning "hx.userFacingText: A module and key are expected as strings but was passed module: moduleWithParams and key: 123"
+
+
+
+      describe 'with plaintext module key', ->
+        describe 'key1', ->
+          value = undefined
+          beforeEach ->
+            value = userFacingText('moduleWithPlainStrings', 'key1')
+
+          it 'returns the correct value', ->
+            value.should.equal('value1')
+
+          it 'does not log any warnings', ->
+            hx.consoleWarning.should.not.have.been.called()
+
+        describe 'key2', ->
+          value = undefined
+          beforeEach ->
+            value = userFacingText('moduleWithPlainStrings', 'key2')
+
+          it 'returns the correct value', ->
+            value.should.equal('value2')
+
+          it 'does not log any warnings', ->
+            hx.consoleWarning.should.not.have.been.called()
+
+      describe 'without params', ->
+        describe 'with params module key', ->
+          describe 'keyParam1', ->
+            value = undefined
+            beforeEach ->
+              value = userFacingText('moduleWithParams', 'keyParam1')
+
+            it 'returns the correct value', ->
+              value.should.equal('value $param1')
+
+            it 'logs a console warning', ->
+              hx.consoleWarning.should.have.been.called.with('hx.userFacingText: Parameterised string was returned without parsing parameters: value $param1')
+
+          describe 'without params and parseLater flag', ->
+            value = undefined
+            beforeEach ->
+              value = userFacingText('moduleWithParams', 'keyParam1', true)
+
+            it 'returns the correct value', ->
+              value.should.equal('value $param1')
+
+            it 'does not log any warnings', ->
+              hx.consoleWarning.should.not.have.been.called()
+
+          describe 'with params', ->
+            value = undefined
+            beforeEach ->
+              value = userFacingText('moduleWithParams', 'keyParam1', { param1: 'abc' })
+
+            it 'returns the correct value', ->
+              value.should.equal('value abc')
+
+            it 'does not log any warnings', ->
+              hx.consoleWarning.should.not.have.been.called()
+
+        describe 'keyParam2 - sanity check for $ currency values', ->
+          describe 'without params', ->
+            value = undefined
+            beforeEach ->
+              value = userFacingText('moduleWithParams', 'keyParam2')
+
+            it 'returns the correct value', ->
+              value.should.equal('value $100')
+
+            it 'does not log any warnings', ->
+              hx.consoleWarning.should.not.have.been.called()
+
+
+          describe 'without params and parseLater flag', ->
+            value = undefined
+            beforeEach ->
+              value = userFacingText('moduleWithParams', 'keyParam2', true)
+
+            it 'returns the correct value', ->
+              value.should.equal('value $100')
+
+            it 'does not log any warnings', ->
+              hx.consoleWarning.should.not.have.been.called()
+
+          describe 'with params', ->
+            value = undefined
+            beforeEach ->
+              value = userFacingText('moduleWithParams', 'keyParam2', { 100: 'abc' })
+
+            it 'returns the correct value', ->
+              value.should.equal('value $100')
+
+            it 'does not log any warnings', ->
+              hx.consoleWarning.should.not.have.been.called()
+
+    # Set
+    #
+    # userFacingText(module: string, key: string, value: string)
+    # userFacingText({
+    #   module: {
+    #     key: 'value'
+    #   }
+    # })
+    describe 'when setting values', ->
+      describe 'per module', ->
+        value = undefined
+        beforeEach ->
+          userFacingText('something', 'value', 'the value')
+          value = userFacingText('something', 'value')
+
+        it 'sets the value correctly', ->
+          value.should.equal('the value')
+
+      describe 'with object', ->
+        value1 = undefined
+        value2 = undefined
+
+        beforeEach ->
+          userFacingText({
+            something: {
+              key: 'the value'
+            },
+            somethingElse: {
+              key: 'the other value'
+            },
+          })
+          value1 = userFacingText('something', 'key')
+          value2 = userFacingText('somethingElse', 'key')
+
+        it 'sets the something key correctly', ->
+          value1.should.equal('the value')
+
+        it 'sets the somethingElse key correctly', ->
+          value2.should.equal('the other value')
+
+      describe 'with object and invalid values', ->
+        testObj = undefined
+        testNumber = undefined
+
+        beforeEach ->
+          testObj = { a: '123' }
+          userFacingText({
+            something: {
+              key: testNumber
+            },
+            somethingElse: {
+              key: testObj
+            },
+          })
+
+        it 'shows the correct warnings', ->
+          hx.consoleWarning.should.have.been.called.with("hx.userFacingText: The value provided must be a string but was passed value: #{testNumber}")
+
+        it 'calls a warning for an object', ->
+          hx.consoleWarning.should.have.been.called.with("hx.userFacingText: The value provided must be a string but was passed value: #{testObj}")
+
+        it 'does not update the userFacingText', ->
+          userFacingText().should.eql({})
+
+      describe 'with a non-plain object', ->
+        testObj = undefined
+        beforeEach ->
+          class Test
+            constructor: ->
+              @length = 1
+              @module1 =
+                key1: 'value'
+          testObj = new Test
+
+          userFacingText(testObj)
+
+        it 'shows a console warning', ->
+          hx.consoleWarning.should.have.been.called.with("hx.userFacingText: Expected a plain object but was instead passed: #{testObj}")
+
+        it 'does not update the userFacingText', ->
+          userFacingText().should.eql({})
+
+      describe 'with an invalid value', ->
+        testNumber = undefined
+        beforeEach ->
+          testNumber = 123
+
+          userFacingText('a', 'b', testNumber)
+
+        it 'shows a console warning', ->
+          hx.consoleWarning.should.have.been.called.with("hx.userFacingText: The value provided must be a string but was passed value: #{testNumber}")
+
+        it 'does not update the userFacingText', ->
+          userFacingText().should.eql({})
+
+  describe 'userFacingText.replaceParams', ->
+    replaceParams = hx.userFacingText.replaceParams
+
+    it 'replaces simple params', ->
+      replaceParams('XX$abcXX', { abc: 123 }).should.equal('XX123XX')
+
+    it 'replaces numeric params', ->
+      replaceParams('XXX$100XXX', { 100: 'abc'}).should.equal('XXXabcXXX')
+
+    it 'replaces numeric params when the key is a string value', ->
+      replaceParams('XXX$100XXX', { '100': 'abc'}).should.equal('XXXabcXXX')
+
+    it 'replaces multiple params', ->
+      replaceParams('$a123$b123$c123', { a: 'A', b: 'B', c: 'C'}).should.equal('A123B123C123')
+
+    it 'replaces longest params first', ->
+      replaceParams('$abcd$abc$ab$a', { a: 'A', ab: 'BB', abc: 'CCC', abcd: '123' }).should.equal('123CCCBBA')
+
+    it 'always replaces the same way', ->
+      replaceParams('$abc$abc$abc', { a: 'A', b: 'BB', c: 'CCC', abc: '123' }).should.equal('123123123')
+
+    describe 'custom replacer', ->
+      arrayReplacer = (str, key, array) -> str.replace(new RegExp("\\\{#{key}\\\}", 'g'), array[key])
+
+      it 'uses the custom replacer', ->
+        replaceParams('Hello {0}!', ['Bob'], arrayReplacer).should.equal('Hello Bob!')
+
+  describe 'userFacingText.defaults', ->
+    beforeEach ->
+      mockTextFirst = {
+        module: {
+          key1: 'value1orig',
+          key2: 'value2orig',
+          key4: 'value4orig'
+        }
+      }
+
+      mockTextSecond = {
+        module: {
+          key1: 'value1changed',
+          key3: 'value3orig',
+          key4: 'value4changed',
+        }
+        otherModule: {
+          key: 'valueorig',
+        }
+      }
+      userFacingText(mockTextFirst)
+      userFacingText(mockTextSecond)
+
+    it 'user facing text is set correctly', ->
+      userFacingText().should.eql({
+        module: {
+          key1: 'value1changed',
+          key2: 'value2orig',
+          key3: 'value3orig',
+          key4: 'value4changed',
+        },
+        otherModule: {
+          key: 'valueorig'
+        }
+      })
+
+    it 'returns the first set values', ->
+      userFacingText.defaults().should.eql({
+        module: {
+          key1: 'value1orig',
+          key2: 'value2orig',
+          key3: 'value3orig',
+          key4: 'value4orig',
+        },
+        otherModule: {
+          key: 'valueorig'
+        }
+      })
+
+
+
+
 describe 'User Facing Text', ->
   origText = hx.clone hx._.userFacingText.localisedText
   origInitialText = hx.clone hx._.userFacingText.initialValues

--- a/modules/user-facing-text/test/spec.coffee
+++ b/modules/user-facing-text/test/spec.coffee
@@ -363,7 +363,105 @@ describe 'user-facing-text', ->
         }
       })
 
+  describe 'userFacingText.toMultilineSelection', ->
+    multilineSelection = undefined
+    stringWithMultiline = 'a.\nb c d\ne'
 
+    describe 'when using the default element', ->
+      beforeEach ->
+        multilineSelection = userFacingText.toMultilineSelection(stringWithMultiline)
+
+      it 'returns a selection', ->
+        multilineSelection.should.be.an.instanceof(hx.Selection)
+
+      it 'returns a Selection with 5 items', ->
+        multilineSelection.size().should.equal(5)
+
+      it 'the first element is a <span>', ->
+        multilineSelection.node(0).tagName.should.equal('SPAN')
+
+      it 'the first element text is "a."', ->
+        multilineSelection.node(0).textContent.should.equal('a.')
+
+      it 'the second element is a <br>', ->
+        multilineSelection.node(1).tagName.should.equal('BR')
+
+      it 'the third element is a <span>', ->
+        multilineSelection.node(2).tagName.should.equal('SPAN')
+
+      it 'the third element text is is "b c d"', ->
+        multilineSelection.node(2).textContent.should.equal('b c d')
+
+      it 'the fourth element is a <br>', ->
+        multilineSelection.node(3).tagName.should.equal('BR')
+
+      it 'the fifth element is a <span>', ->
+        multilineSelection.node(4).tagName.should.equal('SPAN')
+
+      it 'the fifth element text is is "e"', ->
+        multilineSelection.node(4).textContent.should.equal('e')
+
+    describe 'when using a custom element', ->
+      beforeEach ->
+        multilineSelection = userFacingText.toMultilineSelection(stringWithMultiline, 'div')
+
+      it 'returns a selection', ->
+        multilineSelection.should.be.an.instanceof(hx.Selection)
+
+      it 'returns a Selection with 5 items', ->
+        multilineSelection.size().should.equal(5)
+
+      it 'the first element is a <div>', ->
+        multilineSelection.node(0).tagName.should.equal('DIV')
+
+      it 'the first element text is "a."', ->
+        multilineSelection.node(0).textContent.should.equal('a.')
+
+      it 'the second element is a <br>', ->
+        multilineSelection.node(1).tagName.should.equal('BR')
+
+      it 'the third element is a <div>', ->
+        multilineSelection.node(2).tagName.should.equal('DIV')
+
+      it 'the third element text is is "b c d"', ->
+        multilineSelection.node(2).textContent.should.equal('b c d')
+
+      it 'the fourth element is a <br>', ->
+        multilineSelection.node(3).tagName.should.equal('BR')
+
+      it 'the fifth element is a <div>', ->
+        multilineSelection.node(4).tagName.should.equal('DIV')
+
+      it 'the fifth element text is is "e"', ->
+        multilineSelection.node(4).textContent.should.equal('e')
+
+    describe 'when using a custom element and not inserting a BR', ->
+      beforeEach ->
+        multilineSelection = userFacingText.toMultilineSelection(stringWithMultiline, 'p', true)
+
+      it 'returns a selection', ->
+        multilineSelection.should.be.an.instanceof(hx.Selection)
+
+      it 'returns a Selection with 3 items', ->
+        multilineSelection.size().should.equal(3)
+
+      it 'the first element is a <p>', ->
+        multilineSelection.node(0).tagName.should.equal('P')
+
+      it 'the first element text is "a."', ->
+        multilineSelection.node(0).textContent.should.equal('a.')
+
+      it 'the second element is a <p>', ->
+        multilineSelection.node(1).tagName.should.equal('P')
+
+      it 'the second element text is is "b c d"', ->
+        multilineSelection.node(1).textContent.should.equal('b c d')
+
+      it 'the third element is a <p>', ->
+        multilineSelection.node(2).tagName.should.equal('P')
+
+      it 'the third element text is is "e"', ->
+        multilineSelection.node(2).textContent.should.equal('e')
 
 
 describe 'User Facing Text', ->

--- a/modules/user-facing-text/test/spec.coffee
+++ b/modules/user-facing-text/test/spec.coffee
@@ -8,12 +8,12 @@ describe 'user-facing-text', ->
 
   beforeEach ->
     hx.consoleWarning = chai.spy()
-
-  afterEach ->
     hx._.userFacingText.localisedText = {}
     hx._.userFacingText.initialValues = {}
-    userFacingText(initial)
+
+  after ->
     hx.consoleWarning = origConsoleWarning
+    userFacingText(initial)
 
   describe 'userFacingText', ->
     # Get
@@ -82,7 +82,6 @@ describe 'user-facing-text', ->
         it 'shows a console warning', ->
           hx.consoleWarning "hx.userFacingText: A module and key are expected as strings but was passed module: 123 and key: bob"
 
-
       describe 'with an invalid key', ->
         value = undefined
         beforeEach ->
@@ -93,8 +92,6 @@ describe 'user-facing-text', ->
 
         it 'shows a console warning', ->
           hx.consoleWarning "hx.userFacingText: A module and key are expected as strings but was passed module: moduleWithParams and key: 123"
-
-
 
       describe 'with plaintext module key', ->
         describe 'key1', ->
@@ -119,6 +116,7 @@ describe 'user-facing-text', ->
           it 'does not log any warnings', ->
             hx.consoleWarning.should.not.have.been.called()
 
+
       describe 'without params', ->
         describe 'with params module key', ->
           describe 'keyParam1', ->
@@ -130,7 +128,7 @@ describe 'user-facing-text', ->
               value.should.equal('value $param1')
 
             it 'logs a console warning', ->
-              hx.consoleWarning.should.have.been.called.with('hx.userFacingText: Parameterised string was returned without parsing parameters: value $param1')
+              hx.consoleWarning.should.have.been.called.with('hx.userFacingText: Parameterised string was returned without parsing parameters: value $param1.\nCall userFacingText(module, key, parameters) to replace the parameters or userFacingText(module, key, true) if you are handling this externally.')
 
           describe 'without params and parseLater flag', ->
             value = undefined
@@ -154,6 +152,7 @@ describe 'user-facing-text', ->
             it 'does not log any warnings', ->
               hx.consoleWarning.should.not.have.been.called()
 
+
         describe 'keyParam2 - sanity check for $ currency values', ->
           describe 'without params', ->
             value = undefined
@@ -165,7 +164,6 @@ describe 'user-facing-text', ->
 
             it 'does not log any warnings', ->
               hx.consoleWarning.should.not.have.been.called()
-
 
           describe 'without params and parseLater flag', ->
             value = undefined
@@ -284,32 +282,37 @@ describe 'user-facing-text', ->
         it 'does not update the userFacingText', ->
           userFacingText().should.eql({})
 
-  describe 'userFacingText.replaceParams', ->
-    replaceParams = hx.userFacingText.replaceParams
+
+  describe 'userFacingText.format', ->
+    format = hx.userFacingText.format
 
     it 'replaces simple params', ->
-      replaceParams('XX$abcXX', { abc: 123 }).should.equal('XX123XX')
+      format('XX$abcXX', { abc: 123 }).should.equal('XX123XX')
 
     it 'replaces numeric params', ->
-      replaceParams('XXX$100XXX', { 100: 'abc'}).should.equal('XXXabcXXX')
+      format('XXX$100XXX', { 100: 'abc'}).should.equal('XXXabcXXX')
 
     it 'replaces numeric params when the key is a string value', ->
-      replaceParams('XXX$100XXX', { '100': 'abc'}).should.equal('XXXabcXXX')
+      format('XXX$100XXX', { '100': 'abc'}).should.equal('XXXabcXXX')
 
     it 'replaces multiple params', ->
-      replaceParams('$a123$b123$c123', { a: 'A', b: 'B', c: 'C'}).should.equal('A123B123C123')
+      format('$a123$b123$c123', { a: 'A', b: 'B', c: 'C'}).should.equal('A123B123C123')
 
     it 'replaces longest params first', ->
-      replaceParams('$abcd$abc$ab$a', { a: 'A', ab: 'BB', abc: 'CCC', abcd: '123' }).should.equal('123CCCBBA')
+      format('$abcd$abc$ab$a', { a: 'A', ab: 'BB', abc: 'CCC', abcd: '123' }).should.equal('123CCCBBA')
 
     it 'always replaces the same way', ->
-      replaceParams('$abc$abc$abc', { a: 'A', b: 'BB', c: 'CCC', abc: '123' }).should.equal('123123123')
+      format('$abc$abc$abc', { a: 'A', b: 'BB', c: 'CCC', abc: '123' }).should.equal('123123123')
 
     describe 'custom replacer', ->
       arrayReplacer = (str, key, array) -> str.replace(new RegExp("\\\{#{key}\\\}", 'g'), array[key])
 
       it 'uses the custom replacer', ->
-        replaceParams('Hello {0}!', ['Bob'], arrayReplacer).should.equal('Hello Bob!')
+        format('Hello {0}!', ['Bob'], arrayReplacer).should.equal('Hello Bob!')
+
+      it 'uses the custom replacer for multiple keys', ->
+        format('{0} {1} {2}', ['a', 'b', 'c'], arrayReplacer).should.equal('a b c')
+
 
   describe 'userFacingText.defaults', ->
     beforeEach ->

--- a/modules/user-facing-text/test/spec.coffee
+++ b/modules/user-facing-text/test/spec.coffee
@@ -189,11 +189,16 @@ describe 'user-facing-text', ->
 
     # Set
     #
-    # userFacingText(module: string, key: string, value: string)
+    # userFacingText(module: string, key: string, value: string | array)
     # userFacingText({
     #   module: {
-    #     key: 'value'
-    #   }
+    #     key: 'value',
+    #     pluralKey: [
+    #         [null, 0, 'Value Zero'],
+    #         [1, 1, 'Value Singular'],
+    #         [2, null, 'Value Plural']
+    #     ]
+    #   },
     # })
     describe 'when setting values', ->
       describe 'per module', ->
@@ -204,6 +209,34 @@ describe 'user-facing-text', ->
 
         it 'sets the value correctly', ->
           value.should.equal('the value')
+
+      describe 'per module with a plural key', ->
+        value = undefined
+        valueZero = undefined
+        valuePluralA = undefined
+        valuePluralB = undefined
+        beforeEach ->
+          userFacingText('something', 'value', [
+            [null, 0, 'Value Zero'],
+            [1, 1, 'Value Singular'],
+            [2, null, 'Value Plural']
+          ])
+          value = userFacingText('something', 'value')
+          valueZero = userFacingText('something', 'value', { n: 0 })
+          valuePluralA = userFacingText('something', 'value', { n: 2 })
+          valuePluralB = userFacingText('something', 'value', { n: 100 })
+
+        it 'sets the singular value correctly', ->
+          value.should.equal('Value Singular')
+
+        it 'sets the zero value correctly', ->
+          valueZero.should.equal('Value Zero')
+
+        it 'sets the plural value correctly', ->
+          valuePluralA.should.equal('Value Plural')
+
+        it 'sets the plural value correctly for larger numbers', ->
+          valuePluralB.should.equal('Value Plural')
 
       describe 'with object', ->
         value1 = undefined
@@ -226,6 +259,38 @@ describe 'user-facing-text', ->
 
         it 'sets the somethingElse key correctly', ->
           value2.should.equal('the other value')
+
+      describe 'with object and plural values', ->
+        value = undefined
+        valueZero = undefined
+        valuePluralA = undefined
+        valuePluralB = undefined
+        beforeEach ->
+          userFacingText({
+            something: {
+              value: [
+                [null, 0, 'Value Zero'],
+                [1, 1, 'Value Singular'],
+                [2, null, 'Value Plural $n $something']
+              ]
+            }
+          })
+          value = userFacingText('something', 'value')
+          valueZero = userFacingText('something', 'value', { n: 0 })
+          valuePluralA = userFacingText('something', 'value', { n: 2 })
+          valuePluralB = userFacingText('something', 'value', { n: 100, something: 'Else' })
+
+        it 'sets the singular value correctly', ->
+          value.should.equal('Value Singular')
+
+        it 'sets the zero value correctly', ->
+          valueZero.should.equal('Value Zero')
+
+        it 'sets the plural value correctly', ->
+          valuePluralA.should.equal('Value Plural 2 $something')
+
+        it 'sets the plural value correctly for larger numbers', ->
+          valuePluralB.should.equal('Value Plural 100 Else')
 
       describe 'with object and invalid values', ->
         testObj = undefined


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above in the following format -->
<!--- #404: resolved issue with data table -->
## Description
<!--- Describe your changes in detail -->
```ts
// Interface
interface UserFacingTextData {
  [module: string]: {
    [key: string]: value
  }
}

// API

// Get all data (unchanged)
userFacingText() => UserFacingTextData

// Set all data
userFacingText(textObject: UserFacingTextData)
// e.g.
userFacingText({
  myModule: {
    myString: 'My String',
    helloUser: 'Hello $name!'
  } 
})

// Get value for string
// Throws a warning when there is a parameter in string
userFacingText(module: string, key: string) => string
// e.g. 
userFacingText('myModule', 'key1') 
// => 'My String'

// Get value for string that has parameters
// Throws a warning when there is a parameter in string unless parseLater is true
userFacingText(module: string, key: string, parseLater: boolean) => string 
// e.g.
userFacingText('myModule', 'helloUser')
// Shows console warning to let you know the string has params
// => 'Hello $name!'

userFacingText('myModule', 'helloUser', true)
// No console warning
// => 'Hello $name!'

// Get value and replace parameters
userFacingText(module: string, key: string, parameters: { [key: string]: string }) => string
userFacingText('myModule', 'helloUser', { name: 'Bob' })
// Shows console warning to let you know the string has params
// => 'Hello Bob!'

// Set value (unchanged)
userFacingText(module: string, key: string, value: string)

// Get initial values (unchanged)
userFacingText.defaults()

// Format strings
interface ParamsToReplace {
  [key: string]: string | number
}

// Replace params in string
userFacingText.format(string: string, params: ParamsToReplace)
// e.g.
userFacingText.format('Hello $name!', { name: 'Bob' })
// => 'Hello Bob!'


// Replace params in string with custom replacer
// Allows custom keys (e.g. not just `$param`)
type Replacer<T> = (stringToFormat: string, key: string, params: T) => string
userFacingText.format(string: string, params: T, replacer: Replacer<T>)
// e.g.
const arrayReplacer = (str, key, array) => str.replace(new RegExp(`\\\{${key}\\\}`, 'g'), array[key])
userFacingText.format('{0} {1}', ['a', 'b'], arrayReplacer)
// => 'a b'
```

Also includes an update to the following modules to use the new API (and remove the console warning)
- DataTable
- FileInput
- Autocomplete
- Paginator

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Resolves #404) -->
Resolves #459 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests and made sure existing tests pass

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document.
- [x] All my changes are covered by tests.
- [x] This request is ready to review and merge
