### PR TITLE
fix(date-localizer): resolve issue with localisation

### DIFF
--- a/docs/content/changelog/index.um
+++ b/docs/content/changelog/index.um
@@ -591,3 +591,7 @@
         Added a tooltip component to provide additional information for icons or text.
 
         Resolved an issue in the form styles for error messages.
+
+    @version 2.5.3
+      @description
+        Resolved an issue with the date time localizer where values typed in the input did not work for non DD/MM/YYYY locales

--- a/docs/content/docs/date-picker/api/auto.um
+++ b/docs/content/docs/date-picker/api/auto.um
@@ -1,3 +1,8 @@
+@bugfix 2.5.3
+  @description
+    Resolve an issue with localisation where non DD/MM/YYYY locales could not have
+    a date entered via the input.
+
 @bugfix 0.14.1
   @description
     Fixed an issue where the events were firing out of order.

--- a/docs/content/templates/versions.um
+++ b/docs/content/templates/versions.um
@@ -61,3 +61,6 @@
 @version 2.3.1
 @version 2.4.0
 @version 2.5.0
+@version 2.5.1
+@version 2.5.2
+@version 2.5.3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexagon-js",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "A modular, themeable collection of components for modern browsers",
   "author": "James Smyth <james.smyth@ocado.com>",
   "contributors": [

--- a/src/components/date-picker/spec.coffee
+++ b/src/components/date-picker/spec.coffee
@@ -17,6 +17,7 @@ export default () ->
     animationDelay = 301
     origAttachSelector = dropdownConfig.attachToSelector
     originalLoggerWarn = logger.warn
+    inputDebounceDelay = 501
 
     fixture = undefined
     body = select('body')
@@ -307,7 +308,6 @@ export default () ->
 
             describe 'and passing a dateValidityCallback', ->
               dateValidityCallback = undefined
-              inputDebounceDelay = 501
 
               beforeEach ->
                 input.remove()
@@ -526,7 +526,7 @@ export default () ->
               intlDp = new DatePicker(fixture.append(div()))
 
             it 'has the correct screen date', () ->
-              intlDp.getScreenDate().should.equal('5/21/2019')
+              intlDp.getScreenDate().should.equal('05/21/2019')
 
             it 'has the correct date', () ->
               intlDp.date().should.eql(new Date(2019, 4, 22))
@@ -536,7 +536,129 @@ export default () ->
                 preferences.timezone('Europe/London')
 
               it 'has the correct screen date', () ->
-                intlDp.getScreenDate().should.equal('5/22/2019')
+                intlDp.getScreenDate().should.equal('05/22/2019')
+
+              it 'has the correct date', () ->
+                intlDp.date().should.eql(new Date(2019, 4, 22))
+
+          describe 'when using en-CA and America/Los_Angeles', () ->
+            intlDp = undefined
+            input = undefined
+            dateValidityCallback = undefined
+            clock = undefined
+
+            beforeEach () ->
+              dateValidityCallback = chai.spy()
+              preferences.locale('en-CA')
+              preferences.timezone('America/Los_Angeles')
+              input = fixture.append('input');
+              intlDp = new DatePicker(input, {
+                v2Features: {
+                  dontModifyDateOnError: true,
+                  displayLongMonthInCalendar: true,
+                  dontSetInitialInputValue: true,
+                  updateVisibleMonthOnDateChange: true,
+                  dateValidityCallback: dateValidityCallback,
+                }
+              })
+              clock = installFakeTimers()
+
+            afterEach () ->
+              clock.restore()
+
+            it 'has the correct screen date', () ->
+              intlDp.getScreenDate().should.equal('2019-05-21')
+
+            it 'has the correct date', () ->
+              intlDp.date().should.eql(new Date(2019, 4, 22))
+
+            describe 'then typing a value', () ->
+              input = undefined
+
+              beforeEach ->
+                input.value('2019-03-25')
+                emit(input.node(), 'input')
+                clock.tick(inputDebounceDelay)
+
+              it 'sets the input value correctly', () ->
+                input.value().should.equal('2019-03-25')
+
+              it 'has the correct date', () ->
+                intlDp.date().should.eql(new Date(2019, 2, 25))
+
+              it 'calls the validate function with true', ->
+                dateValidityCallback.should.have.been.called.with(true, undefined)
+
+              it 'calls the validate function once', ->
+                dateValidityCallback.should.have.been.called.exactly(1)
+
+            describe 'then changing to Europe/London', ->
+              beforeEach ->
+                preferences.timezone('Europe/London')
+
+              it 'has the correct screen date', () ->
+                intlDp.getScreenDate().should.equal('2019-05-22')
+
+              it 'has the correct date', () ->
+                intlDp.date().should.eql(new Date(2019, 4, 22))
+
+          describe 'when using ja and America/Los_Angeles', () ->
+            intlDp = undefined
+            input = undefined
+            dateValidityCallback = undefined
+            clock = undefined
+
+            beforeEach () ->
+              dateValidityCallback = chai.spy()
+              preferences.locale('ja')
+              preferences.timezone('America/Los_Angeles')
+              input = fixture.append('input');
+              intlDp = new DatePicker(input, {
+                v2Features: {
+                  dontModifyDateOnError: true,
+                  displayLongMonthInCalendar: true,
+                  dontSetInitialInputValue: true,
+                  updateVisibleMonthOnDateChange: true,
+                  dateValidityCallback: dateValidityCallback,
+                }
+              })
+              clock = installFakeTimers()
+
+            afterEach () ->
+              clock.restore()
+
+            it 'has the correct screen date', () ->
+              intlDp.getScreenDate().should.equal('2019/05/21')
+
+            it 'has the correct date', () ->
+              intlDp.date().should.eql(new Date(2019, 4, 22))
+
+            describe 'then typing a value', () ->
+              input = undefined
+
+              beforeEach ->
+                input.value('2019/03/22')
+                emit(input.node(), 'input')
+                clock.tick(inputDebounceDelay)
+
+              it 'sets the input value correctly', () ->
+                input.value().should.equal('2019/03/22')
+
+              it 'has the correct date', () ->
+                intlDp.date().should.eql(new Date(2019, 2, 22))
+
+              it 'calls the validate function with true', ->
+                dateValidityCallback.should.have.been.called.with(true, undefined)
+
+              it 'calls the validate function once', ->
+                dateValidityCallback.should.have.been.called.exactly(1)
+
+            describe 'then changing to Europe/London', ->
+              beforeEach ->
+                preferences.timezone('Europe/London')
+
+              it 'has the correct screen date', () ->
+                intlDp.getScreenDate().should.equal('2019/05/22')
 
               it 'has the correct date', () ->
                 intlDp.date().should.eql(new Date(2019, 4, 22))
@@ -596,7 +718,7 @@ export default () ->
               })
 
             it 'has the correct screen date', () ->
