### PR TITLE
fix: update dropdown position calculation

### DIFF
--- a/docs/content/docs/dropdown/api/auto.um
+++ b/docs/content/docs/dropdown/api/auto.um
@@ -16,6 +16,10 @@
 
       Also converted the dropdown to reposition whenever the content is updated to prevent overlap or overflow outside the window area. Uses @hyperlink(https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver)[MutationObserver]
 
+  @fix nextReleaseVersion
+    @description
+      Resolved an issue where the dropdown would overlap for themes with non-zero @code[--dropdown-spacing] value.
+
   @description
     An api for creating a dropdown that shows when the user either clicks or hovers over an element.
 

--- a/src/components/dropdown/positioning.coffee
+++ b/src/components/dropdown/positioning.coffee
@@ -1,6 +1,14 @@
 import { clamp } from 'utils/utils'
 
-export calculateDropdownPosition = (alignments, selectionRect, dropdownRect, windowRect, ddMaxHeight, scrollbarWidth) ->
+export calculateDropdownPosition = (align, selectionRect, dropdownRect, windowRect, ddMaxHeight, scrollbarWidth) ->
+  alignQuad = switch align
+    when 'up' then 'ltlb'
+    when 'down' then 'lblt'
+    when 'left' then 'ltrt'
+    when 'right' then 'rtlt'
+    else align
+
+  alignments = alignQuad.split('')
 
   # figure out the direction the drop-down should be revealed (for the animation)
   direction = if alignments[1] is alignments[3] and alignments[0] isnt alignments[2]

--- a/src/components/dropdown/spec.coffee
+++ b/src/components/dropdown/spec.coffee
@@ -87,7 +87,6 @@ export default () ->
       dd._.selection.should.eql(button)
       getSpacing(dd).should.equal(0)
       dd.options.matchWidth.should.equal(true)
-      dd._.alignments.should.eql('lblt'.split(''))
       should.not.exist(dd._.dropdown)
       dd._.visible.should.equal(false)
       dd.options.ddClass.should.equal('')
@@ -105,24 +104,6 @@ export default () ->
       getHexagonElementDataObject(button.node()).eventEmitter.has('click').should.equal(true)
       getHexagonElementDataObject(button.node()).eventEmitter.has('mouseover').should.equal(true)
       getHexagonElementDataObject(button.node()).eventEmitter.has('mouseout').should.equal(true)
-
-
-    it 'should set the alignment correctly', ->
-      dd = new Dropdown(button, content, {align: 'rbrb'})
-      dd._.alignments.should.eql('rbrb'.split(''))
-
-    it 'should use the right alignment option when a named align value is used', ->
-      dd = new Dropdown(button, content, {align: 'up'})
-      dd._.alignments.should.eql('ltlb'.split(''))
-
-      dd = new Dropdown(button, content, {align: 'down'})
-      dd._.alignments.should.eql('lblt'.split(''))
-
-      dd = new Dropdown(button, content, {align: 'left'})
-      dd._.alignments.should.eql('ltrt'.split(''))
-
-      dd = new Dropdown(button, content, {align: 'right'})
-      dd._.alignments.should.eql('rtlt'.split(''))
 
     it 'should set the spacing correctly', ->
       dd = new Dropdown(button, content, {spacing: 10} )
