### PR TITLE
fix(form-builder): Resolve issue with additional div wrapping autocomplete

### DIFF
--- a/docs/content/docs/form-builder/api/auto.um
+++ b/docs/content/docs/form-builder/api/auto.um
@@ -1,4 +1,8 @@
 @prototype hx.Form
+  @bugfix 2.0.2
+    @description
+      Resolved an issue where a text field with an autocompelete was incorrectly wrapped with a div, breaking the alignment of the form.
+
   @bugfix 1.2.0
     @description
       Updated the hidden/disabled state for properties so they can be hidden/disabled when added using the options and also using the hidden/disabled methods after they have been added.

--- a/src/components/form/form-builder.coffee
+++ b/src/components/form/form-builder.coffee
@@ -124,7 +124,7 @@ export class Form extends EventEmitter
     entry.append('label').attr('for', id).text(name)
     prop = f() or {}
     key = prop.key || name
-    selection = entry.append(if prop.component then div().add(prop.elem) else prop.elem).attr('id', id)
+    selection = entry.append(prop.elem).attr('id', id)
 
     # Define the default function for enabling/disabling a form property
     prop.disable ?= (disable) ->
@@ -327,11 +327,11 @@ export class Form extends EventEmitter
   addToggle: (name, options = {}) ->
     self = this
     @add name, 'toggle', ->