-              intlDp.getScreenDate().should.equal('5/21/2019')
+              intlDp.getScreenDate().should.equal('05/21/2019')
 
             it 'has the correct date', () ->
               intlDp.date().should.eql(new Date(testDateMs))
@@ -606,7 +728,7 @@ export default () ->
                 preferences.timezone('Europe/London')
 
               it 'has the correct screen date', () ->
-                intlDp.getScreenDate().should.equal('5/22/2019')
+                intlDp.getScreenDate().should.equal('05/22/2019')
 
               it 'has the correct date', () ->
                 intlDp.date().should.eql(new Date(testDateMs))

--- a/src/utils/date-localizer/index.js
+++ b/src/utils/date-localizer/index.js
@@ -251,10 +251,16 @@ class IntlDateTimeLocalizer extends PreferencesHandler {
 
     const date = new Intl.DateTimeFormat(locale, {
       timeZone,
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric'
     });
 
     const gbDate = new Intl.DateTimeFormat('en-GB', {
       timeZone,
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric'
     });
 
     const time = new Intl.DateTimeFormat(locale, {

--- a/src/utils/date-localizer/index.js
+++ b/src/utils/date-localizer/index.js
@@ -253,14 +253,14 @@ class IntlDateTimeLocalizer extends PreferencesHandler {
       timeZone,
       day: '2-digit',
       month: '2-digit',
-      year: 'numeric'
+      year: 'numeric',
     });
 
     const gbDate = new Intl.DateTimeFormat('en-GB', {
       timeZone,
       day: '2-digit',
       month: '2-digit',
-      year: 'numeric'
+      year: 'numeric',
     });
 
     const time = new Intl.DateTimeFormat(locale, {
@@ -307,8 +307,15 @@ class IntlDateTimeLocalizer extends PreferencesHandler {
       return result;
     }
 
-    const dateOrder = getDateOrder(date
-      .format(new Date(Date.UTC(dateOrderYear, dateOrderMonth - 1, dateOrderDay, 12))));
+    const staticDate = new Date(Date.UTC(
+      Number(dateOrderYear),
+      Number(dateOrderMonth) - 1,
+      Number(dateOrderDay),
+      12,
+    ));
+
+    const dateOrder = getDateOrder(date.format(staticDate));
+    const [, { value: dateSeparator }] = date.formatToParts(staticDate);
 
     // 2019-05-19 is a Sunday
     const weekDays = range(7).map((_, i) => weekDay
@@ -328,6 +335,7 @@ class IntlDateTimeLocalizer extends PreferencesHandler {
       months,
       fullMonths,
       dateOrder,
+      dateSeparator,
     };
     return this;
   }
@@ -416,7 +424,7 @@ class IntlDateTimeLocalizer extends PreferencesHandler {
       split = dateString.split('-');
     } else {
       order = this.dateOrder();
-      split = dateString.split('/');
+      split = dateString.split(this._.constants.dateSeparator);
     }
     const allValid = split.length === 3 && !split.some(e => e === '' || e === '0');
     if (allValid) {
@@ -443,7 +451,9 @@ class IntlDateTimeLocalizer extends PreferencesHandler {
         }
       }
       if (daysValid && monthsValid && yearsValid) {
-        return new Date(Date.UTC(year, month - 1, day));
+        const convertedDate = new Date(Date.UTC(year, month - 1, day));
+        const timezoneOffset = preferences.getTimezoneOffset(convertedDate, this.timezone());
+        return new Date(convertedDate.getTime() - (timezoneOffset * 1000 * 60 * 60));
       }
       return new Date('Invalid Date');
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above in the following format -->
<!--- #404: resolved issue with data table -->

## Description
<!--- Describe your changes in detail -->

The date formatting for `en-US` uses `5/8/2019` which breaks the `getDateOrder` method (it only returns `['YYYY']`) which prevents user-entered strings for dates.

The formatters should be using explicit 2-digit output for days / months

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
TODO

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document. (Last updated 16 Aug 2019)
- [x] All my changes are covered by tests.
- [x] This request is ready to review and merge