@@ -353,7 +334,7 @@ export default () ->
         scrollbarWidth = 0
 
         calculateDropdownPosition(
-          alignments.split(''),
+          alignments,
           selectionRect,
           dropdownRect,
           windowRect,
@@ -369,7 +350,7 @@ export default () ->
         scrollbarWidth = 0
 
         calculateDropdownPosition(
-          alignments.split(''),
+          alignments,
           selectionRect,
           dropdownRect,
           windowRect,
@@ -377,8 +358,16 @@ export default () ->
           scrollbarWidth
         )
 
-
       # downwards tests
+      describe 'down', ->
+        it 'ample space', -> check(500, 500, 'down').should.eql({ x: 500, y: 600, direction: 'down' })
+        it 'not enough space to flip', -> checkNoSpaceToFlipV('down').should.eql({ x: 500, y: 150, direction: 'down' })
+        it 'shifted left', -> check(850, 500, 'down').should.eql({ x: 800, y: 600, direction: 'down' })
+        it 'shifted right', -> check(-50, 500, 'down').should.eql({ x: 0, y: 600, direction: 'down' })
+        it 'flipped', -> check(500, 850, 'down').should.eql({ x: 500, y: 650, direction: 'up' })
+        it 'flipped shifted left', -> check(850, 850, 'down').should.eql({ x: 800, y: 650, direction: 'up' })
+        it 'flipped shifted right', -> check(-50, 850, 'down').should.eql({ x: 0, y: 650, direction: 'up' })
+
       describe 'lblt', ->
         it 'ample space', -> check(500, 500, 'lblt').should.eql({ x: 500, y: 600, direction: 'down' })
         it 'not enough space to flip', -> checkNoSpaceToFlipV('lblt').should.eql({ x: 500, y: 150, direction: 'down' })
@@ -434,6 +423,15 @@ export default () ->
         it 'flipped shifted right', -> check(50, 850, 'rtrt').should.eql({ x: 0, y: 750, direction: 'up' })
 
       # upwards tests
+      describe 'up', ->
+        it 'ample space', -> check(500, 500, 'up').should.eql({ x: 500, y: 300, direction: 'up' })
+        it 'not enough space to flip', -> checkNoSpaceToFlipV('up').should.eql({ x: 500, y: -150, direction: 'up' })
+        it 'shifted left', -> check(850, 500, 'up').should.eql({ x: 800, y: 300, direction: 'up' })
+        it 'shifted right', -> check(-50, 500, 'up').should.eql({ x: 0, y: 300, direction: 'up' })
+        it 'flipped', -> check(500, 150, 'up').should.eql({ x: 500, y: 250, direction: 'down' })
+        it 'flipped shifted left', -> check(850, 150, 'up').should.eql({ x: 800, y: 250, direction: 'down' })
+        it 'flipped shifted right', -> check(-50, 150, 'up').should.eql({ x: 0, y: 250, direction: 'down' })
+
       describe 'lblb', ->
         it 'ample space', -> check(500, 500, 'lblb').should.eql({ x: 500, y: 400, direction: 'up' })
         it 'not enough space to flip', -> checkNoSpaceToFlipV('lblb').should.eql({ x: 500, y: -50, direction: 'up' })
@@ -489,6 +487,15 @@ export default () ->
         it 'flipped shifted right', -> check(50, 50, 'rtrb').should.eql({ x: 0, y: 150, direction: 'down' })
 
       # rightwards tests
+      describe 'right', ->
+        it 'ample space', -> check(500, 500, 'right').should.eql({ x: 600, y: 500, direction: 'right' })
+        it 'not enough space to flip', -> checkNoSpaceToFlipH('right').should.eql({ x: 150, y: 500, direction: 'right' })
+        it 'shifted down', -> check(500, -50, 'right').should.eql({ x: 600, y: 0, direction: 'right' })
+        it 'shifted up', -> check(500, 850, 'right').should.eql({ x: 600, y: 800, direction: 'right' })
+        it 'flipped', -> check(750, 500, 'right').should.eql({ x: 550, y: 500, direction: 'left' })
+        it 'flipped shifted down', -> check(750, -50, 'right').should.eql({ x: 550, y: 0, direction: 'left' })
+        it 'flipped shifted up', -> check(750, 850, 'right').should.eql({ x: 550, y: 800, direction: 'left' })
+
       describe 'rtlt', ->
         it 'ample space', -> check(500, 500, 'rtlt').should.eql({ x: 600, y: 500, direction: 'right' })
         it 'not enough space to flip', -> checkNoSpaceToFlipH('rtlt').should.eql({ x: 150, y: 500, direction: 'right' })
@@ -508,6 +515,15 @@ export default () ->
         it 'flipped shifted up', -> check(750, 950, 'rblb').should.eql({ x: 550, y: 800, direction: 'left' })
 
       # leftwards tests
+      describe 'left', ->
+        it 'ample space', -> check(500, 500, 'left').should.eql({ x: 300, y: 500, direction: 'left' })
+        it 'not enough space to flip', -> checkNoSpaceToFlipH('left').should.eql({ x: -150, y: 500, direction: 'left' })
+        it 'shifted down', -> check(500, -50, 'left').should.eql({ x: 300, y: 0, direction: 'left' })
+        it 'shifted up', -> check(500, 850, 'left').should.eql({ x: 300, y: 800, direction: 'left' })
+        it 'flipped', -> check(150, 500, 'left').should.eql({ x: 250, y: 500, direction: 'right' })
+        it 'flipped shifted down', -> check(150, -50, 'left').should.eql({ x: 250, y: 0, direction: 'right' })
+        it 'flipped shifted up', -> check(150, 850, 'left').should.eql({ x: 250, y: 800, direction: 'right' })
+
       describe 'ltrt', ->
         it 'ample space', -> check(500, 500, 'ltrt').should.eql({ x: 300, y: 500, direction: 'left' })
         it 'not enough space to flip', -> checkNoSpaceToFlipH('ltrt').should.eql({ x: -150, y: 500, direction: 'left' })

--- a/src/components/dropdown/theme.css
+++ b/src/components/dropdown/theme.css
@@ -3,5 +3,20 @@
   box-shadow: 0px 2px 2px 2px var(--dropdown-shadow-color);
   border-color: var(--dropdown-border-color);
   border-radius: var(--dropdown-border-radius);
+}
+
+.hx-dropdown-up {
+  margin-bottom: var(--dropdown-spacing);
+}
+
+.hx-dropdown-down {
   margin-top: var(--dropdown-spacing);
+}
+
+.hx-dropdown-left {
+  margin-right: var(--dropdown-spacing);
+}
+
+.hx-dropdown-right {
+  margin-left: var(--dropdown-spacing);
 }

