### PR TITLE
fix: jarring effect in Tooltip component

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -55,8 +55,8 @@ running this script and should not be pushed to the repository.
 Once you see a line like `[TIMESTAMP] waiting for changes...`, hexagon has
 finished building and you can navigate to the following URLs in your browser:
 
-- `http://localhost:10011/demo/` - The built version of `src/demo`
-- `http://localhost:10011/test/` - The tests, built from `src/hexagon.spec.js`
+- `http://localhost:10001/demo/` - The built version of `src/demo`
+- `http://localhost:10001/test/` - The tests, built from `src/hexagon.spec.js`
 - `http://localhost:10001/coverage/` - Code coverage (only available after running the tests at least once)
 
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,6 +21,6 @@
 - [ ] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
 - [ ] My code follows the code style of this project.
 - [ ] I have updated the documentation accordingly. (This includes updating the changelog).
-- [ ] I have read the **CONTRIBUTING** document. (Last updated 16 Aug 2019)
+- [ ] I have read the **CONTRIBUTING** document. (Last updated 24 March 2020)
 - [ ] All my changes are covered by tests.
 - [ ] This request is ready to review and merge

--- a/src/components/tooltip/theme.css
+++ b/src/components/tooltip/theme.css
@@ -14,6 +14,10 @@
   margin-top: var(--tooltip-space);
 }
 
+.hx-dropdown.hx-dropdown-up{
+    margin-top: calc(-1 * var(--tooltip-space));
+}
+
 .hx-tooltip-label  {
     border-bottom-color: var(--tooltip-label-underline-color);
     color: var(--tooltip-label-text-color);

--- a/src/components/tooltip/theme.css
+++ b/src/components/tooltip/theme.css
@@ -1,5 +1,4 @@
 .hx-tooltip {
-    margin-bottom: var(--tooltip-space);
     background-color: var(--tooltip-background-color);
     font-size: var(--tooltip-font-size);
     color: var(--tooltip-text-color);
@@ -10,8 +9,7 @@
 }
 
 .hx-tooltip.hx-dropdown-down {
-  margin-bottom: 0;
-  margin-top: var(--tooltip-space);
+    margin-top: var(--tooltip-space);
 }
 
 .hx-dropdown.hx-dropdown-up{


### PR DESCRIPTION
## Description
Tooltip uses the Dropdown component for dynamic positioning. When tooltip icon is hovered, the tooltip content is positioned overlapping on the icon, which creates a jarring effect.

## Motivation and Context
Users can easily see the tooltip text without the jarring effect.

## How Has This Been Tested?
Tested the change in the browser since its a CSS fix

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
- [ ] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly. (This includes updating the changelog).
- [ ] I have read the **CONTRIBUTING** document. (Last updated 24 Mar 2020)
- [ ] All my changes are covered by tests.
- [ ] This request is ready to review and merge
