### PR TITLE
docs: add demo page from hexagon to documentation

### DIFF
--- a/docs/content/index.um
+++ b/docs/content/index.um
@@ -4,7 +4,7 @@
 
 @stylesheet [/resources/hexagon/docs/hexagon.css]
 @stylesheet [https://fonts.googleapis.com/css?family=Open+Sans:100,400,700|Roboto+Slab:400,700|Source+Code+Pro:400,700]
-@stylesheet [/resources/font-awesome/css/font-awesome.min.css]
+@stylesheet [/resources/font-awesome/css/all.min.css]
 @stylesheet [/resources/docs-new.css]
 @stylesheet [/resources/docs-landing.css]
 
@@ -32,28 +32,20 @@
     @div .qm-html-paragraph
       @div .buttons
         @a .button: @span[Documentation]
-          @attr href: /guide/installation
-          @img
-            @attr src: /resources/book.svg
-            @attr role: presentation
-            @attr alt: Book Icon
-            @attr height: 30px
+          @attr href: /guide/installation/
+          @i .fas.fa-book-open
+
+        @a .button: @span[Component Demos]
+          @attr href: /demo/
+          @i .fas.fa-swatchbook
 
         @a .button: @span[Changelog]
-          @attr href: /changelog
-          @img
-            @attr src: /resources/tags.svg
-            @attr role: presentation
-            @attr alt: Tags Icon
-            @attr height: 30px
+          @attr href: /changelog/
+          @i .fas.fa-tags
 
         @a .button: @span[GitHub]
           @attr href: https://github.com/ocadotechnology/hexagonjs/
-          @img
-            @attr src: /resources/github-mark.svg
-            @attr role: presentation
-            @attr alt: GitHub Logo
-            @attr height: 30px
+          @i .fab.fa-github
 
   @landingSection Themeable
     Create custom themes with variable-driven theme files.
@@ -89,28 +81,16 @@
   @landingSection Get Started
     @div .buttons
       @a .button: @span[Quick Start]
-        @attr href: /guide/getting-started
-        @img
-          @attr src: /resources/rocket.svg
-          @attr role: presentation
-          @attr alt: Rocket Icon
-          @attr height: 30px
+        @attr href: /guide/getting-started/
+        @i .fas.fa-rocket
 
       @a .button: @span[Releases]
         @attr href: https://github.com/ocadotechnology/hexagonjs/releases
-        @img
-          @attr src: /resources/tags.svg
-          @attr role: presentation
-          @attr alt: Tags Icon
-          @attr height: 30px
+        @i .fas.fa-tags
 
       @a .button: @span[GitHub]
         @attr href: https://github.com/ocadotechnology/hexagonjs/
-        @img
-          @attr src: /resources/github-mark.svg
-          @attr role: presentation
-          @attr alt: GitHub Logo
-          @attr height: 30px
+        @i .fab.fa-github
 
   @div .footer
     @span .footer-note: Created @(@) @hyperlink(https://github.com/ocadotechnology)[Ocado Technology]

--- a/docs/content/templates/sidebar-page.um
+++ b/docs/content/templates/sidebar-page.um
@@ -39,6 +39,9 @@
             # @page /guide/create-custom-themes: Creating Custom Themes
             @page /guide/printing: Print Styles
 
+          @section Demos
+            @page /demo/: Component Demo Page
+
           @section Css Components
             @page /docs/base/: Base
             @page /docs/button/: Button

--- a/docs/quantum.config.js
+++ b/docs/quantum.config.js
@@ -118,6 +118,14 @@ module.exports = {
       watch: false
     },
     {
+      files: [
+        'node_modules/hexagon-js/demo/**',
+      ],
+      base: 'node_modules/hexagon-js/demo',
+      dest: 'demo',
+      watch: false
+    },
+    {
       files: 'content/guide/**/*.html',
       base: 'content',
       watch: false

--- a/docs/resources/docs-landing.css
+++ b/docs/resources/docs-landing.css
@@ -151,7 +151,7 @@ h1,h2,h3,h4,h5,h6 {
   vertical-align: middle;
 }
 
-.button img {
+.button i {
   display: inline-block;
   margin-left: 0.5em;
   opacity: 0.7;

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -5,7 +5,7 @@ module.exports = {
   plugins: [
     postcssImport(),
     postcssPresetEnv({
-      browsers: [
+      overrideBrowserslist: [
         'last 2 Chrome versions',
         'last 2 iOS versions',
       ],

--- a/src/demo/index.css
+++ b/src/demo/index.css
@@ -31,8 +31,12 @@ hr {
 
 .example-section{
   margin: 0;
-  padding: 2em;
+  padding: 0.5rem 2rem 2rem;
   box-shadow: 0 5px 5px -5px #000;
+}
+
+.example-section > h2 {
+  padding-top: 1.5rem;
 }
 
 .example-header {
@@ -86,4 +90,40 @@ note {
   font-weight: bold;
   font-size: 32px;
   margin-bottom: 1em;
+}
+
+.sidebar {
+  position: fixed;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 250px;
+  box-sizing: border-box;
+  background: white;
+  border-right: 1px solid #ccc;
+  display: flex;
+  flex-direction: column;
+}
+
+.intro,
+.examples {
+  margin-left: 250px;
+}
+
+.intro {
+  margin-top: 0;
+  padding: 1em;
+}
+
+.sidebar ul {
+  list-style: none;
+  padding: 1em;
+  margin: 0;
+  overflow: auto;
+  border-top: 1px dashed #DDD;
+}
+
+.sidebar input {
+  display: block;
+  margin: 1em 0.5em;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above in the following format -->
<!--- #404: resolved issue with data table -->

## Description
<!--- Describe your changes in detail -->
Adds the `demo` page to the documentation. Cherry picked from #535 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Resolves #404) -->
Improves the usage of Hexagon by providing some 'real' examples based on the latest demos

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A

## Screenshots (if appropriate):
![Demo Page](https://user-images.githubusercontent.com/3194349/61063711-54b6e500-a3f8-11e9-8f29-b756e543450f.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document. (Last updated 18th May 2019)
- [x] All my changes are covered by tests.
- [x] This request is ready to review and merge
