### PR TITLE
Fix moment calendar

### DIFF
--- a/src/utils/date-localizer/index.js
+++ b/src/utils/date-localizer/index.js
@@ -499,8 +499,7 @@ class DateTimeLocalizerMoment extends PreferencesHandler {
   }
 
   weekDays() {
-    const dayDate = moment().weekday(0);
-    dayDate.locale(this.locale());
+    const dayDate = moment().locale(this.locale()).weekday(0);
     const dayNames = [dayDate.format('dd')];
     for (let i = 0; i < 6; i += 1) {
       dayNames.push(dayDate.add(1, 'd').format('dd'));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above in the following format -->
<!--- #404: resolved issue with data table -->

## Description
I found a bug related to calendar view and after investigating I found a mistake in hexagon.js code in function:
DateTimeLocalizerMoment.prototype.weekDays = function()
line 6924:
dayDate = moment().weekday(0);
line 6925:
dayDate.locale(this.locale());
After setting dayDate starts from 0 you’re setting a locale, but locale doesn’t affect anything.
Despite this locale settings we can see on Calendar that week starts from Sunday event if I changed locale (where week starts from Monday for example).
There is should be another order of settings:
first set locale and then set weekday like this:
dayDate = moment().locale(this.locale()).weekday(0); 
Instead of these 2 lines of code:
dayDate = moment().weekday(0);
dayDate.locale(this.locale());
After testing my method I could see the correct view of Calendar regarding to locale.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a tag to this pull request that indicates the impact of the change (patch, minor or major)
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly. (This includes updating the changelog).
- [x] I have read the **CONTRIBUTING** document. (Last updated 24 March 2020)
- [x] All my changes are covered by tests.
- [x] This request is ready to review and merge
