### PR TITLE
fix(form-builder): move form builder buttons back to bottom of form

### DIFF
--- a/docs/content/changelog/index.um
+++ b/docs/content/changelog/index.um
@@ -574,3 +574,7 @@
         Added improved notifications via the @code[Alert] module and APIs.
 
         Tweaked the form builder styles to work better in modals.
+
+    @version 2.3.1
+      @description
+        Resolved an issue with the form builder where the buttons were inadvertently moved to the top of the form.

--- a/docs/content/docs/form-builder/api/auto.um
+++ b/docs/content/docs/form-builder/api/auto.um
@@ -1,4 +1,8 @@
 @prototype hx.Form
+  @bugfix 2.3.1
+    @description
+      Resolved an issue where the buttons were moved to the top of the form
+
   @bugfix 2.2.0
     @description
       Resolved an issue where elements added with @code[addButton] could not be retrieved with @code[.node(...)]

--- a/src/components/form/form-builder.coffee
+++ b/src/components/form/form-builder.coffee
@@ -23,7 +23,7 @@ getButtons = (form, createIfEmpty = true) ->
   selection = select(form.selector)
   sel = selection.select('.hx-form-buttons')
   buttons = if createIfEmpty and sel.empty()
-    selection.prepend('div').class('hx-form-buttons')
+    selection.append('div').class('hx-form-buttons')
   else sel
 
 export class Form extends EventEmitter

--- a/src/demo/examples/modal/index.js
+++ b/src/demo/examples/modal/index.js
@@ -50,7 +50,7 @@ export default () => {
   const renderFullFooter = thisModal => ([
     button('hx-btn')
       .text('Cancel')
-      .on('click', () => thisModal.onClose()),
+      .on('click', () => thisModal.close()),
     button('hx-btn hx-primary hx-margin-left')
       .text('Primary')
       .on('click', () => thisModal.hide()),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above in the following format -->
<!--- #404: resolved issue with data table -->

## Description
<!--- Describe your changes in detail -->

An unnecesary `prepend` used during testing managed to make its way into
the last release (making forms work correctly in modals) which meant the
form buttons added (submit/additional buttons) were inserted at the
start of the form instead of continuing to be placed at the bottom of
the form.

As the change was only solving some minor spacing problems, reverting it
makes the most sense. I'll follow up with investigation into the modal
issue moving forwards.

I also noticed an issue with the modal demo not working as intended due
to some refactoring (onClose -> close) so fixed that as well

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Resolves #404) -->
Bugfix

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Visual testing only in the demo

## Screenshots (if appropriate):
*Before*

![Screenshot 2019-09-04 at 08 00 37](https://user-images.githubusercontent.com/3194349/64232666-4a8e0000-ceea-11e9-854f-ca320f1a9221.png)

![Screenshot 2019-09-04 at 08 00 32](https://user-images.githubusercontent.com/3194349/64232667-4a8e0000-ceea-11e9-82cc-79c7b894326d.png)

*After*

![Screenshot 2019-09-04 at 08 01 54](https://user-images.githubusercontent.com/3194349/64232664-49f56980-ceea-11e9-92ba-9e857687592e.png)

![Screenshot 2019-09-04 at 08 01 58](https://user-images.githubusercontent.com/3194349/64232663-49f56980-ceea-11e9-8c3f-7327d90f56d9.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document. (Last updated 16 Aug 2019)
- [ ] All my changes are covered by tests.
- [x] This request is ready to review and merge