--- a/src/components/form/theme.css
+++ b/src/components/form/theme.css
@@ -152,6 +152,10 @@
   height: var(--input-height);
   line-height: var(--input-line-height);
   font-size: 1em;
+}
+
+.hx-flag-form .hx-date-time-picker .hx-date-picker,
+.hx-flag-form .hx-date-time-picker .hx-time-picker {
   margin: calc(-1 * var(--input-border-width));
 }
 

--- a/src/hexagon.variables.css
+++ b/src/hexagon.variables.css
@@ -390,7 +390,7 @@
   --dropdown-border-color: var(--theme-container-border-color);
   --dropdown-border-radius: 0;
   --dropdown-shadow-color: var(--theme-shadow-color);
-  --dropdown-spacing: 0;
+  --dropdown-spacing: 0.2em;
 
 
   /* Error Pages */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above in the following format -->
<!--- #404: resolved issue with data table -->

## Description
<!--- Describe your changes in detail -->
Applies a directional class to the dropdown to apply the margin spacing on the correct side of the dropdown and resolves an issue where the dropdown could grow and cover the selection by switching to use `bottom` position instead of `top` when shown above the selection.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Resolves #404) -->
Currently, the dropdown applies a top margin in the styles to add spacing between the dropdown and the selection. 

When the dropdown is in any position other than 'down' (i.e. below the selection) this top margin either causes the dropdown to be slightly misaligned or to overlap with the content in the dropdown.

This change prevents the dropdown overlapping when the spacing is greater than zero.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Added tests to the check the alignment works correctly.
- All existing tests pass.

## Screenshots (if appropriate):
Before(5px dropdown spacing)         After
<img width="183" alt="Screenshot 2019-07-18 at 15 14 20" src="https://user-images.githubusercontent.com/3194349/61464774-c1892c80-a96e-11e9-8ea1-c2a9a85eadba.png"> <img width="185" alt="Screenshot 2019-07-18 at 15 13 11" src="https://user-images.githubusercontent.com/3194349/61464775-c1892c80-a96e-11e9-9119-d9750fe5cb50.png">

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document. (Last updated 18th May 2019)
- [x] All my changes are covered by tests.
- [x] This request is ready to review and merge