-      elem = div('hx-btn hx-btn-invisible hx-no-pad-left')
-      component = new Toggle(elem, options.toggleOptions)
+      componentElem = div('hx-btn hx-btn-invisible hx-no-pad-left')
+      component = new Toggle(componentElem, options.toggleOptions)
       {
         key: options.key
-        elem: elem
+        elem: div().add(componentElem)
         component: component
         options: {
           hidden: options.hidden
@@ -341,7 +341,7 @@ export class Form extends EventEmitter
 
   addPicker: (name, values, options = {}) ->
     @add name, 'picker', ->
-      elem = button(options.buttonClass)
+      componentElem = button(options.buttonClass)
         .attr('type', 'button')
         .style('position', 'relative')
 
@@ -350,12 +350,12 @@ export class Form extends EventEmitter
       if values.length > 0
         pickerOptions.items = values
 
-      component = new Picker(elem.node(), pickerOptions)
-      input = elem.append('input').class('hx-form-builder-hidden-form-input').attr('size', 0)
+      component = new Picker(componentElem, pickerOptions)
+      hiddenInput = detached('input').class('hx-form-builder-hidden-form-input').attr('size', 0)
       component.value(values[0]) unless typeof options.required is 'boolean'
 
       setValidity = () ->
-        input.node().setCustomValidity(userFacingText('form', 'pleaseSelectAValue'))
+        hiddenInput.node().setCustomValidity(userFacingText('form', 'pleaseSelectAValue'))
 
       if options.required
         setValidity()
@@ -363,11 +363,13 @@ export class Form extends EventEmitter
           if value is undefined
             setValidity()
           else
-            input.node().setCustomValidity('')
+            hiddenInput.node().setCustomValidity('')
 
       return {
         key: options.key
-        elem: elem
+        elem: div()
+          .add(componentElem)
+          .add(hiddenInput)
         component: component
         options: {
           hidden: options.hidden
@@ -377,8 +379,8 @@ export class Form extends EventEmitter
 
   addDatePicker: (name, options = {}) ->
     @add name, 'date-picker', ->
-      elem = div()
-      component = new DatePicker(elem, options.datePickerOptions)
+      componentElem = div()
+      component = new DatePicker(componentElem, options.datePickerOptions)
 
       if options.validStart? or options.validEnd?
         component.validRange(options.validStart, options.validEnd)
@@ -397,7 +399,8 @@ export class Form extends EventEmitter
 
       return {
         key: options.key
-        elem: elem
+        elem: div()
+          .add(componentElem)
         component: component
         getValue: getValue
         setValue: setValue
@@ -409,15 +412,16 @@ export class Form extends EventEmitter
 
   addTimePicker: (name, options = {}) ->
     @add name, 'time-picker', ->
-      elem = div()
-      component = new TimePicker(elem, options.timePickerOptions)
+      componentElem = div()
+      component = new TimePicker(componentElem, options.timePickerOptions)
 
       getValue = -> component.date()
       setValue = (value) -> component.date(value)
 
       return {
         key: options.key
-        elem: elem
+        elem: div()
+          .add(componentElem)
         component: component
         getValue: getValue
         setValue: setValue
@@ -429,15 +433,16 @@ export class Form extends EventEmitter
 
   addDateTimePicker: (name, options = {}) ->
     @add name, 'date-time-picker', ->
-      elem = div()
-      component = new DateTimePicker(elem, options.dateTimePickerOptions)
+      componentElem = div()
+      component = new DateTimePicker(componentElem, options.dateTimePickerOptions)
 
       getValue = -> component.date()
       setValue = (value) -> component.date(value)
 
       return {
         key: options.key
-        elem: elem
+        elem: div()
+          .add(componentElem)
         component: component
         getValue: getValue
         setValue: setValue
@@ -450,18 +455,18 @@ export class Form extends EventEmitter
   addTagInput: (name, options = {}) ->
     self = this
     @add name, 'tag-input', ->
-      elem = div()
+      componentElem = div()
       if options.placeholder
         options.tagInputOptions ?= {}
         options.tagInputOptions.placeholder ?= options.placeholder
 
-      component = new TagInput(elem, options.tagInputOptions)
+      component = new TagInput(componentElem, options.tagInputOptions)
 
       getValue = -> component.items()
       setValue = (items) -> component.items(items)
 
       if options.required
-        input = elem.select('input')
+        input = componentElem.select('input')
 
         setValidity = () ->
           input.node().setCustomValidity(userFacingText('form', 'pleaseAddAValue'))
@@ -480,7 +485,8 @@ export class Form extends EventEmitter
 
       return {
         key: options.key
-        elem: elem
+        elem: div()
+          .add(componentElem)
         component: component
         getValue: getValue
         setValue: setValue
@@ -493,11 +499,12 @@ export class Form extends EventEmitter
   addFileInput: (name, options = {}) ->
     self = this
     @add name, 'file-input', ->
-      elem = div()
-      component = new FileInput(elem, options.fileInputOptions)
+      componentElem = div()
+      component = new FileInput(componentElem, options.fileInputOptions)
       return {
         key: options.key
-        elem: elem
+        elem: div()
+          .add(componentElem)
         component: component
         options: {
           hidden: options.hidden
@@ -507,7 +514,7 @@ export class Form extends EventEmitter
 
   addAutocompletePicker: (name, values, options = {}) ->
     @add name, 'select', ->
-      elem = button()
+      componentElem = button()
         .attr('type', 'button')
         .class(options.buttonClass)
 
@@ -516,9 +523,9 @@ export class Form extends EventEmitter
       if values.length > 0
         autocompletePickerOptions.items = values
 
-      component = new AutocompletePicker(elem.node(), values, autocompletePickerOptions)
-      input = elem.append('input').class('hx-form-builder-hidden-form-input').attr('size', 0)
-      elem.style('position', 'relative')
+      component = new AutocompletePicker(componentElem, values, autocompletePickerOptions)
+      input = componentElem.append('input').class('hx-form-builder-hidden-form-input').attr('size', 0)
+      componentElem.style('position', 'relative')
 
       component.value(values[0]) unless typeof options.required is 'boolean'
 
@@ -535,7 +542,8 @@ export class Form extends EventEmitter
 
       return {
         key: options.key
-        elem: elem
+        elem: div()
+          .add(componentElem)
         component: component
         disable: (disabled) -> component.disabled(disabled)
         options: {

--- a/src/demo/examples/form/index.js
+++ b/src/demo/examples/form/index.js
@@ -6,6 +6,7 @@ export default () => {
   const theForm = div();
   new Form(theForm)
     .addText('Text', { required: true, placeholder: 'Name' })
+    .addText('Text with Autocomplete', { required: true, placeholder: 'Name', autocompleteData: [1, 2, 3] })
     .addTextArea('Text Area', { placeholder: 'Name' })
     .addEmail('Email', { required: true, placeholder: 'your.name@ocado.com' })
     .addUrl('Url', { placeholder: 'http://www.example.co.uk/' }) // Allows blank or valid URL (with http:// prefix)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above in the following format -->
<!--- #404: resolved issue with data table -->

## Description
<!--- Describe your changes in detail -->
Replaced generic div wrapper for fields with a `component` with explicit element creation inside the `addXXX` method.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Resolves #404) -->
The autocomplete is a component but it doesn't require a wrapper element. This change makes the components that require a wrapper behave properly whilst allowing the autocomplete to continue working

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document. (Last updated 18th May 2019)
- [x] All my changes are covered by tests.
- [x] This request is ready to review and merge
