### PR TITLE
Fix tag input in form validation

### DIFF
--- a/docs/content/changelog/index.um
+++ b/docs/content/changelog/index.um
@@ -508,3 +508,11 @@
           @item: The @code[build] api for creating a bundle was removed
           @item: @code[ColorPicker] was removed
           @item: @code[hx.theme] replaced by @code[hx.theme()] (find/replace resolves this)
+
+    @version 2.0.1
+
+    @version 2.0.2
+
+    @version 2.0.3
+      @description
+        Bugfix for TagInput validation in forms

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hexagon-js",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/form/form-builder.coffee
+++ b/src/components/form/form-builder.coffee
@@ -460,6 +460,9 @@ export class Form extends EventEmitter
         options.tagInputOptions ?= {}
         options.tagInputOptions.placeholder ?= options.placeholder
 
+      options.tagInputOptions ?= {}
+      options.tagInputOptions.isInsideForm = true
+
       component = new TagInput(componentElem, options.tagInputOptions)
 
       getValue = -> component.items()

--- a/src/components/tag-input/index.coffee
+++ b/src/components/tag-input/index.coffee
@@ -39,7 +39,8 @@ class TagInput extends EventEmitter
       autocompleteData: undefined
       autocompleteOptions: {}
       excludeTags: true
-      mustMatchAutocomplete: true
+      mustMatchAutocomplete: true,
+      isInsideForm: false
     }, options
 
     if @options.mustMatchAutocomplete
@@ -55,15 +56,10 @@ class TagInput extends EventEmitter
     if @options.draggable
       _.dragContainer = new DragContainer(@tagContainer.node())
 
-    isInsideForm = not @selection.closest('form').empty()
+    isInsideForm = @options.isInsideForm || not @selection.closest('form').empty()
 
     inputContainer = @selection.append(if isInsideForm then 'div' else 'form')
       .class('hx-tag-input-container')
-
-    validationForm = if isInsideForm
-      @selection.closest('.hx-form')
-    else
-      inputContainer
 
     @input = inputContainer.append('input').attr('placeholder', @options.placeholder)
     if @options.autocompleteData?
@@ -91,6 +87,7 @@ class TagInput extends EventEmitter
         false
 
     validateTagInput = (clear) =>
+      validationForm = if isInsideForm then @selection.closest('.hx-form') else inputContainer
       if isInsideForm
         if clear
           validationForm.selectAll('.hx-form-error').remove()

--- a/src/demo/examples/form/index.js
+++ b/src/demo/examples/form/index.js
@@ -21,6 +21,17 @@ export default () => {
     .addPicker('Picker', ['red', 'green', 'blue'], { required: true })
     .addTagInput('Tag Input')
     .addTagInput('Tag Input', { required: true })
+    .addTagInput('Tag Input', {
+      required: true,
+      tagInputOptions: {
+        validator: (name) => {
+          if (!isNaN(Number(name))) {
+            return 'Please enter text';
+          }
+          return false;
+        },
+      },
+    })
     .addFileInput('File Input')
     .addFileInput('File Input', { required: true })
     .addDatePicker('Date Picker')

--- a/src/demo/examples/form/index.js
+++ b/src/demo/examples/form/index.js
@@ -25,7 +25,7 @@ export default () => {
       required: true,
       tagInputOptions: {
         validator: (name) => {
-          if (!isNaN(Number(name))) {
+          if (!Number.isNaN(Number(name))) {
             return 'Please enter text';
           }
           return false;


### PR DESCRIPTION
## Description
Shows tag input validation when created via a form builder - previously would not get shown due to the form detection failing when the tag input was created

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document. (Last updated 18th May 2019)
- [x] All my changes are covered by tests.
- [x] This request is ready to review and merge
