### PR TITLE
fix(form-builder): Fix issue with incorrectly removed options

### DIFF
--- a/docs/content/docs/form-builder/api/auto.um
+++ b/docs/content/docs/form-builder/api/auto.um
@@ -93,6 +93,11 @@
           This Form
 
     @method addText
+      @updated 2.0.0
+      @bugfix 2.0.1
+        @description
+          Fixed an issue where the autocomplete data and options were incorrectly removed instead of deprecated
+
       @description
         Adds a text field to the form.
 
@@ -121,12 +126,40 @@
             Additional attributes to give the text input. This should be an array of objects with type and value properties.
 
         @property autoCompleteData [Data/Function]
+          @bugfix 2.0.1
+            @description
+              Added the deprecated warning and fallback in to handle the deprecation
+          @deprecated 2.0.0
+            @description
+              This option has been replaced with the lowercase variant @code[autocompleteData]
           @description
             The data to use for auto complete suggestions. Can be either an array of data or a function that returns data. For a more detailed explanation, see the Auto Complete page.
 
         @property autoCompleteOptions [Object]
+          @bugfix 2.0.1
+            @description
+              Added the deprecated warning and fallback in to handle the deprecation
+          @deprecated 2.0.0
+            @description
+              This option has been replaced with the lowercase variant @code[autocompleteOptions]
           @description
             The options to use for the auto complete. For a more detailed explanation, see the Auto Complete page.
+
+        @property autocompleteData [Data/Function]
+          @bugfix 2.0.1
+            @description
+              Added the deprecated warning and fallback in to handle the deprecation
+          @added 2.0.0
+          @description
+            The data to use for auto complete suggestions. Can be either an array of data or a function that returns data. For a more detailed explanation, see the Autocomplete.
+
+        @property autocompleteOptions [Object]
+          @bugfix 2.0.1
+            @description
+              Added the deprecated warning and fallback in to handle the deprecation
+          @added 2.0.0
+          @description
+            The options to use for the auto complete. For a more detailed explanation, see the Autocomplete page.
 
         @property key [String]
           @description

--- a/src/components/form/form-builder.coffee
+++ b/src/components/form/form-builder.coffee
@@ -3,6 +3,7 @@ import { EventEmitter } from 'utils/event-emitter'
 import { Map as HMap } from 'utils/map'
 import { randomId, merge, isArray, mergeDefined } from 'utils/utils'
 import { select, detached, span, div, button, i } from 'utils/selection'
+import logger from 'utils/logger'
 
 import { Autocomplete } from 'components/autocomplete'
 import { Picker } from 'components/picker'
@@ -210,6 +211,12 @@ export class Form extends EventEmitter
     options.attrs ?= []
     @add name, 'text', ->
       elem = detached('input').attr('type', options.type)
+
+      if options.autoCompleteData or options.autoCompleteOptions
+        logger.deprecated('Form::addText autoCompleteData/Options', 'Deprecated in favour of using the correct casing (autocompleteData and autocompleteOptions)')
+        options.autocompleteData = options.autocompleteData or options.autoCompleteData
+        options.autocompleteOptions = options.autocompleteOptions or options.autoCompleteOptions
+
       if options.autocompleteData? and options.type isnt 'password' and options.type isnt 'number'
         component = new Autocomplete(elem,
           options.autocompleteData,


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above in the following format -->
<!--- #404: resolved issue with data table -->

## Description
<!--- Describe your changes in detail -->
- Correctly deprecate `autoCompleteData/Options`
- Document

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Resolves #404) -->
Resolves issue with `form.addText` when using `autoCompleteOptions/Data`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document. (Last updated 18th May 2019)
- [x] All my changes are covered by tests.
- [x] This request is ready to review and merge
